### PR TITLE
Fixed flickering containers in Trashable story

### DIFF
--- a/stories/2 - Presets/Sortable/MultipleContainers.tsx
+++ b/stories/2 - Presets/Sortable/MultipleContainers.tsx
@@ -167,6 +167,7 @@ export function MultipleContainers({
       }}
       onDragOver={({active, over, draggingRect}) => {
         const overId = over?.id;
+
         if (!overId) {
           return;
         }

--- a/stories/2 - Presets/Sortable/MultipleContainers.tsx
+++ b/stories/2 - Presets/Sortable/MultipleContainers.tsx
@@ -166,7 +166,11 @@ export function MultipleContainers({
         setClonedItems(items);
       }}
       onDragOver={({active, over, draggingRect}) => {
-        const overId = over?.id || VOID_ID;
+        const overId = over?.id;
+        if (!overId) {
+          return;
+        }
+
         const overContainer = findContainer(overId);
         const activeContainer = findContainer(active.id);
 


### PR DESCRIPTION
Fixes #109.

The problem is line:
```ts
onDragOver={({active, over, draggingRect}) => {
  const overId = over?.id || VOID_ID; // <----
```

When dragging away from the trash droppable element, `over` is `undefined` and then falls back to collision detection which determines the closest drag container. But the above line doesn't let that happen, as it resets the `overContainer` to be trash over and over in an endless tug-of-war.

The solution is to remove this fallback to `VOID_ID`. The `customCollisionDetectionStrategy` anyway updates the `over` prop to the closest drag containers.

Here's how it looks now - no flicker, expected behavior:

https://user-images.githubusercontent.com/486954/109420166-ae0ec600-79d9-11eb-8d40-99352babcc78.mov

