### PR TITLE
Autoscrolling improvements

### DIFF
--- a/.changeset/auto-scrolling-improvements.md
+++ b/.changeset/auto-scrolling-improvements.md
@@ -1,0 +1,6 @@
+---
+"@dnd-kit/core": minor
+"@dnd-kit/sortable": minor
+---
+
+Auto-scrolling improvements. The auto-scroller now bases its calculations based on the position of the pointer rather than the edges of the draggable element's rect. This change is aligned with how the native HTML 5 Drag & Drop auto-scrolling behaves. The auto-scroller now also looks at scrollable ancestors in reverse order by default, meaning it will first attempt to scroll the window, and narrow its focus down rather than the old behaviour of looking at scrollable ancestors in order of closeness to the draggable element in the DOM tree. This generally leads to an improved user experience, but can be customized by passing a configuration object to the `autoScroll` prop that includes a custom `sortScrollableAncestors` function.

--- a/.changeset/auto-scrolling-improvements.md
+++ b/.changeset/auto-scrolling-improvements.md
@@ -5,8 +5,7 @@
 
 Auto-scrolling defaults have been updated, which should generally lead to improved user experience for most consumers.
 
-The auto-scroller now bases its calculations based on the position of the pointer rather than the edges of the draggable element's rect by default.
-This change is aligned with how the native HTML 5 Drag & Drop auto-scrolling behaves.
+The auto-scroller now bases its calculations based on the position of the pointer rather than the edges of the draggable element's rect by default. This change is aligned with how the native HTML 5 Drag & Drop auto-scrolling behaves.
 
 This behaviour can be customized using the `activator` option of the `autoScroll` prop:
 
@@ -16,13 +15,14 @@ import {AutoScrollActivator, DndContext} from '@dnd-kit/core';
 <DndContext autoScroll={{activator: AutoScrollActivator.DraggableRect}} />;
 ```
 
-The auto-scroller now also looks at scrollable ancestors in reverse tree order by default, meaning it will first attempt to scroll the window, and narrow its focus down rather than the old behaviour of looking at scrollable ancestors in order of closeness to the draggable element in the DOM tree.
-This generally leads to an improved user experience, but can be customized by passing a configuration object to the `autoScroll` prop that sets the `scrollOrder` option to `ScrollOrder.TreeOrder` instead of the new default value of `ScrollOrder.ReversedTreeOrder`:
+The auto-scroller now also looks at scrollable ancestors in order of appearance in the DOM tree, meaning it will first attempt to scroll the window, and narrow its focus down rather than the old behaviour of looking at scrollable ancestors in order of closeness to the draggable element in the DOM tree (reversed tree order).
+
+This generally leads to an improved user experience, but can be customized by passing a configuration object to the `autoScroll` prop that sets the `order` option to `TraversalOrder.ReversedTreeOrder` instead of the new default value of `TraversalOrder.TreeOrder`:
 
 ```tsx
-import {ScrollOrder, DndContext} from '@dnd-kit/core';
+import {DndContext, TraversalOrder} from '@dnd-kit/core';
 
