### PR TITLE
Fix collision detection race conditions

### DIFF
--- a/.changeset/collision-detection-issues.md
+++ b/.changeset/collision-detection-issues.md
@@ -1,0 +1,9 @@
+---
+"@dnd-kit/core": minor
+---
+
+React updates in non-synthetic event handlers are now batched to reduce re-renders and prepare for React 18.
+
+Also fixed issues with collision detection:
+- Defer measurement of droppable node rects until second render after dragging.
+- Use DragOverlay's width and height in collision rect (if it is used)

--- a/.changeset/collision-detection-issues.md
+++ b/.changeset/collision-detection-issues.md
@@ -1,5 +1,5 @@
 ---
-"@dnd-kit/core": minor
+"@dnd-kit/core": major
 ---
 
 React updates in non-synthetic event handlers are now batched to reduce re-renders and prepare for React 18.

--- a/cypress.json
+++ b/cypress.json
@@ -2,5 +2,6 @@
   "$schema": "https://on.cypress.io/cypress.schema.json",
   "supportFile": "cypress/support/index.ts",
   "projectId": "zkn9qu",
-  "baseUrl": "http://localhost:6006/"
+  "baseUrl": "http://localhost:6006/",
+  "viewportHeight": 1000
 }

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -135,10 +135,20 @@ Cypress.Commands.add(
 
     cy.wrap(subject, {log: false})
       .focus({log: false})
-      .type(Keys.Space, {force: true, log: false})
+      .type(Keys.Space, {
+        delay: 150,
+        scrollBehavior: false,
+        force: true,
+        log: false,
+      })
       .closest('body')
-      .type(arrowKey.repeat(times), {delay: 150, force: true})
-      .type(Keys.Space, {log: false, force: true});
+      .type(arrowKey.repeat(times), {
+        scrollBehavior: false,
+        delay: 150,
+        force: true,
+      })
+      .wait(150)
+      .type(Keys.Space, {scrollBehavior: false, log: false, force: true});
   }
 );
 

