### PR TITLE
Fix issue with reducer initial state variable causing collisions due to variable references

### DIFF
--- a/.changeset/fix-reducer-collisions.md
+++ b/.changeset/fix-reducer-collisions.md
@@ -1,0 +1,5 @@
+---
+"@dnd-kit/core": patch
+---
+
+Fix issue with reducer initial state variable causing collisions due to variable references all pointing to the original initial state variable.

--- a/packages/core/src/components/DndContext/DndContext.tsx
+++ b/packages/core/src/components/DndContext/DndContext.tsx
@@ -17,10 +17,10 @@ import {
 } from '@dnd-kit/utilities';
 
 import {
+  Action,
   Context,
   DndContextDescriptor,
-  Action,
-  initialState,
+  getInitialState,
   reducer,
 } from '../../store';
 import type {Coordinates, ViewRect, LayoutRect, Translate} from '../../types';
@@ -149,7 +149,7 @@ export const DndContext = memo(function DndContext({
   modifiers,
   ...props
 }: Props) {
-  const store = useReducer(reducer, initialState);
+  const store = useReducer(reducer, undefined, getInitialState);
   const [state, dispatch] = store;
   const {
     draggable: {active, lastEvent, nodes: draggableNodes, translate},

--- a/packages/core/src/store/index.ts
+++ b/packages/core/src/store/index.ts
@@ -1,6 +1,6 @@
 export {Action} from './actions';
 export {Context} from './context';
-export {reducer, initialState} from './reducer';
+export {reducer, getInitialState} from './reducer';
 export type {
   Data,
   DraggableElement,

--- a/packages/core/src/store/reducer.ts
+++ b/packages/core/src/store/reducer.ts
@@ -2,18 +2,20 @@ import {omit} from '../utilities';
 import {Action, Actions} from './actions';
 import type {State} from './types';
 
-export const initialState: State = {
-  draggable: {
-    active: null,
-    initialCoordinates: {x: 0, y: 0},
-    lastEvent: null,
-    nodes: {},
-    translate: {x: 0, y: 0},
-  },
-  droppable: {
-    containers: {},
-  },
-};
+export function getInitialState(): State {
+  return {
+    draggable: {
+      active: null,
+      initialCoordinates: {x: 0, y: 0},
+      lastEvent: null,
+      nodes: {},
+      translate: {x: 0, y: 0},
+    },
+    droppable: {
+      containers: {},
+    },
+  };
+}
 
 export function reducer(state: State, action: Actions): State {
   switch (action.type) {
@@ -21,7 +23,7 @@ export function reducer(state: State, action: Actions): State {
       return {
         ...state,
         draggable: {
-          ...initialState.draggable,
+          ...state.draggable,
           initialCoordinates: action.initialCoordinates,
           active: action.active,
           lastEvent: Action.DragStart,
@@ -47,7 +49,10 @@ export function reducer(state: State, action: Actions): State {
       return {
         ...state,
         draggable: {
-          ...initialState.draggable,
+          ...state.draggable,
+          active: null,
+          initialCoordinates: {x: 0, y: 0},
+          translate: {x: 0, y: 0},
           lastEvent: action.type,
         },
       };


### PR DESCRIPTION
Fixes https://github.com/clauderic/dnd-kit/issues/46

The initial state variable was being shared across all `<DndContext>` components in the same application, which was causing id collisions for both nested and sibling `<DndContext>` providers.

See https://codesandbox.io/s/fervent-wing-0zqhd for a sandbox replicating this issue. 