### PR TITLE
Cancel drag on window resize

### DIFF
--- a/.changeset/sour-feet-watch.md
+++ b/.changeset/sour-feet-watch.md
@@ -1,0 +1,5 @@
+---
+"@dnd-kit/core": minor
+---
+
+Keyboard sensor now cancels dragging on window resize

--- a/packages/core/src/sensors/keyboard/KeyboardSensor.ts
+++ b/packages/core/src/sensors/keyboard/KeyboardSensor.ts
@@ -31,6 +31,7 @@ export class KeyboardSensor implements SensorInstance {
   public autoScrollEnabled = false;
   private coordinates: Coordinates = defaultCoordinates;
   private listeners: Listeners;
+  private windowListeners: Listeners;
 
   constructor(private props: KeyboardSensorProps) {
     const {
@@ -39,7 +40,9 @@ export class KeyboardSensor implements SensorInstance {
 
     this.props = props;
     this.listeners = new Listeners(getOwnerDocument(target));
+    this.windowListeners = new Listeners(window);
     this.handleKeyDown = this.handleKeyDown.bind(this);
+    this.handleCancel = this.handleCancel.bind(this);
 
     this.attach();
   }
@@ -47,7 +50,10 @@ export class KeyboardSensor implements SensorInstance {
   private attach() {
     this.handleStart();
 
-    setTimeout(() => this.listeners.add('keydown', this.handleKeyDown));
+    setTimeout(() => {
+      this.listeners.add('keydown', this.handleKeyDown);
+      this.windowListeners.add('resize', this.handleCancel);
+    });
   }
 
   private handleStart() {
@@ -242,6 +248,7 @@ export class KeyboardSensor implements SensorInstance {
 
   private detach() {
     this.listeners.removeAll();
+    this.windowListeners.removeAll();
   }
 
   static activators = [

--- a/packages/core/src/sensors/keyboard/KeyboardSensor.ts
+++ b/packages/core/src/sensors/keyboard/KeyboardSensor.ts
@@ -16,6 +16,7 @@ import {
   defaultCoordinates,
   getBoundingClientRect,
   getOwnerDocument,
+  getWindow,
   getScrollPosition,
 } from '../../utilities';
 
@@ -40,7 +41,7 @@ export class KeyboardSensor implements SensorInstance {
 
     this.props = props;
     this.listeners = new Listeners(getOwnerDocument(target));
-    this.windowListeners = new Listeners(window);
+    this.windowListeners = new Listeners(getWindow(target));
     this.handleKeyDown = this.handleKeyDown.bind(this);
     this.handleCancel = this.handleCancel.bind(this);
 

--- a/packages/core/src/sensors/utilities/Listeners.ts
+++ b/packages/core/src/sensors/utilities/Listeners.ts
@@ -4,7 +4,7 @@ export class Listeners {
     handler: EventListenerOrEventListenerObject;
   }[] = [];
 
-  constructor(private target: HTMLElement | Document) {}
+  constructor(private target: HTMLElement | Document | Window) {}
 
   public add(
     eventName: string,

--- a/packages/core/src/utilities/document/getWindow.ts
+++ b/packages/core/src/utilities/document/getWindow.ts
@@ -1,0 +1,5 @@
+import {getOwnerDocument} from './getOwnerDocument';
+
+export function getWindow(target: Event['target']) {
+  return getOwnerDocument(target).defaultView ?? window;
+}

--- a/packages/core/src/utilities/document/index.ts
+++ b/packages/core/src/utilities/document/index.ts
@@ -1,1 +1,2 @@
 export {getOwnerDocument} from './getOwnerDocument';
+export {getWindow} from './getWindow';

--- a/packages/core/src/utilities/index.ts
+++ b/packages/core/src/utilities/index.ts
@@ -22,7 +22,7 @@ export {
   isViewRect,
 } from './rect';
 
-export {getOwnerDocument} from './document';
+export {getOwnerDocument, getWindow} from './document';
 
 export {isMouseEvent, isTouchEvent} from './event';
 


### PR DESCRIPTION
Fixes issue #16.

Knowing this issue is an edge case, working on updating the draglayer position to match the viewport size might be unnecessarily complex. A simpler approach is to cancel the drag when the window is resized.

Here's how it looks:

https://user-images.githubusercontent.com/486954/109474789-8a9d5700-7a7d-11eb-9cd2-3a5a3ba60ef1.mov

