### PR TITLE
Improve animation finish browser support

### DIFF
--- a/.changeset/animation-finish-detection.md
+++ b/.changeset/animation-finish-detection.md
@@ -1,0 +1,5 @@
+---
+"@dnd-kit/core": patch
+---
+
+Replace `animation.finished` with `animation.onfinish` for DragOverlay drop animation as the latter has much better support across browsers. 

--- a/packages/core/src/components/DragOverlay/hooks/useDropAnimation.ts
+++ b/packages/core/src/components/DragOverlay/hooks/useDropAnimation.ts
@@ -83,28 +83,28 @@ export function useDropAnimation({
             const originalOpacity = finalNode.style.opacity;
 
             finalNode.style.opacity = '0';
-            node
-              .animate(
-                [
-                  {
-                    transform: CSS.Transform.toString(transform),
-                  },
-                  {
-                    transform: finalTransform,
-                  },
-                ],
+            const nodeAnimation = node.animate(
+              [
                 {
-                  easing,
-                  duration,
-                }
-              )
-              .finished.then(() => {
-                setDropAnimationComplete(true);
+                  transform: CSS.Transform.toString(transform),
+                },
+                {
+                  transform: finalTransform,
+                },
+              ],
+              {
+                easing,
+                duration,
+              }
+            );
 
-                if (finalNode) {
-                  finalNode.style.opacity = originalOpacity;
-                }
-              });
+            nodeAnimation.onfinish = () => {
+              setDropAnimationComplete(true);
+
+              if (finalNode) {
+                finalNode.style.opacity = originalOpacity;
+              }
+            };
             return;
           }
         }


### PR DESCRIPTION
Addresses issue #105.

### The bug
Dnd-kit [relies](https://github.com/clauderic/dnd-kit/blob/master/packages/core/src/components/DragOverlay/hooks/useDropAnimation.ts#L101) on [animation.finished](https://developer.mozilla.org/en-US/docs/Web/API/Animation/finished), which [lacks in browser support](https://caniuse.com/mdn-api_animation_finished).
I encountered this error on Electron v9.4.1 (Electron supports `animation.finished` only from version 10.x).

### Proposed solution
Swap it with [animation.onfinish](https://developer.mozilla.org/en-US/docs/Web/API/Animation/onfinish), which has [better browser supported](https://caniuse.com/mdn-api_animation_onfinish).