### PR TITLE
[WIP] Update scroll ancestor detection when the draggable is not over a droppable

### DIFF
--- a/packages/core/src/components/DndContext/DndContext.tsx
+++ b/packages/core/src/components/DndContext/DndContext.tsx
@@ -32,6 +32,7 @@ import {
   useScrollableAncestors,
   useClientRect,
   useClientRects,
+  useFindElementFromPoint,
   useScrollOffsets,
   useViewRect,
   SyntheticListener,
@@ -50,6 +51,7 @@ import {
   CollisionDetection,
   defaultCoordinates,
   getAdjustedRect,
+  centerOfRectangle,
   getRectDelta,
   rectIntersection,
 } from '../../utilities';
@@ -198,9 +200,22 @@ export const DndContext = memo(function DndContext({
   const containerNodeRect = useClientRect(
     activeNode ? activeNode.parentElement : null
   );
-  const scrollableAncestors = useScrollableAncestors(
-    active ? overNode ?? activeNode : null
+  const scrollDetectionCoordinates = activeNodeRect
+    ? add(
+        centerOfRectangle(
+          activeNodeRect,
+          activeNodeRect.left,
+          activeNodeRect.top
+        ),
+        translate
+      )
+    : defaultCoordinates;
+  const detectedScrollElement = useFindElementFromPoint(
+    scrollDetectionCoordinates,
+    activeNode?.ownerDocument
   );
+  const scrollTarget = active ? overNode ?? detectedScrollElement : null;
+  const scrollableAncestors = useScrollableAncestors(scrollTarget);
   const scrollableAncestorRects = useClientRects(scrollableAncestors);
 
   const [overlayNodeRef, setOverlayNodeRef] = useNodeRef();

--- a/packages/core/src/components/DragOverlay/DragOverlay.tsx
+++ b/packages/core/src/components/DragOverlay/DragOverlay.tsx
@@ -92,6 +92,7 @@ export const DragOverlay = React.memo(
           zIndex,
           transform: CSS.Transform.toString(finalTransform),
           touchAction: 'none',
+          pointerEvents: 'none',
           transformOrigin:
             adjustScale && activatorEvent
               ? getRelativeTransformOrigin(

--- a/packages/core/src/hooks/utilities/index.ts
+++ b/packages/core/src/hooks/utilities/index.ts
@@ -1,6 +1,7 @@
 export {useAutoScroller} from './useAutoScroller';
 export {useCachedNode} from './useCachedNode';
 export {useCombineActivators} from './useCombineActivators';
+export {useFindElementFromPoint} from './useFindElementFromPoint';
 export {useLayoutRectMap} from './useLayoutRectMap';
 export {useScrollOffsets} from './useScrollOffsets';
 export {useScrollableAncestors} from './useScrollableAncestors';

--- a/packages/core/src/hooks/utilities/useFindElementFromPoint.ts
+++ b/packages/core/src/hooks/utilities/useFindElementFromPoint.ts
@@ -1,0 +1,16 @@
+import {useMemo} from 'react';
+import type {Coordinates} from '../../types';
+
+export function useFindElementFromPoint(
+  coordinates: Coordinates,
+  document: Document | undefined
+) {
+  // To-do: This is expensive and needs to be debounced
+  return useMemo(() => {
+    if (!document) {
+      return null;
+    }
+
+    return document.elementFromPoint(coordinates.x, coordinates.y);
+  }, [coordinates.x, coordinates.y, document]);
+}

--- a/packages/core/src/hooks/utilities/useScrollableAncestors.ts
+++ b/packages/core/src/hooks/utilities/useScrollableAncestors.ts
@@ -5,7 +5,7 @@ import {getScrollableAncestors} from '../../utilities';
 
 const defaultValue: Element[] = [];
 
-export function useScrollableAncestors(node: HTMLElement | null) {
+export function useScrollableAncestors(node: Element | null) {
   const previousNode = useRef(node);
 
   const ancestors = useLazyMemo<Element[]>(

--- a/packages/core/src/utilities/algorithms/closestCenter.ts
+++ b/packages/core/src/utilities/algorithms/closestCenter.ts
@@ -1,21 +1,6 @@
 import {getMinValueIndex} from '../other';
-import {distanceBetween} from '../coordinates';
-import type {Coordinates, LayoutRect} from '../../types';
+import {centerOfRectangle, distanceBetween} from '../coordinates';
 import type {CollisionDetection} from './types';
-
-/**
- * Returns the coordinates of the center of a given ClientRect
- */
-function centerOfRectangle(
-  rect: LayoutRect,
-  left = rect.offsetLeft,
-  top = rect.offsetTop
-): Coordinates {
-  return {
-    x: left + rect.width * 0.5,
-    y: top + rect.height * 0.5,
-  };
-}
 
 /**
  * Returns the closest rectangle from an array of rectangles to the center of a given

--- a/packages/core/src/utilities/coordinates/centerOfRectangle.ts
+++ b/packages/core/src/utilities/coordinates/centerOfRectangle.ts
@@ -1,0 +1,15 @@
+import type {Coordinates, LayoutRect} from '../../types';
+
+/**
+ * Returns the coordinates of the center of a given ClientRect
+ */
+export function centerOfRectangle(
+  rect: LayoutRect,
+  left = rect.offsetLeft,
+  top = rect.offsetTop
+): Coordinates {
+  return {
+    x: left + rect.width * 0.5,
+    y: top + rect.height * 0.5,
+  };
+}

--- a/packages/core/src/utilities/coordinates/index.ts
+++ b/packages/core/src/utilities/coordinates/index.ts
@@ -1,3 +1,4 @@
+export {centerOfRectangle} from './centerOfRectangle';
 export {defaultCoordinates} from './constants';
 export {distanceBetween} from './distanceBetweenPoints';
 export {getEventCoordinates} from './getEventCoordinates';

--- a/packages/core/src/utilities/index.ts
+++ b/packages/core/src/utilities/index.ts
@@ -6,6 +6,7 @@ export {
 } from './algorithms';
 
 export {
+  centerOfRectangle,
   defaultCoordinates,
   distanceBetween,
   getEventCoordinates,

--- a/packages/core/src/utilities/rect/getRect.ts
+++ b/packages/core/src/utilities/rect/getRect.ts
@@ -78,7 +78,7 @@ export function getBoundingClientRect(
 
 export function getViewRect(element: HTMLElement): ViewRect {
   const {width, height, offsetTop, offsetLeft} = getElementLayout(element);
-  const scrollableAncestors = getScrollableAncestors(element);
+  const scrollableAncestors = getScrollableAncestors(element.parentNode);
   const scrollOffsets = getScrollOffsets(scrollableAncestors);
 
   const top = offsetTop - scrollOffsets.y;

--- a/packages/core/src/utilities/scroll/getScrollableAncestors.ts
+++ b/packages/core/src/utilities/scroll/getScrollableAncestors.ts
@@ -25,5 +25,5 @@ export function getScrollableAncestors(element: Node | null): Element[] {
     return findScrollableAncestors(node.parentNode);
   }
 
-  return element ? findScrollableAncestors(element.parentNode) : scrollParents;
+  return element ? findScrollableAncestors(element) : scrollParents;
 }


### PR DESCRIPTION
This PR is currently a work in progress, but will eventually resolve #43.

Currently, if the active draggable is not over a droppable, the scroll ancestor logic assumes that the scroll ancestors should be those of the active draggable.

This behaviour is problematic for a number of reasons, including those outlined in #43.

An alternative approach that I'm exploring in this PR is to find the scroll element automatically based on the center point of the active draggable. This isn't a perfect solution, which is why I'm opening this PR as a draft PR for the time being.

This solution isn't perfect currently because the point coordinates used for scroll ancestor detection should be affected by modifiers, but the modifiers also need the scroll ancestors. One solution for this that I'm currently thinking of would be to distinguish between the scroll target ancestors and the active node scroll ancestors.

Also, the `document.getElementFromPoint` method is expensive, and therefore calls to it should be debounced to avoid performance issues. Finding a scroll ancestor when the draggable is not over a droppable is something that can be done asynchronously and doesn't necessarily need to happen immediately for every drag move event.