### PR TITLE
Introduce useDndMonitor hook

### DIFF
--- a/.changeset/use-dnd-monitor.md
+++ b/.changeset/use-dnd-monitor.md
@@ -1,0 +1,30 @@
+---
+"@dnd-kit/accessibility": patch
+"@dnd-kit/core": major
+---
+
+Introduced the `useDndMonitor` hook. The `useDndMonitor` hook can be used within components wrapped in a `DndContext` provider to monitor the different drag and drop events that happen for that `DndContext`.
+
+Example usage:
+
+```tsx
+import {DndContext, useDndMonitor} from '@dnd-kit/core';
+
+function App() {
+  return (
+    <DndContext>
+      <Component />
+    </DndContext>
+  );
+}
+
+function Component() {
+  useDndMonitor({
+    onDragStart(event) {},
+    onDragMove(event) {},
+    onDragOver(event) {},
+    onDragEnd(event) {},
+    onDragCancel(event) {},
+  })
+}
+```

--- a/packages/accessibility/src/hooks/useAnnouncement.ts
+++ b/packages/accessibility/src/hooks/useAnnouncement.ts
@@ -1,7 +1,12 @@
-import {useState} from 'react';
+import {useCallback, useState} from 'react';
 
 export function useAnnouncement() {
   const [announcement, setAnnouncement] = useState('');
+  const announce = useCallback((value: string | undefined) => {
+    if (value != null) {
+      setAnnouncement(value);
+    }
+  }, []);
 
-  return {announce: setAnnouncement, announcement} as const;
+  return {announce, announcement} as const;
 }

--- a/packages/core/src/components/Accessibility/Accessibility.tsx
+++ b/packages/core/src/components/Accessibility/Accessibility.tsx
@@ -1,4 +1,4 @@
-import React, {useRef, useEffect} from 'react';
+import React, {useMemo} from 'react';
 import {createPortal} from 'react-dom';
 import {canUseDOM, useUniqueId} from '@dnd-kit/utilities';
 import {HiddenText, LiveRegion, useAnnouncement} from '@dnd-kit/accessibility';
@@ -6,68 +6,41 @@ import {HiddenText, LiveRegion, useAnnouncement} from '@dnd-kit/accessibility';
 import type {Announcements, ScreenReaderInstructions} from './types';
 import type {UniqueIdentifier} from '../../types';
 import {defaultAnnouncements} from './defaults';
