### PR TITLE
Simplify useAnnouncement hook

### DIFF
--- a/.changeset/simplify-use-announcement.md
+++ b/.changeset/simplify-use-announcement.md
@@ -1,0 +1,8 @@
+---
+"@dnd-kit/accessibility": major
+"@dnd-kit/core": patch
+---
+
+Simplify `useAnnouncement` hook to only return a single `announcement` rather than `entries`. Similarly, the `LiveRegion` component now only accepts a single `announcement` rather than `entries.
+
+- The current strategy used in the useAnnouncement hook is needlessly complex. It's not actually necessary to render multiple announcements at once within the LiveRegion component. It's sufficient to render a single announcement at a time. It's also un-necessary to clean up the announcements after they have been announced, especially now that the role="status" attribute has been added to LiveRegion, keeping the last announcement rendered means users can refer to the last status.

--- a/packages/accessibility/src/components/LiveRegion/LiveRegion.tsx
+++ b/packages/accessibility/src/components/LiveRegion/LiveRegion.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 export interface Props {
   id: string;
-  entries: [NodeJS.Timeout, string][];
+  announcement: string;
 }
 
 // Hide element visually but keep it readable by screen readers
@@ -19,19 +19,16 @@ const visuallyHidden: React.CSSProperties = {
   whiteSpace: 'nowrap',
 };
 
-export function LiveRegion({id, entries}: Props) {
+export function LiveRegion({id, announcement}: Props) {
   return (
     <div
       id={id}
       style={visuallyHidden}
       role="status"
       aria-live="assertive"
-      aria-relevant="additions"
       aria-atomic
     >
-      {entries.map(([id, entry]) => (
-        <React.Fragment key={id.toString()}>{entry}</React.Fragment>
-      ))}
+      {announcement}
     </div>
   );
 }

--- a/packages/accessibility/src/hooks/useAnnouncement.ts
+++ b/packages/accessibility/src/hooks/useAnnouncement.ts
@@ -1,44 +1,7 @@
-import {useCallback, useEffect, useMemo, useRef, useState} from 'react';
-
-const timeout = 1e3; // 1 second
+import {useState} from 'react';
 
 export function useAnnouncement() {
-  const [announcementMap, setAnnouncements] = useState(
-    new Map<NodeJS.Timeout, string>()
-  );
-  const announce = useCallback((announcement: string) => {
-    setAnnouncements((announcements) => {
-      const timeoutId = setTimeout(() => {
-        setAnnouncements((announcements) => {
-          announcements.delete(timeoutId);
+  const [announcement, setAnnouncement] = useState('');
 
-          return new Map(announcements);
-        });
-      }, timeout);
-
-      announcements.set(timeoutId, announcement);
-
-      return new Map(announcements);
-    });
-  }, []);
-  const announcementMapRef = useRef(announcementMap);
-  const entries = useMemo(() => Array.from(announcementMap.entries()), [
-    announcementMap,
-  ]);
-
-  useEffect(() => {
-    announcementMapRef.current = announcementMap;
-  }, [announcementMap]);
-
-  useEffect(() => {
-    return () => {
-      // Clean up any queued `setTimeout` calls on unmount
-      // eslint-disable-next-line react-hooks/exhaustive-deps
-      announcementMapRef.current.forEach((_, key) => {
-        clearTimeout(key);
-      });
-    };
-  }, []);
-
-  return {announce, entries} as const;
+  return {announce: setAnnouncement, announcement} as const;
 }

--- a/packages/core/src/components/Accessibility/Accessibility.tsx
+++ b/packages/core/src/components/Accessibility/Accessibility.tsx
@@ -25,7 +25,7 @@ export function Accessibility({
   hiddenTextDescribedById,
   screenReaderInstructions,
 }: Props) {
-  const {announce, entries} = useAnnouncement();
+  const {announce, announcement} = useAnnouncement();
   const tracked = useRef({
     activeId,
     overId,
@@ -76,7 +76,7 @@ export function Accessibility({
             id={hiddenTextDescribedById}
             value={screenReaderInstructions.draggable}
           />
-          <LiveRegion id={liveRegionId} entries={entries} />
+          <LiveRegion id={liveRegionId} announcement={announcement} />
         </>,
         document.body
       )


### PR DESCRIPTION
The current strategy used in the `useAnnouncement` hook is needlessly complex. It's not actually necessary to render multiple announcements at once within the `LiveRegion` component. It's sufficient to render a single announcement at a time. It's also un-necessary to clean up the announcements after they have been announced, especially now that the `role="status"` attribute has been added to `LiveRegion`, keeping the last announcement rendered means users can refer to the last status.