### PR TITLE
Touch sensor shouldn't activate if there are multiple touches

### DIFF
--- a/packages/core/src/sensors/touch/TouchSensor.tsx
+++ b/packages/core/src/sensors/touch/TouchSensor.tsx
@@ -23,6 +23,12 @@ export class TouchSensor extends PointerSensor {
     {
       eventName: 'onTouchStart' as const,
       handler: ({nativeEvent}: React.TouchEvent) => {
+        const {touches} = nativeEvent;
+
+        if (touches.length > 1) {
+          return false;
+        }
+
         nativeEvent.preventDefault();
 
         if (nativeEvent.target instanceof HTMLElement) {


### PR DESCRIPTION
Related to https://github.com/clauderic/dnd-kit/issues/5 by returning `false` in the activator for the Touch sensor if there are multiple touches. See https://developer.mozilla.org/en-US/docs/Web/API/TouchEvent/touches