### PR TITLE
Added onDragEndConfirm to DndContext

### DIFF
--- a/stories/2 - Presets/Sortable/MultipleContainers.tsx
+++ b/stories/2 - Presets/Sortable/MultipleContainers.tsx
@@ -12,6 +12,7 @@ import {
   UniqueIdentifier,
   useSensors,
   useSensor,
+  DragEndEvent,
 } from '@dnd-kit/core';
 import {
   SortableContext,
@@ -99,7 +100,7 @@ interface Props {
   modifiers?: Modifiers;
   trashable?: boolean;
   vertical?: boolean;
-  confirmDrop?: (overId: string) => boolean;
+  confirmDrop?: (event: DragEndEvent) => Promise<boolean>;
 }
 
 export const VOID_ID = 'void';
@@ -242,14 +243,6 @@ export function MultipleContainers({
 
         const overId = over?.id || VOID_ID;
 
-        if (confirmDrop) {
-          const confirmed = confirmDrop(overId);
-          if (!confirmed) {
-            onDragCancel();
-            return;
-          }
-        }
-
         if (overId === VOID_ID) {
           setItems((items) => ({
             ...(trashable && over?.id === VOID_ID ? items : clonedItems),
@@ -279,6 +272,7 @@ export function MultipleContainers({
 
         setActiveId(null);
       }}
+      onDragEndConfirm={confirmDrop}
       onDragCancel={onDragCancel}
       modifiers={modifiers}
     >

--- a/stories/components/ConfirmModal/ConfirmModal.module.css
+++ b/stories/components/ConfirmModal/ConfirmModal.module.css
@@ -1,0 +1,42 @@
+.ConfirmModal {
+  --width: 250px;
+  --height: 120px;
+
+  display: flex;
+  flex-direction: column;
+  width: var(--width);
+  height: var(--height);
+  position: fixed;
+  top: calc(100vh / 2 - var(--height) / 2);
+  left: calc(100vw / 2 - var(--width) / 2);
+  border-radius: 10px;
+  box-shadow: -1px 0 15px 0 rgba(34, 33, 81, 0.01),
+    0px 15px 15px 0 rgba(34, 33, 81, 0.25);
+  padding: 15px;
+  box-sizing: border-box;
+  background-color: white;
+  text-align: center;
+  z-index: 1;
+
+  h1 {
+    flex: 1;
+    font-size: 16px;
+    font-weight: normal;
+    line-height: 20px;
+  }
+
+  button {
+    width: 50px;
+    height: 23px;
+    background: #242836;
+    color: #f6f8ff;
+    border: none;
+    border-radius: 3px;
+    margin: 0 5px;
+    cursor: pointer;
+
+    &:hover {
+      background-color: #2f3545;
+    }
+  }
+}

--- a/stories/components/ConfirmModal/ConfirmModal.tsx
+++ b/stories/components/ConfirmModal/ConfirmModal.tsx
@@ -1,0 +1,21 @@
+import React, {PropsWithChildren} from 'react';
+import styles from './ConfirmModal.module.css';
+
+interface Props {
+  onConfirm(): void;
+  onDeny(): void;
+}
+
+export const ConfirmModal = ({
+  onConfirm,
+  onDeny,
+  children,
+}: PropsWithChildren<Props>) => (
+  <div className={styles.ConfirmModal}>
+    <h1>{children}</h1>
+    <div>
+      <button onClick={onConfirm}>Yes</button>
+      <button onClick={onDeny}>No</button>
+    </div>
+  </div>
+);

--- a/stories/components/ConfirmModal/index.ts
+++ b/stories/components/ConfirmModal/index.ts
@@ -1,0 +1,1 @@
+export {ConfirmModal} from './ConfirmModal';

--- a/stories/components/index.ts
+++ b/stories/components/index.ts
@@ -1,4 +1,5 @@
 export {Button} from './Button';
+export {ConfirmModal} from './ConfirmModal';
 export {Axis, Draggable} from './Draggable';
 export {Droppable} from './Droppable';
 export {Item} from './Item';


### PR DESCRIPTION
In #107 a confirm dialog on drop was added to storybook.
The demo was implemented with `window.confirm` which is rarely used. Usually a modal is used, but since it can't stop javascript execution the way `window.confirm` does - it won't work, as the drag end handler and its drop animation just won't wait.

### My proposition
`<DndContext>` exposes a new prop `onDragEndConfirm`. If provided, it awaits a `Promise` execution in the drag end handler, expecting a boolean return value:
* `true` continues `onDragEnd`
* `false` aborts `onDragEnd` and triggers `onDragCancel`

```tsx
<DndContext onDragEndConfirm={(event: onDragEvent) => Promise<boolean>}>
```


### Screencast

https://user-images.githubusercontent.com/486954/111068510-b3880800-84d1-11eb-9c6c-b7866a9b4809.mov
