### PR TITLE
Fix auto scroll top and left speed calculations

### DIFF
--- a/.changeset/fix-auto-scroll-speed.md
+++ b/.changeset/fix-auto-scroll-speed.md
@@ -1,0 +1,5 @@
+---
+'@dnd-kit/core': patch
+---
+
+fix calculations for top and left auto scroll speed

--- a/packages/core/src/utilities/scroll/getScrollDirectionAndSpeed.ts
+++ b/packages/core/src/utilities/scroll/getScrollDirectionAndSpeed.ts
@@ -48,7 +48,7 @@ export function getScrollDirectionAndSpeed(
     speed.y =
       acceleration *
       Math.abs(
-        (threshold.height - (finalScrollContainerRect.top + top)) /
+        ((finalScrollContainerRect.top + threshold.height) - top) /
           threshold.height
       );
   } else if (
@@ -60,7 +60,7 @@ export function getScrollDirectionAndSpeed(
     speed.y =
       acceleration *
       Math.abs(
-        (threshold.height - (finalScrollContainerRect.bottom - bottom)) /
+        ((finalScrollContainerRect.bottom - threshold.height) - bottom) /
           threshold.height
       );
   }
@@ -71,7 +71,7 @@ export function getScrollDirectionAndSpeed(
     speed.x =
       acceleration *
       Math.abs(
-        (threshold.width - (finalScrollContainerRect.right - right)) /
+        ((finalScrollContainerRect.right - threshold.width) - right) /
           threshold.width
       );
   } else if (
@@ -83,7 +83,7 @@ export function getScrollDirectionAndSpeed(
     speed.x =
       acceleration *
       Math.abs(
-        (threshold.width - (finalScrollContainerRect.left + left)) /
+        ((finalScrollContainerRect.left + threshold.width) - left) /
           threshold.width
       );
   }

--- a/stories/2 - Presets/Sortable/1-Vertical.story.tsx
+++ b/stories/2 - Presets/Sortable/1-Vertical.story.tsx
@@ -43,7 +43,7 @@ export const RestrictToScrollContainer = () => (
     style={{
       height: '50vh',
       width: 350,
-      margin: '0 auto',
+      margin: '200px auto 0',
       overflow: 'auto',
     }}
   >
@@ -55,7 +55,7 @@ export const ScrollContainer = () => (
   <div
     style={{
       height: '50vh',
-      margin: '0 auto',
+      margin: '200px auto 0',
       overflow: 'auto',
     }}
   >


### PR DESCRIPTION
Auto scroll speed for top and left is currently calculated incorrectly. It scrolls very very fast in these directions depending on the scrollable containers offset to the edge of the page.

The Vertical scrollable stories currently mask the issue because the scrollable containers sit at the very top of the page. This PR also updates the stories.