-<DndContext autoScroll={{scrollOrder: ScrollOrder.TreeOrder}} />;
+<DndContext autoScroll={{order: TraversalOrder.ReversedTreeOrder}} />;
 ```
 
 The autoscrolling `thresholds`, `acceleration` and `interval` can now also be customized using the `autoScroll` prop:
@@ -40,7 +40,7 @@ import {DndContext} from '@dnd-kit/core';
     },
     // Accelerate slower than the default value (10)
     acceleration: 5,
-    // Auto-scroll ever 10ms instead of the default value of 5ms
+    // Auto-scroll every 10ms instead of the default value of 5ms
     interval: 10,
   }}
 />;

--- a/.changeset/auto-scrolling-improvements.md
+++ b/.changeset/auto-scrolling-improvements.md
@@ -1,6 +1,65 @@
 ---
-"@dnd-kit/core": minor
-"@dnd-kit/sortable": minor
+'@dnd-kit/core': major
+'@dnd-kit/sortable': major
 ---
 
-Auto-scrolling improvements. The auto-scroller now bases its calculations based on the position of the pointer rather than the edges of the draggable element's rect. This change is aligned with how the native HTML 5 Drag & Drop auto-scrolling behaves. The auto-scroller now also looks at scrollable ancestors in reverse order by default, meaning it will first attempt to scroll the window, and narrow its focus down rather than the old behaviour of looking at scrollable ancestors in order of closeness to the draggable element in the DOM tree. This generally leads to an improved user experience, but can be customized by passing a configuration object to the `autoScroll` prop that includes a custom `sortScrollableAncestors` function.
+Auto-scrolling defaults have been updated, which should generally lead to improved user experience for most consumers.
+
+The auto-scroller now bases its calculations based on the position of the pointer rather than the edges of the draggable element's rect by default.
+This change is aligned with how the native HTML 5 Drag & Drop auto-scrolling behaves.
+
+This behaviour can be customized using the `activator` option of the `autoScroll` prop:
+
+```tsx
+import {AutoScrollActivator, DndContext} from '@dnd-kit/core';
+
+<DndContext autoScroll={{activator: AutoScrollActivator.DraggableRect}} />;
+```
+
+The auto-scroller now also looks at scrollable ancestors in reverse tree order by default, meaning it will first attempt to scroll the window, and narrow its focus down rather than the old behaviour of looking at scrollable ancestors in order of closeness to the draggable element in the DOM tree.
+This generally leads to an improved user experience, but can be customized by passing a configuration object to the `autoScroll` prop that sets the `scrollOrder` option to `ScrollOrder.TreeOrder` instead of the new default value of `ScrollOrder.ReversedTreeOrder`:
+
+```tsx
+import {ScrollOrder, DndContext} from '@dnd-kit/core';
+
+<DndContext autoScroll={{scrollOrder: ScrollOrder.TreeOrder}} />;
+```
+
+The autoscrolling `thresholds`, `acceleration` and `interval` can now also be customized using the `autoScroll` prop:
+
+```tsx
+import {DndContext} from '@dnd-kit/core';
+
+<DndContext
+  autoScroll={{
+    thresholds: {
+      // Left and right 10% of the scroll container activate scrolling
+      x: 0.1,
+      // Top and bottom 25% of the scroll container activate scrolling
+      y: 0.25,
+    },
+    // Accelerate slower than the default value (10)
+    acceleration: 5,
+    // Auto-scroll ever 10ms instead of the default value of 5ms
+    interval: 10,
+  }}
+/>;
+```
+
+Finally, consumers can now conditionally opt out of scrolling certain scrollable ancestors using the `canScroll` option of the `autoScroll` prop:
+
+```tsx
+import {DndContext} from '@dnd-kit/core';
+
+<DndContext
+  autoScroll={{
+    canScroll(element) {
+      if (element === document.scrollingElement) {
+        return false;
+      }
+
+      return true;
+    },
+  }}
+/>;
+```

--- a/packages/core/src/components/DndContext/DndContext.tsx
+++ b/packages/core/src/components/DndContext/DndContext.tsx
@@ -25,6 +25,7 @@ import {
 } from '../../store';
 import type {Coordinates, ViewRect, LayoutRect, Translate} from '../../types';
 import {
+  CanScroll,
   LayoutMeasuring,
   useAutoScroller,
   useCachedNode,
@@ -126,8 +127,9 @@ interface Props {
   autoScroll?:
     | boolean
     | {
+        canScroll?: CanScroll;
         scrollOrder?: ScrollOrder;
-        enabled: boolean;
+        enabled?: boolean;
       };
   announcements?: Announcements;
   cancelDrop?: CancelDrop;
@@ -548,14 +550,10 @@ export const DndContext = memo(function DndContext({
   ]);
 
   useAutoScroller({
+    ...getAutoScrollerOptions(),
     pointerCoordinates,
-    disabled:
-      !autoScroll ||
-      (typeof autoScroll === 'object' && !autoScroll.enabled) ||
-      !activeSensor?.autoScrollEnabled,
     scrollableAncestors,
     scrollableAncestorRects,
-    order: typeof autoScroll === 'object' ? autoScroll.scrollOrder : undefined,
   });
 
   const contextValue = useMemo(() => {
@@ -629,6 +627,22 @@ export const DndContext = memo(function DndContext({
       />
     </>
   );
+
+  function getAutoScrollerOptions() {
+    const enabled =
+      autoScroll === true ||
+      (typeof autoScroll === 'object' && autoScroll.enabled === true) ||
+      activeSensor?.autoScrollEnabled !== false;
+
+    if (typeof autoScroll === 'object') {
+      return {
+        ...autoScroll,
+        enabled,
+      };
+    }
+
+    return {enabled};
+  }
 });
 
 function getDroppableNode(

--- a/packages/core/src/components/DndContext/DndContext.tsx
+++ b/packages/core/src/components/DndContext/DndContext.tsx
@@ -35,7 +35,7 @@ import {
   useClientRects,
   useScrollOffsets,
   useViewRect,
-  ScrollAncestorSortingFn,
+  ScrollOrder,
   SyntheticListener,
 } from '../../hooks/utilities';
 import {
@@ -126,8 +126,8 @@ interface Props {
   autoScroll?:
     | boolean
     | {
+        scrollOrder?: ScrollOrder;
         enabled: boolean;
-        sortScrollableAncestors?: ScrollAncestorSortingFn;
       };
   announcements?: Announcements;
   cancelDrop?: CancelDrop;
@@ -555,10 +555,7 @@ export const DndContext = memo(function DndContext({
       !activeSensor?.autoScrollEnabled,
     scrollableAncestors,
     scrollableAncestorRects,
-    sortScrollableAncestors:
-      typeof autoScroll === 'object'
-        ? autoScroll.sortScrollableAncestors
-        : undefined,
+    order: typeof autoScroll === 'object' ? autoScroll.scrollOrder : undefined,
   });
 
   const contextValue = useMemo(() => {

--- a/packages/core/src/components/DndContext/DndContext.tsx
+++ b/packages/core/src/components/DndContext/DndContext.tsx
@@ -25,8 +25,6 @@ import {
 } from '../../store';
 import type {Coordinates, ViewRect, LayoutRect, Translate} from '../../types';
 import {
-  CanScroll,
-  LayoutMeasuring,
   useAutoScroller,
   useCachedNode,
   useCombineActivators,
@@ -36,7 +34,10 @@ import {
   useClientRects,
   useScrollOffsets,
   useViewRect,
-  ScrollOrder,
+} from '../../hooks/utilities';
+import type {
+  AutoScrollOptions,
+  LayoutMeasuring,
   SyntheticListener,
 } from '../../hooks/utilities';
 import {
@@ -124,13 +125,7 @@ interface DndEvent extends Event {
 }
 
 interface Props {
-  autoScroll?:
-    | boolean
-    | {
-        canScroll?: CanScroll;
-        scrollOrder?: ScrollOrder;
-        enabled?: boolean;
-      };
+  autoScroll?: boolean | AutoScrollOptions;
   announcements?: Announcements;
   cancelDrop?: CancelDrop;
   children?: React.ReactNode;
@@ -551,6 +546,7 @@ export const DndContext = memo(function DndContext({
 
   useAutoScroller({
     ...getAutoScrollerOptions(),
+    draggingRect: translatedRect,
     pointerCoordinates,
     scrollableAncestors,
     scrollableAncestorRects,

--- a/packages/core/src/components/DndContext/DndContext.tsx
+++ b/packages/core/src/components/DndContext/DndContext.tsx
@@ -26,7 +26,6 @@ import {
 import type {Coordinates, ViewRect, LayoutRect, Translate} from '../../types';
 import {
   LayoutMeasuring,
-  SyntheticListener,
   useAutoScroller,
   useCachedNode,
   useCombineActivators,
@@ -36,6 +35,8 @@ import {
   useClientRects,
   useScrollOffsets,
   useViewRect,
+  ScrollAncestorSortingFn,
+  SyntheticListener,
 } from '../../hooks/utilities';
 import {
   KeyboardSensor,
@@ -122,7 +123,12 @@ interface DndEvent extends Event {
 }
 
 interface Props {
-  autoScroll?: boolean;
+  autoScroll?:
+    | boolean
+    | {
+        enabled: boolean;
+        sortScrollableAncestors?: ScrollAncestorSortingFn;
+      };
   announcements?: Announcements;
   cancelDrop?: CancelDrop;
   children?: React.ReactNode;
@@ -543,9 +549,16 @@ export const DndContext = memo(function DndContext({
 
   useAutoScroller({
     pointerCoordinates,
-    disabled: !autoScroll || !activeSensor?.autoScrollEnabled,
+    disabled:
+      !autoScroll ||
+      (typeof autoScroll === 'object' && !autoScroll.enabled) ||
+      !activeSensor?.autoScrollEnabled,
     scrollableAncestors,
     scrollableAncestorRects,
+    sortScrollableAncestors:
+      typeof autoScroll === 'object'
+        ? autoScroll.sortScrollableAncestors
+        : undefined,
   });
 
   const contextValue = useMemo(() => {

--- a/packages/core/src/components/DndContext/DndContext.tsx
+++ b/packages/core/src/components/DndContext/DndContext.tsx
@@ -52,6 +52,7 @@ import {
   defaultCoordinates,
   getAdjustedRect,
   getRectDelta,
+  getEventCoordinates,
   rectIntersection,
 } from '../../utilities';
 import {applyModifiers, Modifiers} from '../../modifiers';
@@ -183,6 +184,9 @@ export const DndContext = memo(function DndContext({
     getDraggableNode(active, draggableNodes),
     active
   );
+  const activationCoordinates = activatorEvent
+    ? getEventCoordinates(activatorEvent)
+    : null;
   const activeNodeRect = useViewRect(activeNode);
   const activeNodeClientRect = useClientRect(activeNode);
   const initialActiveNodeRectRef = useRef<ViewRect | null>(null);
@@ -237,6 +241,10 @@ export const DndContext = memo(function DndContext({
     scrollableAncestorRects,
     windowRect,
   });
+
+  const pointerCoordinates = activationCoordinates
+    ? add(activationCoordinates, translate)
+    : null;
 
   const scrolllAdjustment = useScrollOffsets(scrollableAncestors);
 
@@ -534,7 +542,7 @@ export const DndContext = memo(function DndContext({
   ]);
 
   useAutoScroller({
-    draggingRect: translatedRect,
+    pointerCoordinates,
     disabled: !autoScroll || !activeSensor?.autoScrollEnabled,
     scrollableAncestors,
     scrollableAncestorRects,

--- a/packages/core/src/hooks/index.ts
+++ b/packages/core/src/hooks/index.ts
@@ -10,4 +10,4 @@ export {
   LayoutMeasuringFrequency,
   ScrollOrder,
 } from './utilities';
-export type {LayoutMeasuring} from './utilities';
+export type {AutoScrollOptions, LayoutMeasuring} from './utilities';

--- a/packages/core/src/hooks/index.ts
+++ b/packages/core/src/hooks/index.ts
@@ -5,5 +5,9 @@ export {
 } from './useDraggable';
 export {useDndContext, UseDndContextReturnValue} from './useDndContext';
 export {useDroppable, UseDroppableArguments} from './useDroppable';
-export {LayoutMeasuringStrategy, LayoutMeasuringFrequency} from './utilities';
+export {
+  LayoutMeasuringStrategy,
+  LayoutMeasuringFrequency,
+  ScrollOrder,
+} from './utilities';
 export type {LayoutMeasuring} from './utilities';

--- a/packages/core/src/hooks/index.ts
+++ b/packages/core/src/hooks/index.ts
@@ -8,6 +8,6 @@ export {useDroppable, UseDroppableArguments} from './useDroppable';
 export {
   LayoutMeasuringStrategy,
   LayoutMeasuringFrequency,
-  ScrollOrder,
+  TraversalOrder,
 } from './utilities';
 export type {AutoScrollOptions, LayoutMeasuring} from './utilities';

--- a/packages/core/src/hooks/utilities/index.ts
+++ b/packages/core/src/hooks/utilities/index.ts
@@ -1,5 +1,5 @@
 export {useAutoScroller, ScrollOrder} from './useAutoScroller';
-export type {CanScroll} from './useAutoScroller';
+export type {Options as AutoScrollOptions} from './useAutoScroller';
 export {useCachedNode} from './useCachedNode';
 export {useCombineActivators} from './useCombineActivators';
 export {

--- a/packages/core/src/hooks/utilities/index.ts
+++ b/packages/core/src/hooks/utilities/index.ts
@@ -1,4 +1,4 @@
-export {useAutoScroller} from './useAutoScroller';
+export {useAutoScroller, ScrollAncestorSortingFn} from './useAutoScroller';
 export {useCachedNode} from './useCachedNode';
 export {useCombineActivators} from './useCombineActivators';
 export {

--- a/packages/core/src/hooks/utilities/index.ts
+++ b/packages/core/src/hooks/utilities/index.ts
@@ -1,4 +1,5 @@
 export {useAutoScroller, ScrollOrder} from './useAutoScroller';
+export type {CanScroll} from './useAutoScroller';
 export {useCachedNode} from './useCachedNode';
 export {useCombineActivators} from './useCombineActivators';
 export {

--- a/packages/core/src/hooks/utilities/index.ts
+++ b/packages/core/src/hooks/utilities/index.ts
@@ -1,4 +1,4 @@
-export {useAutoScroller, ScrollAncestorSortingFn} from './useAutoScroller';
+export {useAutoScroller, ScrollOrder} from './useAutoScroller';
 export {useCachedNode} from './useCachedNode';
 export {useCombineActivators} from './useCombineActivators';
 export {

--- a/packages/core/src/hooks/utilities/index.ts
+++ b/packages/core/src/hooks/utilities/index.ts
@@ -1,4 +1,4 @@
-export {useAutoScroller, ScrollOrder} from './useAutoScroller';
+export {useAutoScroller, TraversalOrder} from './useAutoScroller';
 export type {Options as AutoScrollOptions} from './useAutoScroller';
 export {useCachedNode} from './useCachedNode';
 export {useCombineActivators} from './useCombineActivators';

--- a/packages/core/src/hooks/utilities/useAutoScroller.ts
+++ b/packages/core/src/hooks/utilities/useAutoScroller.ts
@@ -68,18 +68,22 @@ export function useAutoScroller({
         pointerCoordinates
       );
 
-      scrollSpeed.current = speed;
-      scrollDirection.current = direction;
-
-      clearAutoScrollInterval();
-
       if (speed.x > 0 || speed.y > 0) {
+        clearAutoScrollInterval();
+
         scrollContainerRef.current = scrollContainer;
         setAutoScrollInterval(autoScroll, interval);
 
-        break;
+        scrollSpeed.current = speed;
+        scrollDirection.current = direction;
+
+        return;
       }
     }
+
+    scrollSpeed.current = {x: 0, y: 0};
+    scrollDirection.current = {x: 0, y: 0};
+    clearAutoScrollInterval();
   }, [
     autoScroll,
     clearAutoScrollInterval,

--- a/packages/core/src/hooks/utilities/useAutoScroller.ts
+++ b/packages/core/src/hooks/utilities/useAutoScroller.ts
@@ -1,4 +1,4 @@
-import {useCallback, useEffect, useRef} from 'react';
+import {useCallback, useEffect, useMemo, useRef} from 'react';
 import {useInterval} from '@dnd-kit/utilities';
 
 import {getScrollDirectionAndSpeed, defaultCoordinates} from '../../utilities';
@@ -43,6 +43,10 @@ export function useAutoScroller({
 
     scrollContainer.scrollBy(scrollLeft, scrollTop);
   }, []);
+  const reversedScrollAncestors = useMemo(
+    () => [...scrollableAncestors].reverse(),
+    [scrollableAncestors]
+  );
 
   useEffect(() => {
     if (disabled || !scrollableAncestors.length || !pointerCoordinates) {
@@ -50,7 +54,7 @@ export function useAutoScroller({
       return;
     }
 
-    for (const scrollContainer of scrollableAncestors) {
+    for (const scrollContainer of reversedScrollAncestors) {
       const index = scrollableAncestors.indexOf(scrollContainer);
       const scrolllContainerRect = scrollableAncestorRects[index];
 
@@ -84,6 +88,7 @@ export function useAutoScroller({
     pointerCoordinates,
     setAutoScrollInterval,
     scrollableAncestors,
+    reversedScrollAncestors,
     scrollableAncestorRects,
   ]);
 }

--- a/packages/core/src/hooks/utilities/useAutoScroller.ts
+++ b/packages/core/src/hooks/utilities/useAutoScroller.ts
@@ -6,7 +6,7 @@ import type {Coordinates, Direction, ViewRect} from '../../types';
 
 interface Arguments {
   disabled: boolean;
-  draggingRect: ViewRect | null;
+  pointerCoordinates: Coordinates | null;
   interval?: number;
   scrollableAncestors: Element[];
   scrollableAncestorRects: ViewRect[];
@@ -19,8 +19,8 @@ interface ScrollDirection {
 
 export function useAutoScroller({
   disabled,
-  draggingRect,
   interval = 5,
+  pointerCoordinates,
   scrollableAncestors,
   scrollableAncestorRects,
 }: Arguments) {
@@ -45,7 +45,7 @@ export function useAutoScroller({
   }, []);
 
   useEffect(() => {
-    if (disabled || !scrollableAncestors.length || !draggingRect) {
+    if (disabled || !scrollableAncestors.length || !pointerCoordinates) {
       clearAutoScrollInterval();
       return;
     }
@@ -61,7 +61,7 @@ export function useAutoScroller({
       const {direction, speed} = getScrollDirectionAndSpeed(
         scrollContainer,
         scrolllContainerRect,
-        draggingRect
+        pointerCoordinates
       );
 
       scrollSpeed.current = speed;
@@ -78,12 +78,12 @@ export function useAutoScroller({
     }
   }, [
     autoScroll,
-    draggingRect,
     clearAutoScrollInterval,
     disabled,
+    interval,
+    pointerCoordinates,
     setAutoScrollInterval,
     scrollableAncestors,
     scrollableAncestorRects,
-    interval,
   ]);
 }

--- a/packages/core/src/hooks/utilities/useAutoScroller.ts
+++ b/packages/core/src/hooks/utilities/useAutoScroller.ts
@@ -4,12 +4,15 @@ import {useInterval} from '@dnd-kit/utilities';
 import {getScrollDirectionAndSpeed, defaultCoordinates} from '../../utilities';
 import type {Coordinates, Direction, ViewRect} from '../../types';
 
+export type ScrollAncestorSortingFn = (ancestors: Element[]) => Element[];
+
 interface Arguments {
   disabled: boolean;
   pointerCoordinates: Coordinates | null;
   interval?: number;
   scrollableAncestors: Element[];
   scrollableAncestorRects: ViewRect[];
+  sortScrollableAncestors?: ScrollAncestorSortingFn;
 }
 
 interface ScrollDirection {
@@ -20,6 +23,7 @@ interface ScrollDirection {
 export function useAutoScroller({
   disabled,
   interval = 5,
+  sortScrollableAncestors = defaultScrollableAncestorSorting,
   pointerCoordinates,
   scrollableAncestors,
   scrollableAncestorRects,
@@ -43,9 +47,9 @@ export function useAutoScroller({
 
     scrollContainer.scrollBy(scrollLeft, scrollTop);
   }, []);
-  const reversedScrollAncestors = useMemo(
-    () => [...scrollableAncestors].reverse(),
-    [scrollableAncestors]
+  const sortedScrollableAncestors = useMemo(
+    () => sortScrollableAncestors(scrollableAncestors),
+    [sortScrollableAncestors, scrollableAncestors]
   );
 
   useEffect(() => {
@@ -54,7 +58,7 @@ export function useAutoScroller({
       return;
     }
 
-    for (const scrollContainer of reversedScrollAncestors) {
+    for (const scrollContainer of sortedScrollableAncestors) {
       const index = scrollableAncestors.indexOf(scrollContainer);
       const scrolllContainerRect = scrollableAncestorRects[index];
 
@@ -92,7 +96,11 @@ export function useAutoScroller({
     pointerCoordinates,
     setAutoScrollInterval,
     scrollableAncestors,
-    reversedScrollAncestors,
+    sortedScrollableAncestors,
     scrollableAncestorRects,
   ]);
+}
+
+function defaultScrollableAncestorSorting(ancestors: Element[]): Element[] {
+  return [...ancestors].reverse();
 }

--- a/packages/core/src/hooks/utilities/useAutoScroller.ts
+++ b/packages/core/src/hooks/utilities/useAutoScroller.ts
@@ -7,13 +7,16 @@ import type {Coordinates, Direction, ViewRect} from '../../types';
 export type ScrollAncestorSortingFn = (ancestors: Element[]) => Element[];
 
 interface Arguments {
-  disabled: boolean;
-  pointerCoordinates: Coordinates | null;
+  canScroll?: CanScroll;
+  enabled: boolean;
   interval?: number;
+  order?: ScrollOrder;
+  pointerCoordinates: Coordinates | null;
   scrollableAncestors: Element[];
   scrollableAncestorRects: ViewRect[];
-  order?: ScrollOrder;
 }
+
+export type CanScroll = (element: Element) => boolean;
 
 export enum ScrollOrder {
   TreeOrder,
@@ -26,7 +29,8 @@ interface ScrollDirection {
 }
 
 export function useAutoScroller({
-  disabled,
+  canScroll,
+  enabled,
   interval = 5,
   order = ScrollOrder.ReversedTreeOrder,
   pointerCoordinates,
@@ -61,12 +65,16 @@ export function useAutoScroller({
   );
 
   useEffect(() => {
-    if (disabled || !scrollableAncestors.length || !pointerCoordinates) {
+    if (!enabled || !scrollableAncestors.length || !pointerCoordinates) {
       clearAutoScrollInterval();
       return;
     }
 
     for (const scrollContainer of sortedScrollableAncestors) {
+      if (canScroll?.(scrollContainer) === false) {
+        continue;
+      }
+
       const index = scrollableAncestors.indexOf(scrollContainer);
       const scrolllContainerRect = scrollableAncestorRects[index];
 
@@ -98,8 +106,9 @@ export function useAutoScroller({
     clearAutoScrollInterval();
   }, [
     autoScroll,
+    canScroll,
     clearAutoScrollInterval,
-    disabled,
+    enabled,
     interval,
     pointerCoordinates,
     setAutoScrollInterval,

--- a/packages/core/src/hooks/utilities/useAutoScroller.ts
+++ b/packages/core/src/hooks/utilities/useAutoScroller.ts
@@ -12,7 +12,12 @@ interface Arguments {
   interval?: number;
   scrollableAncestors: Element[];
   scrollableAncestorRects: ViewRect[];
-  sortScrollableAncestors?: ScrollAncestorSortingFn;
+  order?: ScrollOrder;
+}
+
+export enum ScrollOrder {
+  TreeOrder,
+  ReversedTreeOrder,
 }
 
 interface ScrollDirection {
@@ -23,7 +28,7 @@ interface ScrollDirection {
 export function useAutoScroller({
   disabled,
   interval = 5,
-  sortScrollableAncestors = defaultScrollableAncestorSorting,
+  order = ScrollOrder.ReversedTreeOrder,
   pointerCoordinates,
   scrollableAncestors,
   scrollableAncestorRects,
@@ -48,8 +53,11 @@ export function useAutoScroller({
     scrollContainer.scrollBy(scrollLeft, scrollTop);
   }, []);
   const sortedScrollableAncestors = useMemo(
-    () => sortScrollableAncestors(scrollableAncestors),
-    [sortScrollableAncestors, scrollableAncestors]
+    () =>
+      order === ScrollOrder.ReversedTreeOrder
+        ? [...scrollableAncestors].reverse()
+        : scrollableAncestors,
+    [order, scrollableAncestors]
   );
 
   useEffect(() => {
@@ -99,8 +107,4 @@ export function useAutoScroller({
     sortedScrollableAncestors,
     scrollableAncestorRects,
   ]);
-}
-
-function defaultScrollableAncestorSorting(ancestors: Element[]): Element[] {
-  return [...ancestors].reverse();
 }

--- a/packages/core/src/hooks/utilities/useAutoScroller.ts
+++ b/packages/core/src/hooks/utilities/useAutoScroller.ts
@@ -17,7 +17,7 @@ export interface Options {
   canScroll?: CanScroll;
   enabled?: boolean;
   interval?: number;
-  scrollOrder?: ScrollOrder;
+  order?: TraversalOrder;
   threshold?: {
     x: number;
     y: number;
@@ -34,7 +34,7 @@ interface Arguments extends Options {
 
 export type CanScroll = (element: Element) => boolean;
 
-export enum ScrollOrder {
+export enum TraversalOrder {
   TreeOrder,
   ReversedTreeOrder,
 }
@@ -51,7 +51,7 @@ export function useAutoScroller({
   draggingRect,
   enabled,
   interval = 5,
-  scrollOrder = ScrollOrder.ReversedTreeOrder,
+  order = TraversalOrder.TreeOrder,
   pointerCoordinates,
   scrollableAncestors,
   scrollableAncestorRects,
@@ -95,10 +95,10 @@ export function useAutoScroller({
   }, []);
   const sortedScrollableAncestors = useMemo(
     () =>
-      scrollOrder === ScrollOrder.ReversedTreeOrder
+      order === TraversalOrder.TreeOrder
         ? [...scrollableAncestors].reverse()
         : scrollableAncestors,
-    [scrollOrder, scrollableAncestors]
+    [order, scrollableAncestors]
   );
 
   useEffect(

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -20,6 +20,7 @@ export {
 export type {
   DraggableSyntheticListeners,
   LayoutMeasuring,
+  ScrollOrder,
   UseDndContextReturnValue,
   UseDraggableArguments,
   UseDroppableArguments,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -75,6 +75,7 @@ export {
   defaultCoordinates,
   getBoundingClientRect,
   getViewRect,
+  getScrollableAncestors,
   closestCenter,
   closestCorners,
   rectIntersection,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -18,6 +18,7 @@ export {
   useDroppable,
 } from './hooks';
 export type {
+  AutoScrollOptions,
   DraggableSyntheticListeners,
   LayoutMeasuring,
   ScrollOrder,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -13,6 +13,7 @@ export type {
 export {
   LayoutMeasuringFrequency,
   LayoutMeasuringStrategy,
+  TraversalOrder,
   useDraggable,
   useDndContext,
   useDroppable,
@@ -21,7 +22,6 @@ export type {
   AutoScrollOptions,
   DraggableSyntheticListeners,
   LayoutMeasuring,
-  ScrollOrder,
   UseDndContextReturnValue,
   UseDraggableArguments,
   UseDroppableArguments,

--- a/packages/core/src/sensors/keyboard/KeyboardSensor.ts
+++ b/packages/core/src/sensors/keyboard/KeyboardSensor.ts
@@ -18,6 +18,7 @@ import {
   getOwnerDocument,
   getWindow,
   getScrollPosition,
+  getScrollElementRect,
 } from '../../utilities';
 
 export interface KeyboardSensorOptions extends SensorOptions {
@@ -122,10 +123,10 @@ export class KeyboardSensor implements SensorInstance {
             isRight,
             isLeft,
             isBottom,
-            scrollElementRect,
             maxScroll,
             minScroll,
           } = getScrollPosition(scrollContainer);
+          const scrollElementRect = getScrollElementRect(scrollContainer);
 
           const clampedCoordinates = {
             x: Math.min(

--- a/packages/core/src/sensors/keyboard/KeyboardSensor.ts
+++ b/packages/core/src/sensors/keyboard/KeyboardSensor.ts
@@ -110,9 +110,8 @@ export class KeyboardSensor implements SensorInstance {
           y: 0,
         };
         const {scrollableAncestors} = context.current;
-        const scrollContainer = scrollableAncestors[0];
 
-        if (scrollContainer) {
+        for (const scrollContainer of scrollableAncestors) {
           const direction = event.code;
           const coordinatesDelta = getCoordinatesDelta(
             newCoordinates,
@@ -187,6 +186,7 @@ export class KeyboardSensor implements SensorInstance {
               left: -scrollDelta.x,
               behavior: scrollBehavior,
             });
+            break;
           } else if (canScrollY && clampedCoordinates.y !== newCoordinates.y) {
             const canFullyScrollToNewCoordinates =
               (direction === KeyboardCode.Down &&
@@ -214,6 +214,8 @@ export class KeyboardSensor implements SensorInstance {
               top: -scrollDelta.y,
               behavior: scrollBehavior,
             });
+
+            break;
           }
         }
 

--- a/packages/core/src/utilities/index.ts
+++ b/packages/core/src/utilities/index.ts
@@ -33,6 +33,7 @@ export {
   getScrollableElement,
   getScrollCoordinates,
   getScrollDirectionAndSpeed,
+  getScrollElementRect,
   getScrollOffsets,
   getScrollPosition,
   isDocumentScrollingElement,

--- a/packages/core/src/utilities/scroll/getScrollDirectionAndSpeed.ts
+++ b/packages/core/src/utilities/scroll/getScrollDirectionAndSpeed.ts
@@ -1,11 +1,11 @@
-import {Direction, ViewRect} from '../../types';
+import {Direction, Coordinates, ViewRect} from '../../types';
 import {getScrollPosition} from './getScrollPosition';
 import {isDocumentScrollingElement} from './documentScrollingElement';
 
 export function getScrollDirectionAndSpeed(
   scrollContainer: Element,
   scrollContainerRect: ViewRect,
-  rect: ViewRect,
+  {x, y}: Coordinates,
   acceleration = 10
 ) {
   const {clientHeight, clientWidth} = scrollContainer;
@@ -15,10 +15,12 @@ export function getScrollDirectionAndSpeed(
         left: 0,
         right: clientWidth,
         bottom: clientHeight,
+        width: clientWidth,
+        height: clientHeight,
       }
     : scrollContainerRect;
   const {isTop, isBottom, isLeft, isRight} = getScrollPosition(scrollContainer);
-  const {width, height, left, top, bottom, right} = rect;
+
   const direction = {
     x: 0,
     y: 0,
@@ -27,33 +29,52 @@ export function getScrollDirectionAndSpeed(
     x: 0,
     y: 0,
   };
+  const threshold = {
+    height: finalScrollContainerRect.height * 0.2,
+    width: finalScrollContainerRect.width * 0.2,
+  };
 
-  if (!isTop && top <= finalScrollContainerRect.top + height) {
+  if (!isTop && y <= finalScrollContainerRect.top + threshold.height) {
     // Scroll Up
     direction.y = Direction.Backward;
     speed.y =
       acceleration *
-      Math.abs((top - height - finalScrollContainerRect.top) / height);
-  } else if (!isBottom && bottom >= finalScrollContainerRect.bottom - height) {
+      Math.abs(
+        (threshold.height - (finalScrollContainerRect.top + y)) /
+          threshold.height
+      );
+  } else if (
+    !isBottom &&
+    y >= finalScrollContainerRect.bottom - threshold.height
+  ) {
     // Scroll Down
     direction.y = Direction.Forward;
     speed.y =
       acceleration *
-      Math.abs((finalScrollContainerRect.bottom - height - bottom) / height);
+      Math.abs(
+        (threshold.height - (finalScrollContainerRect.bottom - y)) /
+          threshold.height
+      );
   }
 
-  if (!isRight && right >= finalScrollContainerRect.right - width) {
+  if (!isRight && x >= finalScrollContainerRect.right - threshold.width) {
     // Scroll Right
     direction.x = Direction.Forward;
     speed.x =
       acceleration *
-      Math.abs((finalScrollContainerRect.right - width - right) / width);
-  } else if (!isLeft && left <= finalScrollContainerRect.left + width) {
+      Math.abs(
+        (threshold.width - (finalScrollContainerRect.right - x)) /
+          threshold.width
+      );
+  } else if (!isLeft && x <= finalScrollContainerRect.left + threshold.width) {
     // Scroll Left
     direction.x = Direction.Backward;
     speed.x =
       acceleration *
-      Math.abs((left - width - finalScrollContainerRect.left) / width);
+      Math.abs(
+        (threshold.width - (finalScrollContainerRect.left + x)) /
+          threshold.width
+      );
   }
 
   return {

--- a/packages/core/src/utilities/scroll/getScrollDirectionAndSpeed.ts
+++ b/packages/core/src/utilities/scroll/getScrollDirectionAndSpeed.ts
@@ -1,12 +1,20 @@
-import {Direction, Coordinates, ViewRect} from '../../types';
+import {Direction, ViewRect} from '../../types';
 import {getScrollPosition} from './getScrollPosition';
 import {isDocumentScrollingElement} from './documentScrollingElement';
+
+interface Rect extends Pick<ViewRect, 'top' | 'left' | 'right' | 'bottom'> {}
+
+const defaultThreshold = {
+  x: 0.2,
+  y: 0.2,
+};
 
 export function getScrollDirectionAndSpeed(
   scrollContainer: Element,
   scrollContainerRect: ViewRect,
-  {x, y}: Coordinates,
-  acceleration = 10
+  {top, left, right, bottom}: Rect,
+  acceleration = 10,
+  thresholdPercentage = defaultThreshold
 ) {
   const {clientHeight, clientWidth} = scrollContainer;
   const finalScrollContainerRect = isDocumentScrollingElement(scrollContainer)
@@ -30,49 +38,52 @@ export function getScrollDirectionAndSpeed(
     y: 0,
   };
   const threshold = {
-    height: finalScrollContainerRect.height * 0.2,
-    width: finalScrollContainerRect.width * 0.2,
+    height: finalScrollContainerRect.height * thresholdPercentage.y,
+    width: finalScrollContainerRect.width * thresholdPercentage.x,
   };
 
-  if (!isTop && y <= finalScrollContainerRect.top + threshold.height) {
+  if (!isTop && top <= finalScrollContainerRect.top + threshold.height) {
     // Scroll Up
     direction.y = Direction.Backward;
     speed.y =
       acceleration *
       Math.abs(
-        (threshold.height - (finalScrollContainerRect.top + y)) /
+        (threshold.height - (finalScrollContainerRect.top + top)) /
           threshold.height
       );
   } else if (
     !isBottom &&
-    y >= finalScrollContainerRect.bottom - threshold.height
+    bottom >= finalScrollContainerRect.bottom - threshold.height
   ) {
     // Scroll Down
     direction.y = Direction.Forward;
     speed.y =
       acceleration *
       Math.abs(
-        (threshold.height - (finalScrollContainerRect.bottom - y)) /
+        (threshold.height - (finalScrollContainerRect.bottom - bottom)) /
           threshold.height
       );
   }
 
-  if (!isRight && x >= finalScrollContainerRect.right - threshold.width) {
+  if (!isRight && right >= finalScrollContainerRect.right - threshold.width) {
     // Scroll Right
     direction.x = Direction.Forward;
     speed.x =
       acceleration *
       Math.abs(
-        (threshold.width - (finalScrollContainerRect.right - x)) /
+        (threshold.width - (finalScrollContainerRect.right - right)) /
           threshold.width
       );
-  } else if (!isLeft && x <= finalScrollContainerRect.left + threshold.width) {
+  } else if (
+    !isLeft &&
+    left <= finalScrollContainerRect.left + threshold.width
+  ) {
     // Scroll Left
     direction.x = Direction.Backward;
     speed.x =
       acceleration *
       Math.abs(
-        (threshold.width - (finalScrollContainerRect.left + x)) /
+        (threshold.width - (finalScrollContainerRect.left + left)) /
           threshold.width
       );
   }

--- a/packages/core/src/utilities/scroll/getScrollElementRect.ts
+++ b/packages/core/src/utilities/scroll/getScrollElementRect.ts
@@ -1,0 +1,25 @@
+export function getScrollElementRect(element: Element) {
+  if (element === document.scrollingElement) {
+    const {innerWidth, innerHeight} = window;
+
+    return {
+      top: 0,
+      left: 0,
+      right: innerWidth,
+      bottom: innerHeight,
+      width: innerWidth,
+      height: innerHeight,
+    };
+  }
+
+  const {top, left, right, bottom} = element.getBoundingClientRect();
+
+  return {
+    top,
+    left,
+    right,
+    bottom,
+    width: element.clientWidth,
+    height: element.clientHeight,
+  };
+}

--- a/packages/core/src/utilities/scroll/getScrollPosition.ts
+++ b/packages/core/src/utilities/scroll/getScrollPosition.ts
@@ -1,29 +1,11 @@
-function getScrollElementRect(element: Element) {
-  if (element === document.scrollingElement) {
-    const {innerWidth, innerHeight} = window;
-
-    return {
-      top: 0,
-      left: 0,
-      right: innerWidth,
-      bottom: innerHeight,
-      width: innerWidth,
-      height: innerHeight,
-    };
-  }
-
-  return element.getBoundingClientRect();
-}
-
 export function getScrollPosition(scrollingContainer: Element) {
-  const scrollElementRect = getScrollElementRect(scrollingContainer);
   const minScroll = {
     x: 0,
     y: 0,
   };
   const maxScroll = {
-    x: scrollingContainer.scrollWidth - scrollElementRect.width,
-    y: scrollingContainer.scrollHeight - scrollElementRect.height,
+    x: scrollingContainer.scrollWidth - scrollingContainer.clientWidth,
+    y: scrollingContainer.scrollHeight - scrollingContainer.clientHeight,
   };
 
   const isTop = scrollingContainer.scrollTop <= minScroll.y;
@@ -36,7 +18,6 @@ export function getScrollPosition(scrollingContainer: Element) {
     isLeft,
     isBottom,
     isRight,
-    scrollElementRect,
     maxScroll,
     minScroll,
   };

--- a/packages/core/src/utilities/scroll/index.ts
+++ b/packages/core/src/utilities/scroll/index.ts
@@ -2,6 +2,7 @@ export {getScrollableAncestors} from './getScrollableAncestors';
 export {getScrollableElement} from './getScrollableElement';
 export {getScrollCoordinates} from './getScrollCoordinates';
 export {getScrollDirectionAndSpeed} from './getScrollDirectionAndSpeed';
+export {getScrollElementRect} from './getScrollElementRect';
 export {getScrollOffsets} from './getScrollOffsets';
 export {getScrollPosition} from './getScrollPosition';
 export {isDocumentScrollingElement} from './documentScrollingElement';

--- a/packages/sortable/src/sensors/keyboard/sortableKeyboardCoordinates.ts
+++ b/packages/sortable/src/sensors/keyboard/sortableKeyboardCoordinates.ts
@@ -1,11 +1,11 @@
 import {
   closestCorners,
   getViewRect,
+  getScrollableAncestors,
   KeyboardCode,
   RectEntry,
   KeyboardCoordinateGetter,
 } from '@dnd-kit/core';
-import {subtract as getCoordinatesDelta} from '@dnd-kit/utilities';
 
 const directions: string[] = [
   KeyboardCode.Down,
@@ -16,7 +16,7 @@ const directions: string[] = [
 
 export const sortableKeyboardCoordinates: KeyboardCoordinateGetter = (
   event,
-  {context: {translatedRect, droppableContainers}}
+  {context: {droppableContainers, translatedRect, scrollableAncestors}}
 ) => {
   if (directions.includes(event.code)) {
     event.preventDefault();
@@ -70,11 +70,24 @@ export const sortableKeyboardCoordinates: KeyboardCoordinateGetter = (
       const newNode = droppableContainers[closestId]?.node.current;
 
       if (newNode) {
+        const newScrollAncestors = getScrollableAncestors(newNode);
+        const hasDifferentScrollAncestors = newScrollAncestors.some(
+          (element, index) => scrollableAncestors[index] !== element
+        );
         const newRect = getViewRect(newNode);
-        const newCoordinates = getCoordinatesDelta({
-          x: newRect.left - (translatedRect.width - newRect.width),
-          y: newRect.top - (translatedRect.height - newRect.height),
-        });
+        const offset = hasDifferentScrollAncestors
+          ? {
+              x: 0,
+              y: 0,
+            }
+          : {
+              x: translatedRect.width - newRect.width,
+              y: translatedRect.height - newRect.height,
+            };
+        const newCoordinates = {
+          x: newRect.left - offset.x,
+          y: newRect.top - offset.y,
+        };
 
         return newCoordinates;
       }


### PR DESCRIPTION
Fixes #23 

Auto-scrolling defaults have been updated, which should generally lead to improved user experience for most consumers.

The auto-scroller now bases its calculations based on the position of the pointer rather than the edges of the draggable element's rect by default. This change is aligned with how the native HTML 5 Drag & Drop auto-scrolling behaves.

This behaviour can be customized using the `activator` option of the `autoScroll` prop:

```tsx
import {AutoScrollActivator, DndContext} from '@dnd-kit/core';

