### PR TITLE
Remove enter from default keyboard activator keys

### DIFF
--- a/packages/core/src/sensors/keyboard/defaults.ts
+++ b/packages/core/src/sensors/keyboard/defaults.ts
@@ -1,9 +1,9 @@
 import {CoordinatesGetter, KeyCode, KeyCodes} from './types';
 
 export const defaultKeyCodes: KeyCodes = {
-  start: [KeyCode.Space, KeyCode.Enter],
+  start: [KeyCode.Space],
   cancel: [KeyCode.Esc],
-  end: [KeyCode.Space, KeyCode.Enter],
+  end: [KeyCode.Space],
 };
 
 export const defaultCoordinatesGetter: CoordinatesGetter = (


### PR DESCRIPTION
From an accessibility perspective, it's likely that the activator would be a button that has a different action when clicked or on enter. Enter should therefore not be a default activator key.