### PR TITLE
LiveRegion tweaks

### DIFF
--- a/.changeset/live-region-tweaks.md
+++ b/.changeset/live-region-tweaks.md
@@ -1,0 +1,8 @@
+---
+"@dnd-kit/accessibility": patch
+---
+
+Tweaked LiveRegion component: 
+- Entries are now rendered without wrapper `span` elements. Having wrapper `span` elements causes VoiceOver on macOS to try to move the VoiceOver cursor to the live region, which interferes with scrolling. This issue is not exhibited when rendering announcement entries as plain text without wrapper spans.
+- Added the `role="status"` attribute to the LiveRegion wrapper element. 
+- Added the `white-space: no-wrap;` property to ensure that text does not wrap.

--- a/packages/accessibility/src/components/LiveRegion/LiveRegion.tsx
+++ b/packages/accessibility/src/components/LiveRegion/LiveRegion.tsx
@@ -28,7 +28,7 @@ export function LiveRegion({id, entries}: Props) {
       aria-atomic
     >
       {entries.map(([id, entry]) => (
-        <span key={id.toString()}>{entry}</span>
+        <React.Fragment key={id.toString()}>{entry}</React.Fragment>
       ))}
     </div>
   );

--- a/packages/accessibility/src/components/LiveRegion/LiveRegion.tsx
+++ b/packages/accessibility/src/components/LiveRegion/LiveRegion.tsx
@@ -23,6 +23,7 @@ export function LiveRegion({id, entries}: Props) {
     <div
       id={id}
       style={visuallyHidden}
+      role="status"
       aria-live="assertive"
       aria-relevant="additions"
       aria-atomic

--- a/packages/accessibility/src/components/LiveRegion/LiveRegion.tsx
+++ b/packages/accessibility/src/components/LiveRegion/LiveRegion.tsx
@@ -16,6 +16,7 @@ const visuallyHidden: React.CSSProperties = {
   overflow: 'hidden',
   clip: 'rect(0 0 0 0)',
   clipPath: 'inset(100%)',
+  whiteSpace: 'nowrap',
 };
 
 export function LiveRegion({id, entries}: Props) {


### PR DESCRIPTION
- Render live region entries as plain text without span wrappers
- Add role="status" to LiveRegion …
- Ensure text in LiveRegion does not wrap