<DndContext autoScroll={{activator: AutoScrollActivator.DraggableRect}} />;
```

The auto-scroller now also looks at scrollable ancestors in order of appearance in the DOM tree, meaning it will first attempt to scroll the window, and narrow its focus down rather than the old behaviour of looking at scrollable ancestors in order of closeness to the draggable element in the DOM tree (reversed tree order).

This generally leads to an improved user experience, but can be customized by passing a configuration object to the `autoScroll` prop that sets the `order` option to `TraversalOrder.ReversedTreeOrder` instead of the new default value of `TraversalOrder.TreeOrder`:

```tsx
import {DndContext, TraversalOrder} from '@dnd-kit/core';

<DndContext autoScroll={{order: TraversalOrder.ReversedTreeOrder}} />;
```

The autoscrolling `thresholds`, `acceleration` and `interval` can now also be customized using the `autoScroll` prop:

```tsx
import {DndContext} from '@dnd-kit/core';

<DndContext
  autoScroll={{
    thresholds: {
      // Left and right 10% of the scroll container activate scrolling
      x: 0.1,
      // Top and bottom 25% of the scroll container activate scrolling
      y: 0.25,
    },
    // Accelerate slower than the default value (10)
    acceleration: 5,
    // Auto-scroll every 10ms instead of the default value of 5ms
    interval: 10,
  }}
/>;
```

Finally, consumers can now conditionally opt out of scrolling certain scrollable ancestors using the `canScroll` option of the `autoScroll` prop:

```tsx
import {DndContext} from '@dnd-kit/core';

<DndContext
  autoScroll={{
    canScroll(element) {
      if (element === document.scrollingElement) {
        return false;
      }

      return true;
    },
  }}
/>;
```
