### PR TITLE
Remove `transform.x` and `transform.y` check in useDropAnimation

### DIFF
--- a/.changeset/fix-dropanimation-bug.md
+++ b/.changeset/fix-dropanimation-bug.md
@@ -1,0 +1,5 @@
+---
+"@dnd-kit/core": patch
+---
+
+`DragOverlay` now attempts to perform drop animation even if  `transform.x` and `transform.y` are both zero. 

--- a/packages/core/src/components/DragOverlay/hooks/useDropAnimation.ts
+++ b/packages/core/src/components/DragOverlay/hooks/useDropAnimation.ts
@@ -34,17 +34,7 @@ export function useDropAnimation({
   const [dropAnimationComplete, setDropAnimationComplete] = useState(false);
 
   useEffect(() => {
-    const shouldPerformDropAnimation = transform
-      ? Boolean(Math.abs(transform.x) || Math.abs(transform.y))
-      : false;
-
-    if (
-      !animate ||
-      !activeId ||
-      !easing ||
-      !duration ||
-      !shouldPerformDropAnimation
-    ) {
+    if (!animate || !activeId || !easing || !duration) {
       if (animate) {
         setDropAnimationComplete(true);
       }


### PR DESCRIPTION
The drop animation logic should be attempted even if `transform.x === 0 && tranform.y === 0`. The reason being that sometimes only the window scroll coordinates have changed, for example, when sorting via the keyboard. In that scenario,  transform.x and transform.y are both zero, yet the position of the draggable has changed and a drop animation should take place. 

Similarly, if `margin` is applied to the drag overlay, we want to also trigger a drop animation.