### PR TITLE
[Sortable stories] Pass activation constraints to touch sensor

### DIFF
--- a/stories/Sortable/Sortable.tsx
+++ b/stories/Sortable/Sortable.tsx
@@ -75,6 +75,11 @@ export function Sortable({
         activationConstraint,
       },
     },
+    touch: {
+      options: {
+        activationConstraint,
+      },
+    },
     keyboard: {
       options: {
         // For automated Cypress integration tests, we don't need the smooth animation


### PR DESCRIPTION
Fixes an issue where the `activationConstraint` prop was not passed to the initialization of the touch sensor in the Sortable stories.

cc @henryyi