### PR TITLE
Return `undefined` instead of `null` for `transition` in `useSortable`

### DIFF
--- a/.changeset/sortable-transition-undefined.md
+++ b/.changeset/sortable-transition-undefined.md
@@ -1,0 +1,5 @@
+---
+"@dnd-kit/sortable": patch
+---
+
+Return `undefined` instead of `null` for `transition` in `useSortable`

--- a/packages/sortable/src/hooks/useSortable.ts
+++ b/packages/sortable/src/hooks/useSortable.ts
@@ -146,7 +146,7 @@ export function useSortable({
     }
 
     if (shouldDisplaceDragSource || !transition) {
-      return null;
+      return undefined;
     }
 
     if (isSorting || shouldAnimateLayoutChanges) {
@@ -156,6 +156,6 @@ export function useSortable({
       });
     }
 
-    return null;
+    return undefined;
   }
 }


### PR DESCRIPTION
Return `undefined` instead of `null` for `transition` in `useSortable`
