### PR TITLE
Fix regression with autoscroll disabling by sensors

### DIFF
--- a/.changeset/sensor-autoscroll-disabling.md
+++ b/.changeset/sensor-autoscroll-disabling.md
@@ -1,0 +1,5 @@
+---
+"@dnd-kit/core": patch
+---
+
+Fix regression with autoscroll disabling by sensors

--- a/packages/core/src/components/DndContext/DndContext.tsx
+++ b/packages/core/src/components/DndContext/DndContext.tsx
@@ -625,10 +625,14 @@ export const DndContext = memo(function DndContext({
   );
 
   function getAutoScrollerOptions() {
+    const activeSensorDisablesAutoscroll =
+      activeSensor?.autoScrollEnabled === false;
+    const autoScrollGloballyDisabled =
+      typeof autoScroll === 'object'
+        ? autoScroll.enabled === false
+        : autoScroll === false;
     const enabled =
-      autoScroll === true ||
-      (typeof autoScroll === 'object' && autoScroll.enabled === true) ||
-      activeSensor?.autoScrollEnabled !== false;
+      !activeSensorDisablesAutoscroll && !autoScrollGloballyDisabled;
 
     if (typeof autoScroll === 'object') {
       return {


### PR DESCRIPTION
There was a regression introduced with #140 where the `autoScrollDisabled` option of sensors was not being respected. This PR fixes that regression.