### PR TITLE
fix: remove `type` keyword from export

### DIFF
--- a/.changeset/autoscroll-activator-enum.md
+++ b/.changeset/autoscroll-activator-enum.md
@@ -1,0 +1,5 @@
+---
+"@dnd-kit/core": patch
+---
+
+AutoScrollActivator enum was being exported as a type rather than a value.

--- a/packages/core/src/hooks/index.ts
+++ b/packages/core/src/hooks/index.ts
@@ -11,7 +11,4 @@ export {
   LayoutMeasuringFrequency,
   TraversalOrder,
 } from './utilities';
-export type {
-  AutoScrollOptions,
-  LayoutMeasuring,
-} from './utilities';
+export type {AutoScrollOptions, LayoutMeasuring} from './utilities';

--- a/packages/core/src/hooks/index.ts
+++ b/packages/core/src/hooks/index.ts
@@ -10,7 +10,7 @@ export {
   LayoutMeasuringFrequency,
   TraversalOrder,
 } from './utilities';
-export type {
+export {
   AutoScrollOptions,
   AutoScrollActivator,
   LayoutMeasuring,

--- a/packages/core/src/hooks/index.ts
+++ b/packages/core/src/hooks/index.ts
@@ -6,12 +6,12 @@ export {
 export {useDndContext, UseDndContextReturnValue} from './useDndContext';
 export {useDroppable, UseDroppableArguments} from './useDroppable';
 export {
+  AutoScrollActivator,
   LayoutMeasuringStrategy,
   LayoutMeasuringFrequency,
   TraversalOrder,
 } from './utilities';
-export {
+export type {
   AutoScrollOptions,
-  AutoScrollActivator,
   LayoutMeasuring,
 } from './utilities';


### PR DESCRIPTION
Fix missing `AutoScrollActivator` when importing from '@dnd-kit/core'