### PR TITLE
Pass data to `useDraggable` and `useDroppable` in `useSortable`

### DIFF
--- a/.changeset/use-sortable-data.md
+++ b/.changeset/use-sortable-data.md
@@ -1,0 +1,7 @@
+---
+"@dnd-kit/sortable": patch
+---
+
+Ensure that consumer defined data passed to `useSortable` is passed down to both `useDraggable` and `useDroppable`. 
+
+The `data` object that is passed to `useDraggable` and `useDroppable` within `useSortable` also contains the `sortable` property, which holds a reference to the index of the item, along with the `containerId` and the `items` of its parent `SortableContext`.

--- a/packages/sortable/src/hooks/useSortable.ts
+++ b/packages/sortable/src/hooks/useSortable.ts
@@ -25,6 +25,7 @@ export function useSortable({
   animateLayoutChanges = defaultAnimateLayoutChanges,
   attributes: userDefinedAttributes,
   disabled,
+  data: customData,
   id,
   strategy: localStrategy,
   transition = defaultTransition,
@@ -40,6 +41,15 @@ export function useSortable({
     strategy: globalStrategy,
     wasSorting,
   } = useContext(Context);
+  const index = items.indexOf(id);
+  const data = useMemo(
+    () => ({sortable: {containerId, index, items}, ...customData}),
+    [containerId, customData, index, items]
+  );
+  const {rect, node, setNodeRef: setDroppableNodeRef} = useDroppable({
+    id,
+    data,
+  });
   const {
     active,
     activeNodeRect,
@@ -52,21 +62,12 @@ export function useSortable({
     transform,
   } = useDraggable({
     id,
+    data,
     attributes: {
       ...defaultAttributes,
       ...userDefinedAttributes,
     },
     disabled,
-  });
-  const index = items.indexOf(id);
-  const data = useMemo(() => ({containerId, index, items}), [
-    containerId,
-    index,
-    items,
-  ]);
-  const {rect, node, setNodeRef: setDroppableNodeRef} = useDroppable({
-    id,
-    data,
   });
   const setNodeRef = useCombinedRefs(setDroppableNodeRef, setDraggableNodeRef);
   const isSorting = Boolean(active);


### PR DESCRIPTION
This PR follows-up on #207 and passes the consumer defined `data` passed to `useSortable` to both `useDraggable` and `useDroppable`.