### PR TITLE
Add `onActivation` option to sensors and delegate `event.preventDefault()` responsibility to consumers

### DIFF
--- a/.changeset/sensors-on-activation.md
+++ b/.changeset/sensors-on-activation.md
@@ -1,0 +1,5 @@
+---
+"@dnd-kit/core": minor
+---
+
+Added `onActivation` option to sensors. Delegated the responsibility of calling `event.preventDefault()` on activation to consumers, as consumers have the most context to decide whether it is appropriate or not to prevent the default browser behaviour on activation. Consumers of the sensors can prevent the default behaviour on activation using the `onActivation` option. Here is an example using the Pointer sensor: `useSensor(PointerSensor, {onActivation: (event) => event.preventDefault()})`

--- a/packages/core/src/sensors/index.ts
+++ b/packages/core/src/sensors/index.ts
@@ -3,6 +3,9 @@ export {useSensor} from './useSensor';
 export {useSensors} from './useSensors';
 
 export {
+  AbstractPointerSensor,
+  AbstractPointerSensorOptions,
+  AbstractPointerSensorProps,
   PointerSensor,
   PointerActivationConstraint,
   PointerEventHandlers,
@@ -10,9 +13,9 @@ export {
   PointerSensorProps,
 } from './pointer';
 
-export {MouseSensor, MouseSensorOptions} from './mouse';
+export {MouseSensor, MouseSensorOptions, MouseSensorProps} from './mouse';
 
-export {TouchSensor, TouchSensorOptions} from './touch';
+export {TouchSensor, TouchSensorOptions, TouchSensorProps} from './touch';
 
 export {
   KeyboardCoordinateGetter,

--- a/packages/core/src/sensors/keyboard/KeyboardSensor.ts
+++ b/packages/core/src/sensors/keyboard/KeyboardSensor.ts
@@ -24,6 +24,7 @@ export interface KeyboardSensorOptions extends SensorOptions {
   keyboardCodes?: KeyboardCodes;
   coordinateGetter?: KeyboardCoordinateGetter;
   scrollBehavior?: ScrollBehavior;
+  onActivation?({event}: {event: KeyboardEvent}): void;
 }
 
 export type KeyboardSensorProps = SensorProps<KeyboardSensorOptions>;
@@ -257,12 +258,17 @@ export class KeyboardSensor implements SensorInstance {
       eventName: 'onKeyDown' as const,
       handler: (
         event: React.KeyboardEvent,
-        {keyboardCodes = defaultKeyboardCodes}: KeyboardSensorOptions
+        {
+          keyboardCodes = defaultKeyboardCodes,
+          onActivation,
+        }: KeyboardSensorOptions
       ) => {
         const {code} = event.nativeEvent;
 
         if (keyboardCodes.start.includes(code)) {
           event.preventDefault();
+
+          onActivation?.({event: event.nativeEvent});
 
           return true;
         }

--- a/packages/core/src/sensors/mouse/MouseSensor.ts
+++ b/packages/core/src/sensors/mouse/MouseSensor.ts
@@ -1,9 +1,9 @@
 import {getOwnerDocument} from '../../utilities';
+import type {SensorProps} from '../types';
 import {
   AbstractPointerSensor,
   PointerEventHandlers,
-  PointerSensorOptions,
-  PointerSensorProps,
+  AbstractPointerSensorOptions,
 } from '../pointer';
 
 const events: PointerEventHandlers = {
@@ -15,22 +15,27 @@ enum MouseButton {
   RightClick = 2,
 }
 
-export interface MouseSensorOptions extends PointerSensorOptions {}
+export interface MouseSensorOptions extends AbstractPointerSensorOptions {}
+
+export type MouseSensorProps = SensorProps<MouseSensorOptions>;
 
 export class MouseSensor extends AbstractPointerSensor {
-  constructor(props: PointerSensorProps) {
+  constructor(props: MouseSensorProps) {
     super(props, events, getOwnerDocument(props.event.target));
   }
 
   static activators = [
     {
       eventName: 'onMouseDown' as const,
-      handler: ({nativeEvent}: React.MouseEvent) => {
-        if (nativeEvent.button === MouseButton.RightClick) {
+      handler: (
+        {nativeEvent: event}: React.MouseEvent,
+        {onActivation}: MouseSensorOptions
+      ) => {
+        if (event.button === MouseButton.RightClick) {
           return false;
         }
 
-        nativeEvent.preventDefault();
+        onActivation?.({event});
 
         return true;
       },

--- a/packages/core/src/sensors/mouse/index.ts
+++ b/packages/core/src/sensors/mouse/index.ts
@@ -1,1 +1,1 @@
-export {MouseSensor, MouseSensorOptions} from './MouseSensor';
+export {MouseSensor, MouseSensorOptions, MouseSensorProps} from './MouseSensor';

--- a/packages/core/src/sensors/pointer/AbstractPointerSensor.ts
+++ b/packages/core/src/sensors/pointer/AbstractPointerSensor.ts
@@ -40,11 +40,12 @@ function isDelayConstraint(
   return Boolean(constraint && 'delay' in constraint);
 }
 
-export interface PointerSensorOptions extends SensorOptions {
+export interface AbstractPointerSensorOptions extends SensorOptions {
   activationConstraint?: PointerActivationConstraint;
+  onActivation?({event}: {event: Event}): void;
 }
 
-export type PointerSensorProps = SensorProps<PointerSensorOptions>;
+export type AbstractPointerSensorProps = SensorProps<AbstractPointerSensorOptions>;
 
 enum EventName {
   Keydown = 'keydown',
@@ -59,7 +60,7 @@ export class AbstractPointerSensor implements SensorInstance {
   private ownerDocument: Document;
 
   constructor(
-    private props: PointerSensorProps,
+    private props: AbstractPointerSensorProps,
     private events: PointerEventHandlers,
     listenerTarget = getEventListenerTarget(props.event.target)
   ) {

--- a/packages/core/src/sensors/pointer/PointerSensor.ts
+++ b/packages/core/src/sensors/pointer/PointerSensor.ts
@@ -1,8 +1,9 @@
 import {getOwnerDocument} from '../../utilities';
 
+import type {SensorProps} from '../types';
 import {
   AbstractPointerSensor,
-  PointerSensorProps,
+  AbstractPointerSensorOptions,
   PointerEventHandlers,
 } from './AbstractPointerSensor';
 
@@ -10,6 +11,10 @@ const events: PointerEventHandlers = {
   move: {name: 'pointermove'},
   end: {name: 'pointerup'},
 };
+
+export interface PointerSensorOptions extends AbstractPointerSensorOptions {}
+
+export type PointerSensorProps = SensorProps<PointerSensorOptions>;
 
 export class PointerSensor extends AbstractPointerSensor {
   constructor(props: PointerSensorProps) {
@@ -24,12 +29,15 @@ export class PointerSensor extends AbstractPointerSensor {
   static activators = [
     {
       eventName: 'onPointerDown' as const,
-      handler: ({nativeEvent}: React.PointerEvent) => {
-        if (!nativeEvent.isPrimary || nativeEvent.button !== 0) {
+      handler: (
+        {nativeEvent: event}: React.PointerEvent,
+        {onActivation}: PointerSensorOptions
+      ) => {
+        if (!event.isPrimary || event.button !== 0) {
           return false;
         }
 
-        nativeEvent.preventDefault();
+        onActivation?.({event});
 
         return true;
       },

--- a/packages/core/src/sensors/pointer/index.ts
+++ b/packages/core/src/sensors/pointer/index.ts
@@ -2,8 +2,12 @@ export {
   AbstractPointerSensor,
   PointerActivationConstraint,
   PointerEventHandlers,
-  PointerSensorOptions,
-  PointerSensorProps,
+  AbstractPointerSensorOptions,
+  AbstractPointerSensorProps,
 } from './AbstractPointerSensor';
 
-export {PointerSensor} from './PointerSensor';
+export {
+  PointerSensor,
+  PointerSensorOptions,
+  PointerSensorProps,
+} from './PointerSensor';

--- a/packages/core/src/sensors/touch/TouchSensor.ts
+++ b/packages/core/src/sensors/touch/TouchSensor.ts
@@ -6,6 +6,7 @@ import {
   PointerEventHandlers,
   PointerSensorOptions,
 } from '../pointer';
+import type {SensorProps} from '../types';
 
 const events: PointerEventHandlers = {
   move: {name: 'touchmove'},
@@ -13,6 +14,8 @@ const events: PointerEventHandlers = {
 };
 
 export interface TouchSensorOptions extends PointerSensorOptions {}
+
+export type TouchSensorProps = SensorProps<TouchSensorOptions>;
 
 export class TouchSensor extends AbstractPointerSensor {
   constructor(props: PointerSensorProps) {
@@ -22,16 +25,17 @@ export class TouchSensor extends AbstractPointerSensor {
   static activators = [
     {
       eventName: 'onTouchStart' as const,
-      handler: ({nativeEvent}: React.TouchEvent) => {
-        const {touches} = nativeEvent;
+      handler: (
+        {nativeEvent: event}: React.TouchEvent,
+        {onActivation}: TouchSensorOptions
+      ) => {
+        const {touches} = event;
 
         if (touches.length > 1) {
           return false;
         }
 
-        if (nativeEvent.cancelable) {
-          nativeEvent.preventDefault();
-        }
+        onActivation?.({event});
 
         return true;
       },

--- a/packages/core/src/sensors/touch/index.ts
+++ b/packages/core/src/sensors/touch/index.ts
@@ -1,1 +1,1 @@
-export {TouchSensor, TouchSensorOptions} from './TouchSensor';
+export {TouchSensor, TouchSensorOptions, TouchSensorProps} from './TouchSensor';


### PR DESCRIPTION
This PR adds the `onActivation` option to all sensors. The `onActivation` options is an optional callback that is invoked when a sensor is activated, along with the activator event that caused the sensor to activate.

This PR also removes `event.preventDefault()` from being called in activators and delegates that responsibility to consumers (fixes https://github.com/clauderic/dnd-kit/issues/88)