### PR TITLE
issue #59: adding active and over variables to modifiers context

### DIFF
--- a/packages/core/src/components/DndContext/DndContext.tsx
+++ b/packages/core/src/components/DndContext/DndContext.tsx
@@ -223,6 +223,8 @@ export const DndContext = memo(function DndContext({
     scrollableAncestors,
     scrollableAncestorRects,
     windowRect,
+    active,
+    overId: tracked.current.overId,
   });
 
   const scrolllAdjustment = useScrollOffsets(scrollableAncestors);

--- a/packages/core/src/components/DragOverlay/DragOverlay.tsx
+++ b/packages/core/src/components/DragOverlay/DragOverlay.tsx
@@ -56,6 +56,7 @@ export const DragOverlay = React.memo(
       scrollableAncestors,
       scrollableAncestorRects,
       windowRect,
+      over,
     } = useDndContext();
     const transform = useContext(ActiveDraggableContext);
     const modifiedTransform = applyModifiers(modifiers, {
@@ -67,6 +68,8 @@ export const DragOverlay = React.memo(
       scrollableAncestors,
       scrollableAncestorRects,
       windowRect,
+      active,
+      overId: over && over.id,
     });
     const derivedTransform = useDerivedTransform(
       modifiedTransform,

--- a/packages/core/src/modifiers/types.ts
+++ b/packages/core/src/modifiers/types.ts
@@ -1,5 +1,5 @@
 import type {Transform} from '@dnd-kit/utilities';
-import type {ClientRect, ViewRect} from '../types';
+import type {ClientRect, UniqueIdentifier, ViewRect} from '../types';
 
 export type Modifier = (args: {
   transform: Transform;
@@ -10,6 +10,8 @@ export type Modifier = (args: {
   scrollableAncestors: Element[];
   scrollableAncestorRects: ViewRect[];
   windowRect: ClientRect | null;
+  active: UniqueIdentifier | null;
+  overId: UniqueIdentifier | null;
 }) => Transform;
 
 export type Modifiers = Modifier[];


### PR DESCRIPTION
Adds over and active id on modifiers context

this allow users to create modifiers by node types rather than just by node coordinates 