-import {Action, State} from '../../store';
+import {DndMonitorArguments, useDndMonitor} from '../../hooks';
 
 interface Props {
   announcements?: Announcements;
-  activeId: UniqueIdentifier | null;
-  overId: UniqueIdentifier | null;
-  lastEvent: State['draggable']['lastEvent'];
   screenReaderInstructions: ScreenReaderInstructions;
   hiddenTextDescribedById: UniqueIdentifier;
 }
 
 export function Accessibility({
   announcements = defaultAnnouncements,
-  activeId,
-  overId,
-  lastEvent,
   hiddenTextDescribedById,
   screenReaderInstructions,
 }: Props) {
   const {announce, announcement} = useAnnouncement();
-  const tracked = useRef({
-    activeId,
-    overId,
-  });
   const liveRegionId = useUniqueId(`DndLiveRegion`);
 
-  useEffect(() => {
-    const {
-      activeId: previousActiveId,
-      overId: previousOverId,
-    } = tracked.current;
-    let announcement: string | undefined;
-
-    if (!previousActiveId && activeId) {
-      announcement = announcements.onDragStart(activeId);
-    } else if (!activeId && previousActiveId) {
-      if (lastEvent === Action.DragEnd) {
-        announcement = announcements.onDragEnd(
-          previousActiveId,
-          previousOverId ?? undefined
-        );
-      } else if (lastEvent === Action.DragCancel) {
-        announcement = announcements.onDragCancel(previousActiveId);
-      }
-    } else if (activeId && previousActiveId && overId !== previousOverId) {
-      announcement = announcements.onDragOver(activeId, overId ?? undefined);
-    }
-
-    if (announcement) {
-      announce(announcement);
-    }
-
-    if (
-      tracked.current.overId !== overId ||
-      tracked.current.activeId !== activeId
-    ) {
-      tracked.current = {
-        activeId,
-        overId,
-      };
-    }
-  }, [announcements, announce, activeId, overId, lastEvent]);
+  useDndMonitor(
+    useMemo<DndMonitorArguments>(
+      () => ({
+        onDragStart({active}) {
+          announce(announcements.onDragStart(active.id));
+        },
+        onDragOver({active, over}) {
+          announce(announcements.onDragOver(active.id, over?.id));
+        },
+        onDragEnd({active, over}) {
+          announce(announcements.onDragEnd(active.id, over?.id));
+        },
+        onDragCancel({active}) {
+          announce(announcements.onDragCancel(active.id));
+        },
+      }),
+      [announce, announcements]
+    )
+  );
 
   return canUseDOM
     ? createPortal(

--- a/packages/core/src/components/DndContext/DndContext.tsx
+++ b/packages/core/src/components/DndContext/DndContext.tsx
@@ -475,7 +475,7 @@ export const DndContext = memo(function DndContext({
           : null,
     };
 
-    setMonitorState({type: Action.DragOver, event});
+    setMonitorState({type: Action.DragMove, event});
     onDragMove?.(event);
   }, [scrollAdjustedTransalte.x, scrollAdjustedTransalte.y]);
 
@@ -519,7 +519,7 @@ export const DndContext = memo(function DndContext({
           : null,
     };
 
-    setMonitorState({type: Action.DragMove, event});
+    setMonitorState({type: Action.DragOver, event});
     onDragOver?.(event);
   }, [overId]);
 

--- a/packages/core/src/components/DndContext/index.ts
+++ b/packages/core/src/components/DndContext/index.ts
@@ -1,8 +1,2 @@
 export {ActiveDraggableContext, DndContext} from './DndContext';
-export type {
-  CancelDrop,
-  DragStartEvent,
-  DragMoveEvent,
-  DragOverEvent,
-  DragEndEvent,
-} from './DndContext';
+export type {CancelDrop} from './DndContext';

--- a/packages/core/src/components/index.ts
+++ b/packages/core/src/components/index.ts
@@ -1,12 +1,6 @@
 export {defaultAnnouncements} from './Accessibility';
 export type {Announcements, ScreenReaderInstructions} from './Accessibility';
 export {DndContext} from './DndContext';
-export type {
-  CancelDrop,
-  DragEndEvent,
-  DragOverEvent,
-  DragMoveEvent,
-  DragStartEvent,
-} from './DndContext';
+export type {CancelDrop} from './DndContext';
 export {DragOverlay, defaultDropAnimation} from './DragOverlay';
 export type {DropAnimation, Props as DragOverlayProps} from './DragOverlay';

--- a/packages/core/src/hooks/index.ts
+++ b/packages/core/src/hooks/index.ts
@@ -1,3 +1,5 @@
+export {useDndMonitor} from './monitor';
+export type {DndMonitorArguments} from './monitor';
 export {useDraggable} from './useDraggable';
 export type {
   DraggableSyntheticListeners,

--- a/packages/core/src/hooks/monitor/index.ts
+++ b/packages/core/src/hooks/monitor/index.ts
@@ -1,0 +1,5 @@
+export {DndMonitorContext, useDndMonitor} from './useDndMonitor';
+export type {
+  Arguments as DndMonitorArguments,
+  DndMonitorState,
+} from './useDndMonitor';

--- a/packages/core/src/hooks/monitor/useDndMonitor.ts
+++ b/packages/core/src/hooks/monitor/useDndMonitor.ts
@@ -1,0 +1,78 @@
+import {createContext, useContext, useEffect, useRef} from 'react';
+
+import {Action} from '../../store';
+import type {
+  DragStartEvent,
+  DragCancelEvent,
+  DragEndEvent,
+  DragMoveEvent,
+  DragOverEvent,
+} from '../../types';
+
+export interface Arguments {
+  onDragStart?(event: DragStartEvent): void;
+  onDragMove?(event: DragMoveEvent): void;
+  onDragOver?(event: DragOverEvent): void;
+  onDragEnd?(event: DragEndEvent): void;
+  onDragCancel?(event: DragCancelEvent): void;
+}
+
+export interface DndMonitorState {
+  type: Action | null;
+  event:
+    | null
+    | DragStartEvent
+    | DragMoveEvent
+    | DragOverEvent
+    | DragEndEvent
+    | DragCancelEvent;
+}
+
+export const DndMonitorContext = createContext<DndMonitorState>({
+  type: null,
+  event: null,
+});
+
+export function useDndMonitor({
+  onDragStart,
+  onDragMove,
+  onDragOver,
+  onDragEnd,
+  onDragCancel,
+}: Arguments) {
+  const monitorState = useContext(DndMonitorContext);
+  const previousMonitorState = useRef(monitorState);
+
+  useEffect(() => {
+    if (monitorState !== previousMonitorState.current) {
+      const {type, event} = monitorState;
+
+      switch (type) {
+        case Action.DragStart:
+          onDragStart?.(event as DragStartEvent);
+          break;
+        case Action.DragMove:
+          onDragMove?.(event as DragMoveEvent);
+          break;
+        case Action.DragOver:
+          onDragOver?.(event as DragOverEvent);
+          break;
+        case Action.DragCancel:
+          onDragCancel?.(event as DragCancelEvent);
+          break;
+        case Action.DragEnd:
+          onDragEnd?.(event as DragEndEvent);
+          break;
+      }
+
+      previousMonitorState.current = monitorState;
+    }
+  }, [
+    monitorState,
+    onDragStart,
+    onDragMove,
+    onDragOver,
+    onDragEnd,
+    onDragCancel,
+  ]);
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -7,10 +7,6 @@ export {
 export type {
   Announcements,
   CancelDrop,
-  DragEndEvent,
-  DragMoveEvent,
-  DragOverEvent,
-  DragStartEvent,
   DropAnimation,
   ScreenReaderInstructions,
 } from './components';
@@ -22,10 +18,12 @@ export {
   TraversalOrder,
   useDraggable,
   useDndContext,
+  useDndMonitor,
   useDroppable,
 } from './hooks';
 export type {
   AutoScrollOptions,
+  DndMonitorArguments,
   DraggableSyntheticListeners,
   LayoutMeasuring,
   UseDndContextReturnValue,
@@ -73,6 +71,10 @@ export type {DndContextDescriptor} from './store';
 
 export type {
   DistanceMeasurement,
+  DragEndEvent,
+  DragMoveEvent,
+  DragOverEvent,
+  DragStartEvent,
   LayoutRect,
   RectEntry,
   Translate,

--- a/packages/core/src/sensors/types.ts
+++ b/packages/core/src/sensors/types.ts
@@ -3,6 +3,7 @@ import type {DraggableNode, DroppableContainers, LayoutRectMap} from '../store';
 import type {
   Coordinates,
   SyntheticEventName,
+  Translate,
   UniqueIdentifier,
   ViewRect,
 } from '../types';
@@ -22,6 +23,7 @@ export type SensorContext = {
     id: string;
   } | null;
   scrollableAncestors: Element[];
+  scrollAdjustedTransalte: Translate | null;
   translatedRect: ViewRect | null;
 };
 

--- a/packages/core/src/store/actions.ts
+++ b/packages/core/src/store/actions.ts
@@ -6,6 +6,7 @@ export enum Action {
   DragMove = 'dragMove',
   DragEnd = 'dragEnd',
   DragCancel = 'dragCancel',
+  DragOver = 'dragOver',
   RegisterDroppable = 'registerDroppable',
   SetDroppableDisabled = 'setDroppableDisabled',
   UnregisterDroppable = 'unregisterDroppable',

--- a/packages/core/src/store/reducer.ts
+++ b/packages/core/src/store/reducer.ts
@@ -7,7 +7,6 @@ export function getInitialState(): State {
     draggable: {
       active: null,
       initialCoordinates: {x: 0, y: 0},
-      lastEvent: null,
       nodes: {},
       translate: {x: 0, y: 0},
     },
@@ -26,7 +25,6 @@ export function reducer(state: State, action: Actions): State {
           ...state.draggable,
           initialCoordinates: action.initialCoordinates,
           active: action.active,
-          lastEvent: Action.DragStart,
         },
       };
     case Action.DragMove:
@@ -53,7 +51,6 @@ export function reducer(state: State, action: Actions): State {
           active: null,
           initialCoordinates: {x: 0, y: 0},
           translate: {x: 0, y: 0},
-          lastEvent: action.type,
         },
       };
 

--- a/packages/core/src/store/types.ts
+++ b/packages/core/src/store/types.ts
@@ -8,7 +8,7 @@ import type {
   UniqueIdentifier,
 } from '../types';
 import type {SyntheticListeners} from '../hooks/utilities';
-import type {Action, Actions} from './actions';
+import type {Actions} from './actions';
 
 export interface DraggableElement {
   node: DraggableNode;
@@ -49,7 +49,6 @@ export interface State {
   draggable: {
     active: UniqueIdentifier | null;
     initialCoordinates: Coordinates;
-    lastEvent: Action.DragStart | Action.DragEnd | Action.DragCancel | null;
     nodes: DraggableNodes;
     translate: Coordinates;
   };

--- a/packages/core/src/types/events.ts
+++ b/packages/core/src/types/events.ts
@@ -1,0 +1,28 @@
+import type {LayoutRect, Translate} from './coordinates';
+import type {Active, UniqueIdentifier} from './other';
+
+interface DragEvent {
+  active: Active & {
+    rect: {
+      initial: LayoutRect;
+      translated: LayoutRect;
+    };
+  };
+  delta: Translate;
+  over: {
+    id: UniqueIdentifier;
+    rect: LayoutRect;
+  } | null;
+}
+
+export interface DragStartEvent {
+  active: Active;
+}
+
+export interface DragMoveEvent extends DragEvent {}
+
+export interface DragOverEvent extends DragMoveEvent {}
+
+export interface DragEndEvent extends DragEvent {}
+
+export interface DragCancelEvent extends DragEndEvent {}

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -9,5 +9,12 @@ export type {
   ScrollCoordinates,
 } from './coordinates';
 export {Direction} from './direction';
+export type {
+  DragStartEvent,
+  DragCancelEvent,
+  DragEndEvent,
+  DragMoveEvent,
+  DragOverEvent,
+} from './events';
+export type {Active, UniqueIdentifier} from './other';
 export type {SyntheticEventName} from './react';
-export type {UniqueIdentifier} from './other';

--- a/packages/core/src/types/other.ts
+++ b/packages/core/src/types/other.ts
@@ -1,1 +1,5 @@
+export interface Active {
+  id: UniqueIdentifier;
+}
+
 export type UniqueIdentifier = string;

--- a/stories/2 - Presets/Sortable/MultipleContainers.tsx
+++ b/stories/2 - Presets/Sortable/MultipleContainers.tsx
@@ -186,7 +186,7 @@ export function MultipleContainers({
         setActiveId(active.id);
         setClonedItems(items);
       }}
-      onDragOver={({active, over, draggingRect}) => {
+      onDragOver={({active, over}) => {
         const overId = over?.id;
 
         if (!overId) {
@@ -215,7 +215,8 @@ export function MultipleContainers({
               const isBelowLastItem =
                 over &&
                 overIndex === overItems.length - 1 &&
-                draggingRect.offsetTop > over.rect.offsetTop + over.rect.height;
+                active.rect.translated.offsetTop >
+                  over.rect.offsetTop + over.rect.height;
 
               const modifier = isBelowLastItem ? 1 : 0;
 


### PR DESCRIPTION
This PR introduces the `useDndMonitor` hook. The `useDndMonitor` hook can be used within components wrapped in a `DndContext` provider to monitor the different drag and drop events that happen for that `DndContext`.

Example usage:

```tsx
import {DndContext, useDndMonitor} from '@dnd-kit/core';

function App() {
  return (
    <DndContext>
      <Component />
    </DndContext>
  );
}

function Component() {
  useDndMonitor({
    onDragStart(event) {},
    onDragMove(event) {},
    onDragOver(event) {},
    onDragEnd(event) {},
    onDragCancel(event) {},
  })
}
```