### PR TITLE
Fixes infinite loop issue in Multiple Containers story when container is empty

### DIFF
--- a/packages/core/src/hooks/core/useDroppable.ts
+++ b/packages/core/src/hooks/core/useDroppable.ts
@@ -28,30 +28,40 @@ export function useDroppable({
     }
   }, [data]);
 
-  useEffect(() => {
-    if (!disabled) {
+  useIsomorphicEffect(
+    () => {
       dispatch({
         type: Events.RegisterDroppable,
         element: {
           id,
+          disabled,
           node: nodeRef,
           clientRect,
           data: dataRef,
         },
       });
-    } else {
-      dispatch({
-        type: Events.UnregisterDroppable,
-        id,
-      });
-    }
 
-    return () =>
+      return () =>
+        dispatch({
+          type: Events.UnregisterDroppable,
+          id,
+        });
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [id]
+  );
+
+  useEffect(
+    () => {
       dispatch({
-        type: Events.UnregisterDroppable,
+        type: Events.SetDroppableDisabled,
         id,
+        disabled,
       });
-  }, [id, clientRect, nodeRef, disabled, dispatch]);
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [disabled]
+  );
 
   return {
     clientRect,

--- a/packages/core/src/store/actions.ts
+++ b/packages/core/src/store/actions.ts
@@ -5,6 +5,7 @@ import {DroppableContainer} from './types';
 
 export enum Events {
   RegisterDroppable = 'registerDroppable',
+  SetDroppableDisabled = 'setDroppableDisabled',
   UnregisterDroppable = 'unregisterDroppable',
   SetActiveElement = 'setActiveElement',
   SetNewIndex = 'setNewIndex',
@@ -15,6 +16,11 @@ export type Action =
   | {
       type: Events.RegisterDroppable;
       element: DroppableContainer;
+    }
+  | {
+      type: Events.SetDroppableDisabled;
+      id: UniqueIdentifier;
+      disabled: boolean;
     }
   | {
       type: Events.UnregisterDroppable;

--- a/packages/core/src/store/reducer.ts
+++ b/packages/core/src/store/reducer.ts
@@ -17,6 +17,22 @@ export function reducer(state: State, action: Action): State {
       };
     }
 
+    case Events.SetDroppableDisabled: {
+      const {id, disabled} = action;
+      const element = state.droppableContainers[id];
+
+      return {
+        ...state,
+        droppableContainers: {
+          ...state.droppableContainers,
+          [id]: {
+            ...element,
+            disabled,
+          },
+        },
+      };
+    }
+
     case Events.UnregisterDroppable: {
       const {id} = action;
 

--- a/packages/core/src/store/types.ts
+++ b/packages/core/src/store/types.ts
@@ -3,7 +3,6 @@ import React from 'react';
 import type {PositionalClientRect, UniqueIdentifier} from '../types';
 import type {SyntheticListeners} from '../hooks/utilities';
 import type {Action} from './actions';
-import {CollisionDetection} from '../utilities';
 
 export interface DraggableElement {
   node: React.MutableRefObject<HTMLElement | null>;
@@ -16,11 +15,11 @@ export interface DraggableElement {
 export type Data = Record<string, any>;
 
 export interface DroppableContainer {
-  node: React.MutableRefObject<HTMLElement | null>;
-  collisionDetection?: CollisionDetection;
-  clientRect: React.MutableRefObject<PositionalClientRect | null>;
-  data: React.MutableRefObject<Data>;
   id: UniqueIdentifier;
+  node: React.MutableRefObject<HTMLElement | null>;
+  clientRect: React.MutableRefObject<PositionalClientRect | null>;
+  disabled: boolean;
+  data: React.MutableRefObject<Data>;
 }
 
 export type DroppableContainers = Record<UniqueIdentifier, DroppableContainer>;

--- a/packages/core/src/utilities/algorithms/closestCenter.ts
+++ b/packages/core/src/utilities/algorithms/closestCenter.ts
@@ -1,14 +1,7 @@
 import {Coordinates, PositionalClientRect} from '../../types';
 import {getMinValueIndex} from '../getValueIndex';
-
+import {distanceBetween} from '../coordinates';
 import {CollisionDetection} from './types';
-
-/**
- * Returns the distance between two points
- */
-function distanceBetween(p1: Coordinates, p2: Coordinates) {
-  return Math.sqrt(Math.pow(p1.x - p2.x, 2) + Math.pow(p1.y - p2.y, 2));
-}
 
 /**
  * Returns the coordinates of the center of a given ClientRect
@@ -28,7 +21,7 @@ function centerOfRectangle(
  * Returns the closest rectangle from an array of rectangles to the center of a given
  * rectangle.
  */
-export const closestRect: CollisionDetection = (rects, rect) => {
+export const closestCenter: CollisionDetection = (rects, rect) => {
   const centerRect = centerOfRectangle(rect, rect.left, rect.top);
   const distances = rects.map(([_, clientRect]) =>
     distanceBetween(centerOfRectangle(clientRect), centerRect)

--- a/packages/core/src/utilities/algorithms/closestCorners.ts
+++ b/packages/core/src/utilities/algorithms/closestCorners.ts
@@ -1,0 +1,55 @@
+import {PositionalClientRect} from '../../types';
+import {getMinValueIndex} from '../getValueIndex';
+import {distanceBetween} from '../coordinates';
+import {CollisionDetection} from './types';
+
+/**
+ * Returns the coordinates of the corners of a given rectangle:
+ * [TopLeft {x, y}, TopRight {x, y}, BottomLeft {x, y}, BottomRight {x, y}]
+ */
+
+function cornersOfRectangle(
+  rect: PositionalClientRect,
+  left = rect.offsetLeft,
+  top = rect.offsetTop
+) {
+  return [
+    {
+      x: left,
+      y: top,
+    },
+    {
+      x: left + rect.width,
+      y: top,
+    },
+    {
+      x: left,
+      y: top + rect.height,
+    },
+    {
+      x: left + rect.width,
+      y: top + rect.height,
+    },
+  ];
+}
+
+/**
+ * Returns the closest rectangle from an array of rectangles to the corners of
+ * another rectangle.
+ */
+export const closestCorners: CollisionDetection = (entries, target) => {
+  const corners = cornersOfRectangle(target, target.left, target.top);
+
+  const distances = entries.map(([_, entry]) => {
+    const entryCorners = cornersOfRectangle(entry);
+    const distances = corners.reduce((accumulator, corner, index) => {
+      return accumulator + distanceBetween(entryCorners[index], corner);
+    }, 0);
+
+    return Number((distances / 4).toFixed(4));
+  });
+
+  const minValueIndex = getMinValueIndex(distances);
+
+  return entries[minValueIndex] ? entries[minValueIndex][0] : null;
+};

--- a/packages/core/src/utilities/algorithms/index.ts
+++ b/packages/core/src/utilities/algorithms/index.ts
@@ -1,4 +1,5 @@
-export {closestRect} from './closestRect';
+export {closestCenter} from './closestCenter';
+export {closestCorners} from './closestCorners';
 export {rectCollision} from './rectCollision';
 export {rectIntersection} from './rectIntersection';
 export * from './types';

--- a/packages/core/src/utilities/algorithms/rectIntersection.ts
+++ b/packages/core/src/utilities/algorithms/rectIntersection.ts
@@ -1,3 +1,4 @@
+import {PositionalClientRect} from '../../types';
 import {getMaxValueIndex} from '../getValueIndex';
 
 import {CollisionDetection} from './types';
@@ -5,16 +6,31 @@ import {CollisionDetection} from './types';
 /**
  * Returns the intersecting rectangle area between two rectangles
  */
-function intersectingRectArea(rect1: ClientRect, rect2: ClientRect): number {
-  const left = Math.max(rect1.left, rect2.left);
-  const top = Math.max(rect1.top, rect2.top);
-  const right = Math.min(rect1.left + rect1.width, rect2.left + rect2.width);
-  const bottom = Math.min(rect1.top + rect1.height, rect2.top + rect2.height);
+function getIntersectionRatio(
+  entry: PositionalClientRect,
+  target: PositionalClientRect
+): number {
+  const top = Math.max(target.top, entry.offsetTop);
+  const left = Math.max(target.left, entry.offsetLeft);
+  const right = Math.min(
+    target.left + target.width,
+    entry.offsetLeft + entry.width
+  );
+  const bottom = Math.min(
+    target.top + target.height,
+    entry.offsetTop + entry.height
+  );
   const width = right - left;
   const height = bottom - top;
 
   if (left < right && top < bottom) {
-    return width * height;
+    const targetArea = target.width * target.height;
+    const entryArea = entry.width * entry.height;
+    const intersectionArea = width * height;
+    const intersectionRatio =
+      intersectionArea / (targetArea + entryArea - intersectionArea);
+
+    return Number(intersectionRatio.toFixed(4));
   }
 
   // Rectangles do not overlap, or overlap has an area of zero (edge/corner overlap)
@@ -25,9 +41,9 @@ function intersectingRectArea(rect1: ClientRect, rect2: ClientRect): number {
  * Returns the rectangle that has the greatest intersection area with a given
  * rectangle in an array of rectangles.
  */
-export const rectIntersection: CollisionDetection = (rects, rect) => {
-  const intersections = rects.map(([_, clientRect]) =>
-    intersectingRectArea(clientRect, rect)
+export const rectIntersection: CollisionDetection = (entries, target) => {
+  const intersections = entries.map(([_, entry]) =>
+    getIntersectionRatio(entry, target)
   );
 
   const maxValueIndex = getMaxValueIndex(intersections);
@@ -36,5 +52,5 @@ export const rectIntersection: CollisionDetection = (rects, rect) => {
     return null;
   }
 
-  return rects[maxValueIndex] ? rects[maxValueIndex][0] : null;
+  return entries[maxValueIndex] ? entries[maxValueIndex][0] : null;
 };

--- a/packages/core/src/utilities/algorithms/types.ts
+++ b/packages/core/src/utilities/algorithms/types.ts
@@ -5,6 +5,6 @@ import {
 } from '../../types';
 
 export type CollisionDetection = (
-  clientRects: PositionalClientRectEntry[],
-  clientRect: PositionalClientRect
+  entries: PositionalClientRectEntry[],
+  target: PositionalClientRect
 ) => UniqueIdentifier | null;

--- a/packages/core/src/utilities/coordinates/distanceBetweenPoints.ts
+++ b/packages/core/src/utilities/coordinates/distanceBetweenPoints.ts
@@ -1,0 +1,8 @@
+import {Coordinates} from '../../types';
+
+/**
+ * Returns the distance between two points
+ */
+export function distanceBetween(p1: Coordinates, p2: Coordinates) {
+  return Math.sqrt(Math.pow(p1.x - p2.x, 2) + Math.pow(p1.y - p2.y, 2));
+}

--- a/packages/core/src/utilities/coordinates/index.ts
+++ b/packages/core/src/utilities/coordinates/index.ts
@@ -1,5 +1,5 @@
 export {defaultCoordinates} from './constants';
-
+export {distanceBetween} from './distanceBetweenPoints';
 export {getCoordinatesFromClientRect} from './getCoordinatesFromClientRect';
 export {getEventCoordinates} from './getEventCoordinates';
 export {getElementCoordinates} from './getElementCoordinates';

--- a/packages/sortable/src/sensors/keyboard/getNextKeyboardCoordinates.ts
+++ b/packages/sortable/src/sensors/keyboard/getNextKeyboardCoordinates.ts
@@ -1,5 +1,5 @@
 import {
-  closestRect,
+  closestCenter,
   defaultCoordinates,
   KeyCode,
   PositionalClientRectEntry,
@@ -72,7 +72,7 @@ export const getNextKeyboardCoordinates = (
       }
     });
 
-    const closestId = closestRect(clientRects, {
+    const closestId = closestCenter(clientRects, {
       ...overRect,
       top: overRect.offsetTop,
       left: overRect.offsetLeft,

--- a/stories/Droppable/Droppable.story.tsx
+++ b/stories/Droppable/Droppable.story.tsx
@@ -4,7 +4,8 @@ import classNames from 'classnames';
 import {Item, GridContainer} from '../components';
 
 import {
-  closestRect,
+  closestCenter,
+  closestCorners,
   rectIntersection,
   DndContext,
   useDraggable,
@@ -117,7 +118,7 @@ function DroppableStory({
   );
 }
 
-interface Draggable {
+interface DraggableProps {
   value: React.ReactNode;
   handle?: boolean;
   style?: React.CSSProperties;
@@ -141,7 +142,7 @@ function Droppable({children, id}: DroppableProps) {
   );
 }
 
-function Draggable({value, handle, style}: Draggable) {
+function Draggable({value, handle, style}: DraggableProps) {
   const {isDragging, setNodeRef, listeners} = useDraggable({
     id: 'draggable-item',
   });
@@ -171,7 +172,7 @@ export const CollisionDetection = () => {
 
   return (
     <>
-    <DroppableStory
+      <DroppableStory
         collisionDetection={algorithm}
         containers={['A', 'B', 'C']}
       />
@@ -199,16 +200,26 @@ export const CollisionDetection = () => {
         <label>
           <input
             type="radio"
-            value="rectCollision"
-            checked={algorithm === closestRect}
+            value="closestCenter"
+            checked={algorithm === closestCenter}
             onClick={() =>
-              setCollisionDetectionAlgorithm({algorithm: closestRect})
+              setCollisionDetectionAlgorithm({algorithm: closestCenter})
             }
           />
-          Closest Rect
+          Closest Center
+        </label>
+        <label>
+          <input
+            type="radio"
+            value="closestCorners"
+            checked={algorithm === closestCorners}
+            onClick={() =>
+              setCollisionDetectionAlgorithm({algorithm: closestCorners})
+            }
+          />
+          Closest Corners
         </label>
       </div>
-      
     </>
   );
 };

--- a/stories/Sortable/Grid/Grid.story.tsx
+++ b/stories/Sortable/Grid/Grid.story.tsx
@@ -60,7 +60,7 @@ export const VariableSizes = () => (
     {...props}
     itemCount={14}
     getItemStyles={({index}) => {
-      if (index === 0 || index == 9) {
+      if (index === 0 || index === 9) {
         return {
           fontSize: '2rem',
           padding: '36px 40px',
@@ -70,7 +70,7 @@ export const VariableSizes = () => (
       return {};
     }}
     wrapperStyle={({index}) => {
-      if (index === 0 || index == 9) {
+      if (index === 0 || index === 9) {
         return {
           height: 288,
           gridRowStart: 'span 2',

--- a/stories/Sortable/Sortable.tsx
+++ b/stories/Sortable/Sortable.tsx
@@ -13,7 +13,7 @@ import {
   ActivationConstraint,
   DraggableClone,
   DndContext,
-  closestRect,
+  closestCenter,
   UniqueIdentifier,
   Modifiers,
 } from '@dnd-kit/core';
@@ -96,13 +96,14 @@ export function Sortable({
         setItems(parentItems);
       }
     },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     parentItems ? [...parentItems] : []
   );
 
   return (
     <DndContext
       sensors={sensors}
-      collisionDetection={closestRect}
+      collisionDetection={closestCenter}
       onDragStart={({active}) => {
         if (!active) {
           return;

--- a/stories/Sortable/Virtualized/Virtualized.story.tsx
+++ b/stories/Sortable/Virtualized/Virtualized.story.tsx
@@ -8,7 +8,7 @@ import {
   SortableContainer,
   verticalListSortingStrategy,
 } from '@dnd-kit/sortable';
-import {closestRect, DndContext, DraggableClone} from '@dnd-kit/core';
+import {closestCenter, DndContext, DraggableClone} from '@dnd-kit/core';
 
 import styles from './Virtualized.module.css';
 
@@ -43,7 +43,7 @@ function Sortable({
   return (
     <DndContext
       sensors={sensors}
-      collisionDetection={closestRect}
+      collisionDetection={closestCenter}
       onDragStart={({active}) => {
         setActiveId(active.id);
       }}


### PR DESCRIPTION
There was an infinite loop issue where the `onDragOver` callback would be called in an infinite loop with the multiple container story when items were changing from one container to another.

This may require additional investigation in the library to see if there's something similar we could do internally instead.