### PR TITLE
Fix regression with activation constraints

### DIFF
--- a/.changeset/activation-constraint-regression.md
+++ b/.changeset/activation-constraint-regression.md
@@ -1,0 +1,5 @@
+---
+"@dnd-kit/core": patch
+---
+
+Fixes a regression introduced with `@dnd-kit/core@3.0.0` that was causeing sensors to stop working after a drag operation where activation constraints were not met.

--- a/cypress/integration/draggable_spec.ts
+++ b/cypress/integration/draggable_spec.ts
@@ -169,6 +169,44 @@ describe('Draggable', () => {
         });
     });
 
+    it('Activates after unsuccessful first drag attempt once the press delay duration is met', () => {
+      const deltaX = 100;
+      const deltaY = 150;
+      const delay = 250;
+
+      cy.visitStory('core-draggable-hooks-usedraggable--press-delay')
+        .findFirstDraggableItem()
+        .mouseMoveBy(deltaX, deltaY, {delay: delay / 2})
+        .then(([subject, {delta}]) => {
+          expect(delta.x).eq(0);
+          expect(delta.y).eq(0);
+
+          return subject;
+        })
+        .wait(delay)
+        .mouseMoveBy(deltaX, deltaY, {delay})
+        .then(([subject, {delta}]) => {
+          expect(delta.x).eq(deltaX);
+          expect(delta.y).eq(deltaY);
+
+          return subject;
+        })
+        .mouseMoveBy(deltaX, deltaY, {delay})
+        .then(([subject, {delta}]) => {
+          expect(delta.x).eq(deltaX);
+          expect(delta.y).eq(deltaY);
+
+          return subject;
+        })
+        .mouseMoveBy(-deltaX * 2, -deltaY * 2, {delay})
+        .then(([subject, {delta}]) => {
+          expect(delta.x).eq(-deltaX * 2);
+          expect(delta.y).eq(-deltaY * 2);
+
+          return subject;
+        });
+    });
+
     it('Does not activate if the mouse is moved before the press delay duration', () => {
       const deltaX = 100;
       const deltaY = 150;
@@ -268,6 +306,28 @@ describe('Draggable', () => {
         .then(([subject, {delta}]) => {
           expect(delta.x).eq(0);
           expect(delta.y).eq(0);
+
+          return subject;
+        });
+    });
+
+    it('Activates after unsuccessful first drag attempt once the mouse is moved more than the minimum distance', () => {
+      const deltaX = 100;
+      const deltaY = 150;
+
+      cy.visitStory('core-draggable-hooks-usedraggable--minimum-distance')
+        .findFirstDraggableItem()
+        .mouseMoveBy(5, 5)
+        .then(([subject, {delta}]) => {
+          expect(delta.x).eq(0);
+          expect(delta.y).eq(0);
+
+          return subject;
+        })
+        .mouseMoveBy(deltaX, deltaY)
+        .then(([subject, {delta}]) => {
+          expect(delta.x).eq(deltaX);
+          expect(delta.y).eq(deltaY);
 
           return subject;
         });


### PR DESCRIPTION
This PR fixes a regression introduced with `@dnd-kit/core@3.0.0` that causes sensors to stop working after activation constraints are not met.

Also going to add Cypress tests before merging this PR to prevent these types of regression from slipping by in the future