--- a/packages/core/src/components/DndContext/DndContext.tsx
+++ b/packages/core/src/components/DndContext/DndContext.tsx
@@ -223,7 +223,7 @@ export const DndContext = memo(function DndContext({
     willRecomputeLayouts
   );
 
-  const draggingNodeRect = overlayNodeRect ?? activeNodeClientRect;
+  const draggingNodeRect = overlayNodeRect ?? activeNodeRect;
   const modifiedTranslate = applyModifiers(modifiers, {
     transform: {
       x: translate.x - nodeRectDelta.x,
@@ -250,9 +250,20 @@ export const DndContext = memo(function DndContext({
 
   const scrollAdjustedTranslate = add(modifiedTranslate, scrollAdjustment);
 
-  const translatedRect = draggingNodeRect
-    ? getAdjustedRect(draggingNodeRect, modifiedTranslate)
-    : null;
+  // The overlay node's position is based on the active node's position.
+  // We assume that any difference in positioning is for visual purposes only
+  // and shouldn't affect collision detection. However, the computed height of
+  // the overlay node should affect the collision rect.
+  const rect =
+    overlayNodeRect && activeNodeRect
+      ? {
+          ...activeNodeRect,
+          height: overlayNodeRect.height,
+          width: overlayNodeRect.width,
+        }
+      : activeNodeRect;
+
+  const translatedRect = rect ? getAdjustedRect(rect, modifiedTranslate) : null;
 
   const collisionRect = translatedRect
     ? getAdjustedRect(translatedRect, scrollAdjustment)

--- a/packages/core/src/components/DndContext/DndContext.tsx
+++ b/packages/core/src/components/DndContext/DndContext.tsx
@@ -60,6 +60,7 @@ import {
   getEventCoordinates,
   rectIntersection,
 } from '../../utilities';
+import {getMeasurableNode} from '../../utilities/nodes';
 import {applyModifiers, Modifiers} from '../../modifiers';
 import type {
   Active,
@@ -218,7 +219,7 @@ export const DndContext = memo(function DndContext({
 
   const [overlayNodeRef, setOverlayNodeRef] = useNodeRef();
   const overlayNodeRect = useClientRect(
-    activeId ? overlayNodeRef.current : null,
+    activeId ? getMeasurableNode(overlayNodeRef.current) : null,
     willRecomputeLayouts
   );
 
@@ -249,8 +250,8 @@ export const DndContext = memo(function DndContext({
 
   const scrollAdjustedTranslate = add(modifiedTranslate, scrollAdjustment);
 
-  const translatedRect = activeNodeRect
-    ? getAdjustedRect(activeNodeRect, modifiedTranslate)
+  const translatedRect = draggingNodeRect
+    ? getAdjustedRect(draggingNodeRect, modifiedTranslate)
     : null;
 
   const collisionRect = translatedRect
@@ -374,6 +375,7 @@ export const DndContext = memo(function DndContext({
 
           unstable_batchedUpdates(() => {
             dispatch({type});
+            setIsDragging(false);
             setActiveSensor(null);
             setActivatorEvent(null);
 
@@ -391,10 +393,6 @@ export const DndContext = memo(function DndContext({
     },
     [dispatch, draggableNodes]
   );
-
-  useEffect(() => {
-    setIsDragging(activeId !== null);
-  }, [activeId]);
 
   const bindActivatorToSensorInstantiator = useCallback(
     (
@@ -439,6 +437,12 @@ export const DndContext = memo(function DndContext({
     // eslint-disable-next-line react-hooks/exhaustive-deps
     Object.values(props)
   );
+
+  useEffect(() => {
+    if (activeId != null) {
+      setIsDragging(true);
+    }
+  }, [activeId]);
 
   useEffect(() => {
     if (!active) {

--- a/packages/core/src/components/DndContext/DndContext.tsx
+++ b/packages/core/src/components/DndContext/DndContext.tsx
@@ -143,6 +143,7 @@ export const DndContext = memo(function DndContext({
     type: null,
     event: null,
   }));
+  const [isDragging, setIsDragging] = useState(false);
   const {
     draggable: {active: activeId, nodes: draggableNodes, translate},
     droppable: {containers: droppableContainers},
@@ -174,7 +175,7 @@ export const DndContext = memo(function DndContext({
     recomputeLayouts,
     willRecomputeLayouts,
   } = useLayoutMeasuring(droppableContainers, {
-    dragging: activeId != null,
+    dragging: isDragging,
     dependencies: [translate.x, translate.y],
     config: layoutMeasuring,
   });
@@ -390,6 +391,10 @@ export const DndContext = memo(function DndContext({
     },
     [dispatch, draggableNodes]
   );
+
+  useEffect(() => {
+    setIsDragging(activeId !== null);
+  }, [activeId]);
 
   const bindActivatorToSensorInstantiator = useCallback(
     (

--- a/packages/core/src/components/DragOverlay/hooks/useDropAnimation.ts
+++ b/packages/core/src/components/DragOverlay/hooks/useDropAnimation.ts
@@ -4,6 +4,7 @@ import {CSS, Transform, useIsomorphicLayoutEffect} from '@dnd-kit/utilities';
 import type {UniqueIdentifier} from '../../../types';
 import type {DraggableNodes} from '../../../store';
 import {getViewRect} from '../../../utilities';
+import {getMeasurableNode} from '../../../utilities/nodes';
 
 export interface DropAnimation {
   duration: number;
@@ -49,7 +50,7 @@ export function useDropAnimation({
       const finalNode = draggableNodes[activeId]?.node.current;
 
       if (transform && node && finalNode && finalNode.parentNode !== null) {
-        const fromNode = node.children.length > 1 ? node : node.children[0];
+        const fromNode = getMeasurableNode(node);
 
         if (fromNode) {
           const from = fromNode.getBoundingClientRect();

--- a/packages/core/src/utilities/nodes/getMeasurableNode.ts
+++ b/packages/core/src/utilities/nodes/getMeasurableNode.ts
@@ -1,0 +1,14 @@
+export function getMeasurableNode(
+  node: HTMLElement | undefined | null
+): HTMLElement | null {
+  if (!node) {
+    return null;
+  }
+
+  if (node.children.length > 1) {
+    return node;
+  }
+  const firstChild = node.children[0];
+
+  return firstChild instanceof HTMLElement ? firstChild : node;
+}

--- a/packages/core/src/utilities/nodes/index.ts
+++ b/packages/core/src/utilities/nodes/index.ts
@@ -1,0 +1,1 @@
+export {getMeasurableNode} from './getMeasurableNode';

--- a/stories/2 - Presets/Sortable/1-Vertical.story.tsx
+++ b/stories/2 - Presets/Sortable/1-Vertical.story.tsx
@@ -140,7 +140,7 @@ export const RerenderBeforeSorting = () => {
       {...props}
       wrapperStyle={({isDragging}) => {
         return {
-          height: isDragging ? 80 : undefined,
+          height: isDragging ? undefined : 200,
         };
       }}
     />

--- a/stories/2 - Presets/Sortable/3-Grid.story.tsx
+++ b/stories/2 - Presets/Sortable/3-Grid.story.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import {LayoutMeasuringStrategy} from '@dnd-kit/core';
-import {restrictToWindowEdges} from '@dnd-kit/modifiers';
 import {
   AnimateLayoutChanges,
   defaultAnimateLayoutChanges,
@@ -22,7 +21,6 @@ const props: Partial<SortableProps> = {
     width: 140,
     height: 140,
   }),
-  modifiers: [restrictToWindowEdges],
 };
 
 export const BasicSetup = () => <Sortable {...props} />;

--- a/stories/2 - Presets/Sortable/5-Virtualized.story.tsx
+++ b/stories/2 - Presets/Sortable/5-Virtualized.story.tsx
@@ -112,6 +112,9 @@ function Sortable({
                 overIndex: -1,
                 isDragOverlay: true,
               })}
+              wrapperStyle={{
+                padding: 5,
+              }}
               dragOverlay
             />
           ) : null}


### PR DESCRIPTION
- Batch React updates in non-synthetic event handlers
- Defer measurement of droppable node rects until second render after dragging
- Use DragOverlay's `width` and `height` in collision rect (if it is used)