### PR TITLE
Fix URL to GitHub repository

### DIFF
--- a/.changeset/repository-url-typo.md
+++ b/.changeset/repository-url-typo.md
@@ -1,0 +1,6 @@
+---
+"@dnd-kit/accessibility": patch
+"@dnd-kit/core": patch
+---
+
+Fix typo in package.json repository URL

--- a/packages/accessibility/package.json
+++ b/packages/accessibility/package.json
@@ -5,7 +5,7 @@
   "author": "Claudéric Demers",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/claudric/dnd-kit.git",
+    "url": "git+https://github.com/clauderic/dnd-kit.git",
     "directory": "packages/accessibility"
   },
   "scripts": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -5,7 +5,7 @@
   "author": "Claudéric Demers",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/claudric/dnd-kit.git",
+    "url": "git+https://github.com/clauderic/dnd-kit.git",
     "directory": "packages/core"
   },
   "scripts": {


### PR DESCRIPTION
Hi 👋 

I was viewing this package on [BundlePhobia](https://bundlephobia.com/result?p=@dnd-kit/core@1.0.0) and tried to jump to GitHub directly but noticed it was linking to `https://github.com/claudric/dnd-kit`

This change fixes the GitHub URL, which will get picked up in the next version bump.

Have a great day 🙂 