### PR TITLE
Add MIT license to Accessibility package

### DIFF
--- a/.changeset/add-mit-license.md
+++ b/.changeset/add-mit-license.md
@@ -1,8 +1,9 @@
 ---
+"@dnd-kit/accessibility": patch
 "@dnd-kit/core": patch
 "@dnd-kit/modifiers": patch
 "@dnd-kit/sortable": patch
 "@dnd-kit/utilities": patch
 ---
 
-Add MIT license to package.json and distributed filess
+Add MIT license to package.json and distributed files

--- a/packages/accessibility/LICENSE
+++ b/packages/accessibility/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2021, Claudéric Demers
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/accessibility/package.json
+++ b/packages/accessibility/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.1",
   "description": "A generic toolkit to help with accessibility",
   "author": "Claudéric Demers",
+  "license": "MIT",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/clauderic/dnd-kit.git",


### PR DESCRIPTION
Hey Clauderic,

I would like to use this package at work, but my company requires that all packages and dependencies contain an MIT license. I think our scanner is choking on the Accessibility package. Would it be alright to add it?

Thanks!