### PR TITLE
Add optional onDragMove screen reader announcements

### DIFF
--- a/.changeset/ondragmove-screenreader-announcments.md
+++ b/.changeset/ondragmove-screenreader-announcments.md
@@ -1,0 +1,5 @@
+---
+"@dnd-kit/core": minor
+---
+
+Added ability to optionally return screen reader announcements `onDragMove`.

--- a/packages/core/src/components/Accessibility/Accessibility.tsx
+++ b/packages/core/src/components/Accessibility/Accessibility.tsx
@@ -34,6 +34,11 @@ export function Accessibility({
         onDragStart({active}) {
           announce(announcements.onDragStart(active.id));
         },
+        onDragMove({active, over}) {
+          if (announcements.onDragMove) {
+            announce(announcements.onDragMove(active.id, over?.id));
+          }
+        },
         onDragOver({active, over}) {
           announce(announcements.onDragOver(active.id, over?.id));
         },

--- a/packages/core/src/components/Accessibility/types.ts
+++ b/packages/core/src/components/Accessibility/types.ts
@@ -2,6 +2,10 @@ import type {UniqueIdentifier} from '../../types';
 
 export interface Announcements {
   onDragStart(id: UniqueIdentifier): string | undefined;
+  onDragMove?(
+    id: UniqueIdentifier,
+    overId: UniqueIdentifier | undefined
+  ): string | undefined;
   onDragOver(
     id: UniqueIdentifier,
     overId: UniqueIdentifier | undefined

--- a/stories/3 - Examples/Tree/SortableTree.tsx
+++ b/stories/3 - Examples/Tree/SortableTree.tsx
@@ -151,13 +151,6 @@ export function SortableTree({
 
   const announcements: Announcements = {
     onDragStart(id) {
-      if (projected) {
-        setCurrentPosition({
-          parentId: projected.parentId,
-          overId: id,
-        });
-      }
-
       return `Picked up ${id}.`;
     },
     onDragMove(id, overId) {
@@ -167,13 +160,9 @@ export function SortableTree({
       return getMovementAnnouncement('onDragOver', id, overId);
     },
     onDragEnd(id, overId) {
-      setCurrentPosition(null);
-
       return getMovementAnnouncement('onDragEnd', id, overId);
     },
     onDragCancel(id) {
-      setCurrentPosition(null);
-
       return `Moving was cancelled. ${id} was dropped in its original position.`;
     },
   };
@@ -227,9 +216,18 @@ export function SortableTree({
     </DndContext>
   );
 
-  function handleDragStart({active: {id}}: DragStartEvent) {
-    setActiveId(id);
-    setOverId(id);
+  function handleDragStart({active: {id: activeId}}: DragStartEvent) {
+    setActiveId(activeId);
+    setOverId(activeId);
+
+    const activeItem = flattenedItems.find(({id}) => id === activeId);
+
+    if (activeItem) {
+      setCurrentPosition({
+        parentId: activeItem.parentId,
+        overId: activeId,
+      });
+    }
 
     document.body.style.setProperty('cursor', 'grabbing');
   }
@@ -271,6 +269,7 @@ export function SortableTree({
     setOverId(null);
     setActiveId(null);
     setOffsetLeft(0);
+    setCurrentPosition(null);
 
     document.body.style.setProperty('cursor', '');
   }

--- a/stories/3 - Examples/Tree/SortableTree.tsx
+++ b/stories/3 - Examples/Tree/SortableTree.tsx
@@ -1,6 +1,7 @@
 import React, {useEffect, useMemo, useRef, useState} from 'react';
 import {createPortal} from 'react-dom';
 import {
+  Announcements,
   DndContext,
   closestCenter,
   KeyboardSensor,
@@ -143,8 +144,39 @@ export function SortableTree({
     };
   }, [flattenedItems, offsetLeft]);
 
+  const announcements: Announcements = {
+    onDragStart(id) {
+      return `Picked up ${id}.`;
+    },
+    onDragMove(id, overId) {
+      if (overId) {
+        return `${id} was nested under ${overId}.`;
+      }
+
+      return;
+    },
+    onDragOver(id, overId) {
+      if (overId) {
+        return `${id} was moved over ${overId}.`;
+      }
+
+      return;
+    },
+    onDragEnd(id, overId) {
+      if (overId) {
+        return `${id} was dropped over ${overId}`;
+      }
+
+      return;
+    },
+    onDragCancel(id) {
+      return `Dragging was cancelled. ${id} was dropped.`;
+    },
+  };
+
   return (
     <DndContext
+      announcements={announcements}
       sensors={sensors}
       modifiers={indicator ? [adjustTranslate] : undefined}
       collisionDetection={closestCenter}


### PR DESCRIPTION
Sometimes you need the screen reader to announce changes that happen `onDragMove`, not `onDragOver`, such as the nesting in the `SortableTree` example.

I've made this announcement optional and left it out of the `defaultAnnouncements` since it probably won't be used very often. I've also updated the `SortableTree` example to make use of it.