### PR TITLE
Update touch sensor event listener target

### DIFF
--- a/packages/core/src/sensors/keyboard/KeyboardSensor.ts
+++ b/packages/core/src/sensors/keyboard/KeyboardSensor.ts
@@ -12,6 +12,7 @@ import {defaultKeyCodes, defaultCoordinatesGetter} from './defaults';
 import {
   defaultCoordinates,
   getElementCoordinates,
+  getOwnerDocument,
   getScrollPosition,
 } from '../../utilities';
 
@@ -29,10 +30,12 @@ export class KeyboardSensor implements SensorInstance {
   private listeners: Listeners;
 
   constructor(private props: KeyboardSensorProps) {
-    const {event} = props;
+    const {
+      event: {target},
+    } = props;
 
     this.props = props;
-    this.listeners = new Listeners(event.target);
+    this.listeners = new Listeners(getOwnerDocument(target));
     this.handleKeyDown = this.handleKeyDown.bind(this);
 
     this.attach();

--- a/packages/core/src/sensors/pointer/PointerSensor.ts
+++ b/packages/core/src/sensors/pointer/PointerSensor.ts
@@ -2,7 +2,7 @@ import {subtract as getCoordinatesDelta} from '@dnd-kit/utilities';
 
 import {Listeners} from '../utilities';
 
-import {getEventCoordinates} from '../../utilities';
+import {getEventCoordinates, getOwnerDocument} from '../../utilities';
 import type {SensorInstance, SensorProps, SensorOptions} from '../types';
 import type {Coordinates} from '../../types';
 import {KeyCode} from '../keyboard';
@@ -55,13 +55,16 @@ export class PointerSensor implements SensorInstance {
 
   constructor(
     private props: PointerSensorProps,
-    private events: PointerEventHandlers
+    private events: PointerEventHandlers,
+    listenerTarget: HTMLElement | Document = getOwnerDocument(
+      props.event.target
+    )
   ) {
     const {event} = props;
 
     this.props = props;
     this.events = events;
-    this.listeners = new Listeners(event.target);
+    this.listeners = new Listeners(listenerTarget);
     this.initialCoordinates = getEventCoordinates(event);
     this.handleStart = this.handleStart.bind(this);
     this.handleMove = this.handleMove.bind(this);

--- a/packages/core/src/sensors/touch/TouchSensor.tsx
+++ b/packages/core/src/sensors/touch/TouchSensor.tsx
@@ -6,6 +6,7 @@ import {
   PointerEventHandlers,
   PointerSensorOptions,
 } from '../pointer';
+import {getOwnerDocument} from '../../utilities';
 
 const events: PointerEventHandlers = {
   move: {name: 'touchmove'},
@@ -16,7 +17,13 @@ export interface TouchSensorOptions extends PointerSensorOptions {}
 
 export class TouchSensor extends PointerSensor {
   constructor(props: PointerSensorProps) {
-    super(props, events);
+    const {
+      event: {target},
+    } = props;
+    const listenerTarget =
+      target instanceof HTMLElement ? target : getOwnerDocument(target);
+
+    super(props, events, listenerTarget);
   }
 
   static activators = [

--- a/packages/core/src/sensors/utilities/Listeners.ts
+++ b/packages/core/src/sensors/utilities/Listeners.ts
@@ -1,27 +1,23 @@
 export class Listeners {
-  private document: Document;
   private listeners: {
     eventName: string;
     handler: EventListenerOrEventListenerObject;
   }[] = [];
 
-  constructor(target: Event['target']) {
-    this.document =
-      target instanceof HTMLElement ? target.ownerDocument : document;
-  }
+  constructor(private target: HTMLElement | Document) {}
 
   public add(
     eventName: string,
     handler: EventListenerOrEventListenerObject,
     options?: AddEventListenerOptions
   ) {
-    this.document.addEventListener(eventName, handler, options);
+    this.target.addEventListener(eventName, handler, options);
     this.listeners.push({eventName, handler});
   }
 
   public removeAll() {
     this.listeners.forEach(({eventName, handler}) =>
-      this.document.removeEventListener(eventName, handler)
+      this.target.removeEventListener(eventName, handler)
     );
   }
 }

--- a/packages/core/src/utilities/getOwnerDocument.ts
+++ b/packages/core/src/utilities/getOwnerDocument.ts
@@ -1,0 +1,3 @@
+export function getOwnerDocument(target: Event['target']) {
+  return target instanceof HTMLElement ? target.ownerDocument : document;
+}

--- a/packages/core/src/utilities/index.ts
+++ b/packages/core/src/utilities/index.ts
@@ -3,6 +3,7 @@ export * from './coordinates';
 
 export {getAdjustedClientRect} from './getAdjustedClientRect';
 export {getMinValueIndex, getMaxValueIndex} from './getValueIndex';
+export {getOwnerDocument} from './getOwnerDocument';
 export {getScrollDirectionAndSpeed} from './getScrollDirectionAndSpeed';
 export {getScrollingParent} from './getScrollingParent';
 export {getScrollPosition} from './getScrollPosition';


### PR DESCRIPTION
Fixes #6 

If the target element is removed from the document, events will still be targeted at it, and hence won't necessarily bubble up to the window or document anymore. If there is any risk of an element being removed while it is being touched, the best practice is to attach the touch listeners directly to the target.