### PR TITLE
Parcel version bug

### DIFF
--- a/playground/package.json
+++ b/playground/package.json
@@ -23,7 +23,7 @@
   "devDependencies": {
     "@types/react": "^16.9.11",
     "@types/react-dom": "^16.8.4",
-    "parcel": "^1.12.3",
+    "parcel": "1.12.3",
     "typescript": "^3.4.5"
   }
 }


### PR DESCRIPTION
There is a bug with the latest parcel version which throws an error when trying to 'yarn build' the playground.
Seting it to 1.12.3 solves the problem.