### PR TITLE
Normalize and expose data for draggable and droppable nodes

### DIFF
--- a/.changeset/expose-data-ref.md
+++ b/.changeset/expose-data-ref.md
@@ -1,0 +1,46 @@
+---
+'@dnd-kit/core': minor
+'@dnd-kit/sortable': minor
+---
+
+The `data` argument for `useDraggable` and `useDroppable` is now exposed in event handlers and on the `active` and `over` objects.
+
+**Example usage:**
+
+```tsx
+import {DndContext, useDraggable, useDroppable} from '@dnd-kit/core';
+
+function Draggable() {
+  const {attributes, listeners, setNodeRef, transform} = useDraggable({
+    id: 'draggable',
+    data: {
+      type: 'type1',
+    },
+  });
+
+  /* ... */
+}
+
+function Droppable() {
+  const {setNodeRef} = useDroppable({
+    id: 'droppable',
+    data: {
+      accepts: ['type1', 'type2'],
+    },
+  });
+
+  /* ... */
+}
+
+function App() {
+  return (
+    <DndContext
+      onDragEnd={({active, over}) => {
+        if (over?.data.current.accepts.includes(active.data.current.type)) {
+          // do stuff
+        }
+      }}
+    />
+  );
+}
+```

--- a/packages/core/src/components/DragOverlay/DragOverlay.tsx
+++ b/packages/core/src/components/DragOverlay/DragOverlay.tsx
@@ -53,6 +53,7 @@ export const DragOverlay = React.memo(
       containerNodeRect,
       draggableNodes,
       activatorEvent,
+      over,
       overlayNode,
       scrollableAncestors,
       scrollableAncestorRects,
@@ -60,13 +61,15 @@ export const DragOverlay = React.memo(
     } = useDndContext();
     const transform = useContext(ActiveDraggableContext);
     const modifiedTransform = applyModifiers(modifiers, {
-      transform,
+      active,
       activeNodeRect: activeNodeClientRect,
-      overlayNodeRect: overlayNode.rect,
       draggingNodeRect: overlayNode.rect,
       containerNodeRect,
+      over,
+      overlayNodeRect: overlayNode.rect,
       scrollableAncestors,
       scrollableAncestorRects,
+      transform,
       windowRect,
     });
     const derivedTransform = useDerivedTransform(
@@ -119,11 +122,11 @@ export const DragOverlay = React.memo(
     const derivedAttributes = attributes ?? attributesSnapshot.current;
     const {children: finalChildren, transform: _, ...otherAttributes} =
       derivedAttributes ?? {};
-    const prevActive = useRef(active);
+    const prevActiveId = useRef(active?.id ?? null);
     const dropAnimationComplete = useDropAnimation({
-      animate: Boolean(dropAnimation && prevActive.current && !active),
+      animate: Boolean(dropAnimation && prevActiveId.current && !active),
       adjustScale,
-      activeId: prevActive.current,
+      activeId: prevActiveId.current,
       draggableNodes,
       duration: dropAnimation?.duration,
       easing: dropAnimation?.easing,
@@ -136,8 +139,8 @@ export const DragOverlay = React.memo(
     );
 
     useEffect(() => {
-      if (prevActive.current !== active) {
-        prevActive.current = active;
+      if (active?.id !== prevActiveId.current) {
+        prevActiveId.current = active?.id ?? null;
       }
 
       if (active && attributesSnapshot.current !== attributes) {

--- a/packages/core/src/components/DragOverlay/hooks/useDropAnimation.ts
+++ b/packages/core/src/components/DragOverlay/hooks/useDropAnimation.ts
@@ -46,7 +46,7 @@ export function useDropAnimation({
     }
 
     requestAnimationFrame(() => {
-      const finalNode = draggableNodes[activeId]?.current;
+      const finalNode = draggableNodes[activeId]?.node.current;
 
       if (transform && node && finalNode && finalNode.parentNode !== null) {
         const fromNode = node.children.length > 1 ? node : node.children[0];

--- a/packages/core/src/hooks/useDraggable.ts
+++ b/packages/core/src/hooks/useDraggable.ts
@@ -1,12 +1,17 @@
 import {createContext, useContext, useEffect, useMemo} from 'react';
 import {Transform, useNodeRef} from '@dnd-kit/utilities';
 
-import {Context} from '../store';
+import {Context, Data} from '../store';
 import {ActiveDraggableContext} from '../components/DndContext';
-import {useSyntheticListeners, SyntheticListenerMap} from './utilities';
+import {
+  useData,
+  useSyntheticListeners,
+  SyntheticListenerMap,
+} from './utilities';
 
 export interface UseDraggableArguments {
   id: string;
+  data?: Data;
   disabled?: boolean;
   attributes?: {
     role?: string;
@@ -23,6 +28,7 @@ const defaultRole = 'button';
 
 export function useDraggable({
   id,
+  data,
   disabled = false,
   attributes,
 }: UseDraggableArguments) {
@@ -38,16 +44,17 @@ export function useDraggable({
   } = useContext(Context);
   const {role = defaultRole, roleDescription = 'draggable', tabIndex = 0} =
     attributes ?? {};
-  const isDragging = Boolean(active === id);
+  const isDragging = active?.id === id;
   const transform: Transform | null = useContext(
     isDragging ? ActiveDraggableContext : NullContext
   );
   const [node, setNodeRef] = useNodeRef();
   const listeners = useSyntheticListeners(activators, id);
+  const dataRef = useData(data);
 
   useEffect(
     () => {
-      draggableNodes[id] = node;
+      draggableNodes[id] = {node, data: dataRef};
 
       return () => {
         delete draggableNodes[id];

--- a/packages/core/src/hooks/useDroppable.ts
+++ b/packages/core/src/hooks/useDroppable.ts
@@ -3,6 +3,7 @@ import {useIsomorphicLayoutEffect, useNodeRef} from '@dnd-kit/utilities';
 
 import {Context, Action, Data} from '../store';
 import type {LayoutRect} from '../types';
+import {useData} from './utilities';
 
 export interface UseDroppableArguments {
   id: string;
@@ -10,23 +11,15 @@ export interface UseDroppableArguments {
   data?: Data;
 }
 
-const defaultData: Data = {};
-
 export function useDroppable({
-  data = defaultData,
+  data,
   disabled = false,
   id,
 }: UseDroppableArguments) {
-  const {dispatch, over} = useContext(Context);
+  const {active, dispatch, over} = useContext(Context);
   const rect = useRef<LayoutRect | null>(null);
   const [nodeRef, setNodeRef] = useNodeRef();
-  const dataRef = useRef(data);
-
-  useIsomorphicLayoutEffect(() => {
-    if (dataRef.current !== data) {
-      dataRef.current = data;
-    }
-  }, [data]);
+  const dataRef = useData(data);
 
   useIsomorphicLayoutEffect(
     () => {
@@ -64,6 +57,7 @@ export function useDroppable({
   );
 
   return {
+    active,
     rect,
     isOver: over?.id === id,
     node: nodeRef,

--- a/packages/core/src/hooks/utilities/index.ts
+++ b/packages/core/src/hooks/utilities/index.ts
@@ -6,6 +6,7 @@ export {
 export type {Options as AutoScrollOptions} from './useAutoScroller';
 export {useCachedNode} from './useCachedNode';
 export {useCombineActivators} from './useCombineActivators';
+export {useData} from './useData';
 export {
   useLayoutMeasuring,
   LayoutMeasuringFrequency,

--- a/packages/core/src/hooks/utilities/useCachedNode.ts
+++ b/packages/core/src/hooks/utilities/useCachedNode.ts
@@ -1,22 +1,26 @@
 import {useLazyMemo} from '@dnd-kit/utilities';
-import type {DraggableNode} from '../../store';
+
+import type {DraggableNode, DraggableNodes} from '../../store';
 import type {UniqueIdentifier} from '../../types';
 
 export function useCachedNode(
-  draggableNode: DraggableNode | null,
-  active: UniqueIdentifier | null
-): DraggableNode['current'] {
+  draggableNodes: DraggableNodes,
+  id: UniqueIdentifier | null
+): DraggableNode['node']['current'] {
+  const draggableNode = id !== null ? draggableNodes[id] : undefined;
+  const node = draggableNode ? draggableNode.node.current : null;
+
   return useLazyMemo(
     (cachedNode) => {
-      if (active === null) {
+      if (id === null) {
         return null;
       }
 
       // In some cases, the draggable node can unmount while dragging
       // This is the case for virtualized lists. In those situations,
       // we fall back to the last known value for that node.
-      return draggableNode?.current ?? cachedNode ?? null;
+      return node ?? cachedNode ?? null;
     },
-    [draggableNode, active]
+    [node, id]
   );
 }

--- a/packages/core/src/hooks/utilities/useData.ts
+++ b/packages/core/src/hooks/utilities/useData.ts
@@ -1,0 +1,16 @@
+import {useRef} from 'react';
+import {useIsomorphicLayoutEffect} from '@dnd-kit/utilities';
+
+import type {Data} from '../../store';
+
+export function useData(data: Data | undefined) {
+  const dataRef = useRef(data);
+
+  useIsomorphicLayoutEffect(() => {
+    if (dataRef.current !== data) {
+      dataRef.current = data;
+    }
+  }, [data]);
+
+  return dataRef;
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -67,7 +67,7 @@ export type {
   TouchSensorOptions,
 } from './sensors';
 
-export type {DndContextDescriptor} from './store';
+export type {Active, DndContextDescriptor, Over} from './store';
 
 export type {
   DistanceMeasurement,

--- a/packages/core/src/modifiers/types.ts
+++ b/packages/core/src/modifiers/types.ts
@@ -1,14 +1,17 @@
 import type {Transform} from '@dnd-kit/utilities';
+import type {Active, Over} from '../store';
 import type {ClientRect, ViewRect} from '../types';
 
 export type Modifier = (args: {
-  transform: Transform;
+  active: Active | null;
   activeNodeRect: ViewRect | null;
   draggingNodeRect: ViewRect | null;
   containerNodeRect: ViewRect | null;
+  over: Over | null;
   overlayNodeRect: ViewRect | null;
   scrollableAncestors: Element[];
   scrollableAncestorRects: ViewRect[];
+  transform: Transform;
   windowRect: ClientRect | null;
 }) => Transform;
 

--- a/packages/core/src/sensors/keyboard/KeyboardSensor.ts
+++ b/packages/core/src/sensors/keyboard/KeyboardSensor.ts
@@ -62,11 +62,11 @@ export class KeyboardSensor implements SensorInstance {
   private handleStart() {
     const {activeNode, onStart} = this.props;
 
-    if (!activeNode.current) {
+    if (!activeNode.node.current) {
       throw new Error('Active draggable node is undefined');
     }
 
-    const activeNodeRect = getBoundingClientRect(activeNode.current);
+    const activeNodeRect = getBoundingClientRect(activeNode.node.current);
     const coordinates = {
       x: activeNodeRect.left,
       y: activeNodeRect.top,

--- a/packages/core/src/sensors/types.ts
+++ b/packages/core/src/sensors/types.ts
@@ -1,7 +1,15 @@
 import type {MutableRefObject} from 'react';
-import type {DraggableNode, DroppableContainers, LayoutRectMap} from '../store';
+import type {
+  Active,
+  Over,
+  DraggableNode,
+  DraggableNodes,
+  DroppableContainers,
+  LayoutRectMap,
+} from '../store';
 import type {
   Coordinates,
+  LayoutRect,
   SyntheticEventName,
   Translate,
   UniqueIdentifier,
@@ -15,13 +23,14 @@ export enum Response {
 }
 
 export type SensorContext = {
+  active: Active | null;
   activeNode: HTMLElement | null;
   collisionRect: ViewRect | null;
+  draggableNodes: DraggableNodes;
+  draggingNodeRect: LayoutRect | null;
   droppableRects: LayoutRectMap;
   droppableContainers: DroppableContainers;
-  over: {
-    id: string;
-  } | null;
+  over: Over | null;
   scrollableAncestors: Element[];
   scrollAdjustedTransalte: Translate | null;
   translatedRect: ViewRect | null;

--- a/packages/core/src/store/index.ts
+++ b/packages/core/src/store/index.ts
@@ -2,7 +2,9 @@ export {Action} from './actions';
 export {Context} from './context';
 export {reducer, getInitialState} from './reducer';
 export type {
+  Active,
   Data,
+  DataRef,
   DraggableElement,
   DraggableNode,
   DraggableNodes,
@@ -10,5 +12,6 @@ export type {
   DroppableContainers,
   DndContextDescriptor,
   LayoutRectMap,
+  Over,
   State,
 } from './types';

--- a/packages/core/src/store/types.ts
+++ b/packages/core/src/store/types.ts
@@ -20,15 +20,36 @@ export interface DraggableElement {
 
 export type Data = Record<string, any>;
 
+export type DataRef = MutableRefObject<Data | undefined>;
+
 export interface DroppableContainer {
   id: UniqueIdentifier;
   node: MutableRefObject<HTMLElement | null>;
   rect: MutableRefObject<LayoutRect | null>;
   disabled: boolean;
-  data: MutableRefObject<Data>;
+  data: DataRef;
 }
 
-export type DraggableNode = MutableRefObject<HTMLElement | null>;
+export interface Active {
+  id: UniqueIdentifier;
+  data: DataRef;
+  rect: MutableRefObject<{
+    initial: LayoutRect | null;
+    translated: LayoutRect | null;
+  }>;
+}
+
+export interface Over {
+  id: UniqueIdentifier;
+  rect: LayoutRect;
+  disabled: boolean;
+  data: DataRef;
+}
+
+export type DraggableNode = {
+  node: MutableRefObject<HTMLElement | null>;
+  data: DataRef;
+};
 
 export type DraggableNodes = Record<
   UniqueIdentifier,
@@ -58,7 +79,7 @@ export interface DndContextDescriptor {
   dispatch: React.Dispatch<Actions>;
   activators: SyntheticListeners;
   activatorEvent: Event | null;
-  active: UniqueIdentifier | null;
+  active: Active | null;
   activeNode: HTMLElement | null;
   activeNodeRect: ViewRect | null;
   activeNodeClientRect: ClientRect | null;
@@ -69,10 +90,7 @@ export interface DndContextDescriptor {
   draggableNodes: DraggableNodes;
   droppableContainers: DroppableContainers;
   droppableRects: LayoutRectMap;
-  over: {
-    id: UniqueIdentifier;
-    rect: LayoutRect;
-  } | null;
+  over: Over | null;
   overlayNode: {
     nodeRef: MutableRefObject<HTMLElement | null>;
     rect: ViewRect | null;

--- a/packages/core/src/types/events.ts
+++ b/packages/core/src/types/events.ts
@@ -1,23 +1,13 @@
-import type {LayoutRect, Translate} from './coordinates';
-import type {Active, UniqueIdentifier} from './other';
+import type {Active, Over} from '../store';
+import type {Translate} from './coordinates';
 
 interface DragEvent {
-  active: Active & {
-    rect: {
-      initial: LayoutRect;
-      translated: LayoutRect;
-    };
-  };
+  active: Active;
   delta: Translate;
-  over: {
-    id: UniqueIdentifier;
-    rect: LayoutRect;
-  } | null;
+  over: Over | null;
 }
 
-export interface DragStartEvent {
-  active: Active;
-}
+export interface DragStartEvent extends Pick<DragEvent, 'active'> {}
 
 export interface DragMoveEvent extends DragEvent {}
 

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -16,5 +16,5 @@ export type {
   DragMoveEvent,
   DragOverEvent,
 } from './events';
-export type {Active, UniqueIdentifier} from './other';
+export type {UniqueIdentifier} from './other';
 export type {SyntheticEventName} from './react';

--- a/packages/core/src/types/other.ts
+++ b/packages/core/src/types/other.ts
@@ -1,5 +1,1 @@
-export interface Active {
-  id: UniqueIdentifier;
-}
-
 export type UniqueIdentifier = string;

--- a/packages/modifiers/test/modifiers.test.tsx
+++ b/packages/modifiers/test/modifiers.test.tsx
@@ -21,6 +21,8 @@ describe('@dnd-kit/modifiers', () => {
     scaleY: 1,
   };
   const defaultArguments: FirstArgument<Modifier> = {
+    active: null,
+    over: null,
     transform: defaultTransform,
     activeNodeRect: defaultRect,
     containerNodeRect: defaultRect,

--- a/packages/sortable/src/components/SortableContext.tsx
+++ b/packages/sortable/src/components/SortableContext.tsx
@@ -55,7 +55,7 @@ export function SortableContext({
   } = useDndContext();
   const containerId = useUniqueId(ID_PREFIX, id);
   const useDragOverlay = Boolean(overlayNode.rect !== null);
-  const activeIndex = active ? items.indexOf(active) : -1;
+  const activeIndex = active ? items.indexOf(active.id) : -1;
   const isSorting = activeIndex !== -1;
   const wasSorting = useRef(isSorting);
   const overIndex = over ? items.indexOf(over.id) : -1;

--- a/packages/sortable/src/hooks/types.ts
+++ b/packages/sortable/src/hooks/types.ts
@@ -1,10 +1,10 @@
-import type {UniqueIdentifier} from '@dnd-kit/core';
+import type {Active, UniqueIdentifier} from '@dnd-kit/core';
 import type {Transition} from '@dnd-kit/utilities';
 
 export type SortableTransition = Pick<Transition, 'easing' | 'duration'>;
 
 export type AnimateLayoutChanges = (args: {
-  active: UniqueIdentifier | null;
+  active: Active | null;
   isDragging: boolean;
   isSorting: boolean;
   id: UniqueIdentifier;

--- a/stories/2 - Presets/Sortable/MultipleContainers.tsx
+++ b/stories/2 - Presets/Sortable/MultipleContainers.tsx
@@ -215,7 +215,8 @@ export function MultipleContainers({
               const isBelowLastItem =
                 over &&
                 overIndex === overItems.length - 1 &&
-                active.rect.translated.offsetTop >
+                active.rect.current.translated &&
+                active.rect.current.translated.offsetTop >
                   over.rect.offsetTop + over.rect.height;
 
               const modifier = isBelowLastItem ? 1 : 0;


### PR DESCRIPTION
The `data` argument for `useDraggable` and `useDroppable` is now exposed in event handlers and on the `active` and `over` objects.

**Example usage:**

```tsx
import {DndContext, useDraggable, useDroppable} from '@dnd-kit/core';

function Draggable() {
  const { attributes, listeners, setNodeRef, transform } = useDraggable({
    id: 'draggable',
    data: {
      type: 'type1',
    },
  });

  /* ... */
};

function Droppable() {
  const { setNodeRef } = useDroppable({
    id: 'droppable',
    data: {
      accepts: ['type1', 'type2'],
    },
  });
  
  /* ... */
};

function App() {
  return (
    <DndContext onDragEnd={({active, over}) => {
      if (over?.data.current.accepts.includes(active.data.current.type)) {
        // do stuff
      }
    }} />
  );
}
```