### PR TITLE
Handle overlay overflow as a scrollable element

### DIFF
--- a/.changeset/dry-seahorses-float.md
+++ b/.changeset/dry-seahorses-float.md
@@ -1,0 +1,5 @@
+---
+'@dnd-kit/core': patch
+---
+
+Update regex used in isScrollable, to consider element with overflow: overlay as a scrollable element.

--- a/packages/core/src/utilities/scroll/isScrollable.ts
+++ b/packages/core/src/utilities/scroll/isScrollable.ts
@@ -1,6 +1,6 @@
 export function isScrollable(node: HTMLElement): boolean {
   const computedStyle = window.getComputedStyle(node);
-  const overflowRegex = /(auto|scroll)/;
+  const overflowRegex = /(auto|scroll|overlay)/;
   const properties = ['overflow', 'overflowX', 'overflowY'];
 
   return (


### PR DESCRIPTION
Update regex used in `isScrollable`, to consider element with `overflow: overlay` as a scrollable element. 