### PR TITLE
Fix style prop of DragOverlay to work

### DIFF
--- a/.changeset/drag-overlay-style.md
+++ b/.changeset/drag-overlay-style.md
@@ -2,4 +2,4 @@
 '@dnd-kit/core': patch
 ---
 
-Fixes the style prop of DragOverlay to work
+`DragOverlay` component now passes down `style` prop to the wrapper element it renders.

--- a/.changeset/drag-overlay-style.md
+++ b/.changeset/drag-overlay-style.md
@@ -1,0 +1,5 @@
+---
+'@dnd-kit/core': patch
+---
+
+Fixes the style prop of DragOverlay to work

--- a/packages/core/src/components/DragOverlay/DragOverlay.tsx
+++ b/packages/core/src/components/DragOverlay/DragOverlay.tsx
@@ -40,7 +40,7 @@ export const DragOverlay = React.memo(
     adjustScale = false,
     children,
     dropAnimation = defaultDropAnimation,
-    style: propStyle,
+    style: styleProp,
     transition = defaultTransition,
     modifiers,
     wrapperElement = 'div',
@@ -109,7 +109,7 @@ export const DragOverlay = React.memo(
             : typeof transition === 'function'
             ? transition(activatorEvent)
             : transition,
-          ...propStyle,
+          ...styleProp,
         }
       : undefined;
     const attributes = isDragging

--- a/packages/core/src/components/DragOverlay/DragOverlay.tsx
+++ b/packages/core/src/components/DragOverlay/DragOverlay.tsx
@@ -40,6 +40,7 @@ export const DragOverlay = React.memo(
     adjustScale = false,
     children,
     dropAnimation = defaultDropAnimation,
+    style: propStyle,
     transition = defaultTransition,
     modifiers,
     wrapperElement = 'div',
@@ -88,6 +89,7 @@ export const DragOverlay = React.memo(
         };
     const style: React.CSSProperties | undefined = activeNodeRect
       ? {
+          ...propStyle,
           position: 'fixed',
           width: activeNodeRect.width,
           height: activeNodeRect.height,

--- a/packages/core/src/components/DragOverlay/DragOverlay.tsx
+++ b/packages/core/src/components/DragOverlay/DragOverlay.tsx
@@ -89,7 +89,6 @@ export const DragOverlay = React.memo(
         };
     const style: React.CSSProperties | undefined = activeNodeRect
       ? {
-          ...propStyle,
           position: 'fixed',
           width: activeNodeRect.width,
           height: activeNodeRect.height,
@@ -110,6 +109,7 @@ export const DragOverlay = React.memo(
             : typeof transition === 'function'
             ? transition(activatorEvent)
             : transition,
+          ...propStyle,
         }
       : undefined;
     const attributes = isDragging


### PR DESCRIPTION
As written [here in docs](https://docs.dndkit.com/api-documentation/draggable/drag-overlay#class-name-and-inline-styles), it looks like that the style prop of DragOverlay should be passed to the wrapper element, but not passed now.