### PR TITLE
Add drop confirmation to trashable story

### DIFF
--- a/stories/2 - Presets/Sortable/4-MultipleContainers.story.tsx
+++ b/stories/2 - Presets/Sortable/4-MultipleContainers.story.tsx
@@ -43,12 +43,29 @@ const customCollisionDetectionStrategy: CollisionDetection = (rects, rect) => {
   return closestCorners(otherRects, rect);
 };
 
-export const TrashableItems = () => (
+const confirmDrop = (overId: string) => {
+  if (overId !== VOID_ID) {
+    return true;
+  }
+
+  return window.confirm('Are you sure you want to delete this item?');
+};
+
+export const TrashableItems = ({confirm}: {confirm: boolean}) => (
   <MultipleContainers
     collisionDetection={customCollisionDetectionStrategy}
+    confirmDrop={confirm ? confirmDrop : undefined}
     trashable
   />
 );
+
+TrashableItems.argTypes = {
+  confirm: {
+    name: 'Request user confirmation before deletion',
+    defaultValue: false,
+    control: {type: 'boolean'},
+  },
+};
 
 export const Grid = () => (
   <MultipleContainers

--- a/stories/2 - Presets/Sortable/MultipleContainers.tsx
+++ b/stories/2 - Presets/Sortable/MultipleContainers.tsx
@@ -99,6 +99,7 @@ interface Props {
   modifiers?: Modifiers;
   trashable?: boolean;
   vertical?: boolean;
+  confirmDrop?: (overId: string) => boolean;
 }
 
 export const VOID_ID = 'void';
@@ -118,6 +119,7 @@ export function MultipleContainers({
   strategy = verticalListSortingStrategy,
   trashable = false,
   vertical = false,
+  confirmDrop,
 }: Props) {
   const [items, setItems] = useState<Items>(
     () =>
@@ -155,6 +157,17 @@ export function MultipleContainers({
     const index = items[container].indexOf(id);
 
     return index;
+  };
+
+  const onDragCancel = () => {
+    if (dragOverlaydItems) {
+      // Reset items to their original state in case items have been
+      // Dragged across containrs
+      setItems(dragOverlaydItems);
+    }
+
+    setActiveId(null);
+    setClonedItems(null);
   };
 
   return (
@@ -224,6 +237,14 @@ export function MultipleContainers({
 
         const overId = over?.id || VOID_ID;
 
+        if (confirmDrop) {
+          const confirmed = confirmDrop(overId);
+          if (!confirmed) {
+            onDragCancel();
+            return;
+          }
+        }
+
         if (overId === VOID_ID) {
           setItems((items) => ({
             ...(trashable && over?.id === VOID_ID ? items : dragOverlaydItems),
@@ -253,16 +274,7 @@ export function MultipleContainers({
 
         setActiveId(null);
       }}
-      onDragCancel={() => {
-        if (dragOverlaydItems) {
-          // Reset items to their original state in case items have been
-          // Dragged across containrs
-          setItems(dragOverlaydItems);
-        }
-
-        setActiveId(null);
-        setClonedItems(null);
-      }}
+      onDragCancel={onDragCancel}
       modifiers={modifiers}
     >
       <div

--- a/stories/2 - Presets/Sortable/MultipleContainers.tsx
+++ b/stories/2 - Presets/Sortable/MultipleContainers.tsx
@@ -131,7 +131,7 @@ export function MultipleContainers({
         [VOID_ID]: [],
       }
   );
-  const [dragOverlaydItems, setClonedItems] = useState<Items | null>(null);
+  const [clonedItems, setClonedItems] = useState<Items | null>(null);
   const [activeId, setActiveId] = useState<string | null>(null);
   const sensors = useSensors(
     useSensor(PointerSensor),
@@ -160,10 +160,10 @@ export function MultipleContainers({
   };
 
   const onDragCancel = () => {
-    if (dragOverlaydItems) {
+    if (clonedItems) {
       // Reset items to their original state in case items have been
       // Dragged across containrs
-      setItems(dragOverlaydItems);
+      setItems(clonedItems);
     }
 
     setActiveId(null);
@@ -247,7 +247,7 @@ export function MultipleContainers({
 
         if (overId === VOID_ID) {
           setItems((items) => ({
-            ...(trashable && over?.id === VOID_ID ? items : dragOverlaydItems),
+            ...(trashable && over?.id === VOID_ID ? items : clonedItems),
             [VOID_ID]: [],
           }));
           setActiveId(null);


### PR DESCRIPTION
Added drop confirmation example to "Trashable Items" storybook example.

Implemented with `window.confirm` to resume on `true` or cancel on `false`.

-----------

Screencast:

https://user-images.githubusercontent.com/486954/109411427-b56aab00-79aa-11eb-894b-625d2aded5d3.mov


