### PR TITLE
Update release workflow to publish with `@next` tag on push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,14 @@ on:
       - master
 jobs:
   release:
+    name: ${{ matrix.channel }}
     runs-on: ubuntu-latest
+    strategy:
+      max-parallel: 1
+      matrix:
+        channel:
+          - latest
+          - next
 
     steps:
       - uses: actions/checkout@v2
@@ -21,9 +28,20 @@ jobs:
         uses: bahmutov/npm-install@v1
 
       - name: Create Release Pull Request or Publish to npm
+        if: matrix.channel == 'latest'
         uses: changesets/action@master
         with:
           publish: yarn release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      # https://github.com/atlassian/changesets/blob/master/docs/snapshot-releases.md
+      - name: Publish on npm with @next tag
+        if: matrix.channel == 'next'
+        run: |
+          yarn run version:next
+          yarn run release:next
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -21,8 +21,8 @@
     "cypress:open": "cypress open",
     "changeset": "changeset",
     "release": "changeset publish",
-    "version:canary": "changeset version --snapshot canary",
-    "release:canary": "changeset publish --tag canary"
+    "version:next": "changeset version --snapshot next",
+    "release:next": "changeset publish --tag next"
   },
   "devDependencies": {
     "@changesets/changelog-github": "^0.2.7",


### PR DESCRIPTION
This PR updates the release workflow to publish with `@next` tag on push to master branch