### PR TITLE
Added mouse move debouncing

### DIFF
--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -68,6 +68,7 @@ Cypress.Commands.add(
               initialRect.top + initialRect.height / 2 + y / 2
             ),
           })
+          .wait(60)
           .trigger('mousemove', {
             force: true,
             clientX: Math.floor(initialRect.left + initialRect.width / 2 + x),

--- a/packages/core/src/utilities/index.ts
+++ b/packages/core/src/utilities/index.ts
@@ -26,7 +26,13 @@ export {getOwnerDocument} from './document';
 
 export {isMouseEvent, isTouchEvent} from './event';
 
-export {getMinValueIndex, getMaxValueIndex, omit, noop} from './other';
+export {
+  getMinValueIndex,
+  getMaxValueIndex,
+  omit,
+  noop,
+  rAFDebounce,
+} from './other';
 
 export {
   getScrollableAncestors,

--- a/packages/core/src/utilities/other/index.ts
+++ b/packages/core/src/utilities/other/index.ts
@@ -3,3 +3,5 @@ export {getMinValueIndex, getMaxValueIndex} from './getValueIndex';
 export {noop} from './noop';
 
 export {omit} from './omit';
+
+export {rAFDebounce} from './rAFDebounce';

--- a/packages/core/src/utilities/other/rAFDebounce.ts
+++ b/packages/core/src/utilities/other/rAFDebounce.ts
@@ -1,0 +1,16 @@
+export function rAFDebounce(func: Function) {
+  let lastHandler: number | null = null;
+
+  return function (...args: any[]) {
+    // debounce
+    if (lastHandler) {
+      cancelAnimationFrame(lastHandler);
+    }
+
+    // schedule func call
+    lastHandler = requestAnimationFrame(() => {
+      func(...args);
+      lastHandler = null;
+    });
+  };
+}


### PR DESCRIPTION
While working with dnd-kit I noticed occasional janky dragging (I'm using a custom collision detector).

As a performance optimization, mouse move handler execution can be debounced with `requestAnimationFrame`, as it is redundant to do so at a higher rate than the screen's fps.