### PR TITLE
Refactor DroppableContainers object into a custom Map instance

### DIFF
--- a/.changeset/droppablecontainers-map-refactor.md
+++ b/.changeset/droppablecontainers-map-refactor.md
@@ -1,6 +1,8 @@
 ---
-"@dnd-kit/core": major
-"@dnd-kit/sortable": patch
+'@dnd-kit/core': major
+'@dnd-kit/sortable': patch
 ---
 
-Refactored `DroppableContainers` type from `Record<UniqueIdentifier, DroppableContainer` to a custom instance that extends the [`Map` constructor](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map) and adds a few other methods such as `toArray()`, `getEnabled()` and `getNodeFor(id)` 
+Refactored `DroppableContainers` type from `Record<UniqueIdentifier, DroppableContainer` to a custom instance that extends the [`Map` constructor](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map) and adds a few other methods such as `toArray()`, `getEnabled()` and `getNodeFor(id)`.
+
+A unique `key` property was also added to the `DraggableNode` and `DroppableContainer` interfaces. This prevents potential race conditions in the mount and cleanup effects of `useDraggable` and `useDroppable`. It's possible for the clean-up effect to run after another React component using `useDraggable` or `useDroppable` mounts, which causes the newly mounted element to accidentally be un-registered.

--- a/.changeset/droppablecontainers-map-refactor.md
+++ b/.changeset/droppablecontainers-map-refactor.md
@@ -1,0 +1,6 @@
+---
+"@dnd-kit/core": major
+"@dnd-kit/sortable": patch
+---
+
+Refactored `DroppableContainers` type from `Record<UniqueIdentifier, DroppableContainer` to a custom instance that extends the [`Map` constructor](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map) and adds a few other methods such as `toArray()`, `getEnabled()` and `getNodeFor(id)` 

--- a/packages/core/src/hooks/useDraggable.ts
+++ b/packages/core/src/hooks/useDraggable.ts
@@ -1,5 +1,5 @@
 import {createContext, useContext, useEffect, useMemo} from 'react';
-import {Transform, useNodeRef} from '@dnd-kit/utilities';
+import {Transform, useNodeRef, useUniqueId} from '@dnd-kit/utilities';
 
 import {Context, Data} from '../store';
 import {ActiveDraggableContext} from '../components/DndContext';
@@ -26,12 +26,15 @@ const NullContext = createContext<any>(null);
 
 const defaultRole = 'button';
 
+const ID_PREFIX = 'Droppable';
+
 export function useDraggable({
   id,
   data,
   disabled = false,
   attributes,
 }: UseDraggableArguments) {
+  const key = useUniqueId(ID_PREFIX);
   const {
     active,
     activeNodeRect,
@@ -54,10 +57,14 @@ export function useDraggable({
 
   useEffect(
     () => {
-      draggableNodes[id] = {id, node, data: dataRef};
+      draggableNodes[id] = {id, key, node, data: dataRef};
 
       return () => {
-        delete draggableNodes[id];
+        const node = draggableNodes[id];
+
+        if (node && node.key === key) {
+          delete draggableNodes[id];
+        }
       };
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/packages/core/src/hooks/useDroppable.ts
+++ b/packages/core/src/hooks/useDroppable.ts
@@ -1,5 +1,9 @@
 import {useContext, useEffect, useRef} from 'react';
-import {useIsomorphicLayoutEffect, useNodeRef} from '@dnd-kit/utilities';
+import {
+  useIsomorphicLayoutEffect,
+  useNodeRef,
+  useUniqueId,
+} from '@dnd-kit/utilities';
 
 import {Context, Action, Data} from '../store';
 import type {LayoutRect} from '../types';
@@ -11,11 +15,14 @@ export interface UseDroppableArguments {
   data?: Data;
 }
 
+const ID_PREFIX = 'Droppable';
+
 export function useDroppable({
   data,
   disabled = false,
   id,
 }: UseDroppableArguments) {
+  const key = useUniqueId(ID_PREFIX);
   const {active, dispatch, over} = useContext(Context);
   const rect = useRef<LayoutRect | null>(null);
   const [nodeRef, setNodeRef] = useNodeRef();
@@ -27,6 +34,7 @@ export function useDroppable({
         type: Action.RegisterDroppable,
         element: {
           id,
+          key,
           disabled,
           node: nodeRef,
           rect,
@@ -37,6 +45,7 @@ export function useDroppable({
       return () =>
         dispatch({
           type: Action.UnregisterDroppable,
+          key,
           id,
         });
     },
@@ -49,6 +58,7 @@ export function useDroppable({
       dispatch({
         type: Action.SetDroppableDisabled,
         id,
+        key,
         disabled,
       });
     },

--- a/packages/core/src/hooks/utilities/useLayoutMeasuring.ts
+++ b/packages/core/src/hooks/utilities/useLayoutMeasuring.ts
@@ -2,7 +2,7 @@ import {useCallback, useEffect, useRef, useState} from 'react';
 import {useLazyMemo} from '@dnd-kit/utilities';
 
 import {getElementLayout} from '../../utilities';
-import type {DroppableContainers, LayoutRectMap} from '../../store/types';
+import type {DroppableContainer, LayoutRectMap} from '../../store/types';
 
 interface Arguments {
   dragging: boolean;
@@ -28,7 +28,7 @@ export interface LayoutMeasuring {
 const defaultValue: LayoutRectMap = new Map();
 
 export function useLayoutMeasuring(
-  containers: DroppableContainers,
+  containers: DroppableContainer[],
   {dragging, dependencies, config}: Arguments
 ) {
   const [willRecomputeLayouts, setWillRecomputeLayouts] = useState(false);
@@ -49,7 +49,7 @@ export function useLayoutMeasuring(
         containersRef.current !== containers ||
         willRecomputeLayouts
       ) {
-        for (let container of Object.values(containers)) {
+        for (let container of containers) {
           if (!container) {
             continue;
           }
@@ -127,19 +127,19 @@ export function useLayoutMeasuring(
 }
 
 function createLayoutRectMap(
-  containers: DroppableContainers | null
+  containers: DroppableContainer[] | null
 ): LayoutRectMap {
   const layoutRectMap: LayoutRectMap = new Map();
 
   if (containers) {
-    for (const container of Object.values(containers)) {
+    for (const container of containers) {
       if (!container) {
         continue;
       }
 
-      const {id, rect, disabled} = container;
+      const {id, rect} = container;
 
-      if (disabled || rect.current == null) {
+      if (rect.current == null) {
         continue;
       }
 

--- a/packages/core/src/store/actions.ts
+++ b/packages/core/src/store/actions.ts
@@ -28,9 +28,11 @@ export type Actions =
   | {
       type: Action.SetDroppableDisabled;
       id: UniqueIdentifier;
+      key: UniqueIdentifier;
       disabled: boolean;
     }
   | {
       type: Action.UnregisterDroppable;
       id: UniqueIdentifier;
+      key: UniqueIdentifier;
     };

--- a/packages/core/src/store/constructors.ts
+++ b/packages/core/src/store/constructors.ts
@@ -1,25 +1,25 @@
 import type {UniqueIdentifier} from '../types';
 import type {DroppableContainer} from './types';
 
-type Key = UniqueIdentifier | null | undefined;
+type Identifier = UniqueIdentifier | null | undefined;
 
 export class DroppableContainersMap extends Map<
   UniqueIdentifier,
   DroppableContainer
 > {
-  get(id: Key) {
+  get(id: Identifier) {
     return id != null ? super.get(id) ?? undefined : undefined;
   }
 
-  toArray() {
+  toArray(): DroppableContainer[] {
     return Array.from(this.values());
   }
 
-  getEnabled() {
+  getEnabled(): DroppableContainer[] {
     return this.toArray().filter(({disabled}) => !disabled);
   }
 
-  getNodeFor(id: Key) {
+  getNodeFor(id: Identifier) {
     return this.get(id)?.node.current ?? undefined;
   }
 }

--- a/packages/core/src/store/constructors.ts
+++ b/packages/core/src/store/constructors.ts
@@ -1,0 +1,25 @@
+import type {UniqueIdentifier} from '../types';
+import type {DroppableContainer} from './types';
+
+type Key = UniqueIdentifier | null | undefined;
+
+export class DroppableContainersMap extends Map<
+  UniqueIdentifier,
+  DroppableContainer
+> {
+  get(id: Key) {
+    return id != null ? super.get(id) ?? undefined : undefined;
+  }
+
+  toArray() {
+    return Array.from(this.values());
+  }
+
+  getEnabled() {
+    return this.toArray().filter(({disabled}) => !disabled);
+  }
+
+  getNodeFor(id: Key) {
+    return this.get(id)?.node.current ?? undefined;
+  }
+}

--- a/packages/core/src/store/context.ts
+++ b/packages/core/src/store/context.ts
@@ -1,6 +1,7 @@
 import {createContext} from 'react';
 
 import {noop} from '../utilities/other';
+import {DroppableContainersMap} from './constructors';
 import type {DndContextDescriptor} from './types';
 
 export const Context = createContext<DndContextDescriptor>({
@@ -17,7 +18,7 @@ export const Context = createContext<DndContextDescriptor>({
   dispatch: noop,
   draggableNodes: {},
   droppableRects: new Map(),
-  droppableContainers: {},
+  droppableContainers: new DroppableContainersMap(),
   over: null,
   overlayNode: {
     nodeRef: {

--- a/packages/core/src/store/reducer.ts
+++ b/packages/core/src/store/reducer.ts
@@ -70,10 +70,10 @@ export function reducer(state: State, action: Actions): State {
     }
 
     case Action.SetDroppableDisabled: {
-      const {id, disabled} = action;
+      const {id, key, disabled} = action;
       const element = state.droppable.containers.get(id);
 
-      if (!element) {
+      if (!element || key !== element.key) {
         return state;
       }
 
@@ -93,7 +93,13 @@ export function reducer(state: State, action: Actions): State {
     }
 
     case Action.UnregisterDroppable: {
-      const {id} = action;
+      const {id, key} = action;
+      const element = state.droppable.containers.get(id);
+
+      if (!element || key !== element.key) {
+        return state;
+      }
+
       const containers = new DroppableContainersMap(state.droppable.containers);
       containers.delete(id);
 

--- a/packages/core/src/store/reducer.ts
+++ b/packages/core/src/store/reducer.ts
@@ -1,5 +1,5 @@
-import {omit} from '../utilities';
 import {Action, Actions} from './actions';
+import {DroppableContainersMap} from './constructors';
 import type {State} from './types';
 
 export function getInitialState(): State {
@@ -11,7 +11,7 @@ export function getInitialState(): State {
       translate: {x: 0, y: 0},
     },
     droppable: {
-      containers: {},
+      containers: new DroppableContainersMap(),
     },
   };
 }
@@ -57,50 +57,51 @@ export function reducer(state: State, action: Actions): State {
     case Action.RegisterDroppable: {
       const {element} = action;
       const {id} = element;
+      const containers = new DroppableContainersMap(state.droppable.containers);
+      containers.set(id, element);
 
       return {
         ...state,
         droppable: {
           ...state.droppable,
-          containers: {
-            ...state.droppable.containers,
-            [id]: element,
-          },
+          containers,
         },
       };
     }
 
     case Action.SetDroppableDisabled: {
       const {id, disabled} = action;
-      const element = state.droppable.containers[id];
+      const element = state.droppable.containers.get(id);
 
       if (!element) {
         return state;
       }
 
+      const containers = new DroppableContainersMap(state.droppable.containers);
+      containers.set(id, {
+        ...element,
+        disabled,
+      });
+
       return {
         ...state,
         droppable: {
           ...state.droppable,
-          containers: {
-            ...state.droppable.containers,
-            [id]: {
-              ...element,
-              disabled,
-            },
-          },
+          containers,
         },
       };
     }
 
     case Action.UnregisterDroppable: {
       const {id} = action;
+      const containers = new DroppableContainersMap(state.droppable.containers);
+      containers.delete(id);
 
       return {
         ...state,
         droppable: {
           ...state.droppable,
-          containers: omit(id, state.droppable.containers),
+          containers,
         },
       };
     }

--- a/packages/core/src/store/types.ts
+++ b/packages/core/src/store/types.ts
@@ -25,10 +25,11 @@ export type DataRef = MutableRefObject<Data | undefined>;
 
 export interface DroppableContainer {
   id: UniqueIdentifier;
+  key: UniqueIdentifier;
+  data: DataRef;
+  disabled: boolean;
   node: MutableRefObject<HTMLElement | null>;
   rect: MutableRefObject<LayoutRect | null>;
-  disabled: boolean;
-  data: DataRef;
 }
 
 export interface Active {
@@ -49,6 +50,7 @@ export interface Over {
 
 export type DraggableNode = {
   id: UniqueIdentifier;
+  key: UniqueIdentifier;
   node: MutableRefObject<HTMLElement | null>;
   data: DataRef;
 };

--- a/packages/core/src/store/types.ts
+++ b/packages/core/src/store/types.ts
@@ -9,6 +9,7 @@ import type {
 } from '../types';
 import type {SyntheticListeners} from '../hooks/utilities';
 import type {Actions} from './actions';
+import type {DroppableContainersMap} from './constructors';
 
 export interface DraggableElement {
   node: DraggableNode;
@@ -57,10 +58,7 @@ export type DraggableNodes = Record<
   DraggableNode | undefined
 >;
 
-export type DroppableContainers = Record<
-  UniqueIdentifier,
-  DroppableContainer | undefined
->;
+export type DroppableContainers = DroppableContainersMap;
 
 export type LayoutRectMap = Map<UniqueIdentifier, LayoutRect>;
 

--- a/packages/core/src/utilities/index.ts
+++ b/packages/core/src/utilities/index.ts
@@ -19,7 +19,7 @@ export {
 
 export {getOwnerDocument, getWindow} from './document';
 
-export {omit, noop} from './other';
+export {noop} from './other';
 
 export {
   getScrollableAncestors,

--- a/packages/core/src/utilities/other/index.ts
+++ b/packages/core/src/utilities/other/index.ts
@@ -1,3 +1,1 @@
 export {noop} from './noop';
-
-export {omit} from './omit';

--- a/packages/core/src/utilities/other/omit.ts
+++ b/packages/core/src/utilities/other/omit.ts
@@ -1,5 +1,0 @@
-export function omit<T>(id: string, elements: Record<string, T>) {
-  const {[id]: _, ...other} = elements;
-
-  return other;
-}

--- a/packages/sortable/src/sensors/keyboard/sortableKeyboardCoordinates.ts
+++ b/packages/sortable/src/sensors/keyboard/sortableKeyboardCoordinates.ts
@@ -27,7 +27,7 @@ export const sortableKeyboardCoordinates: KeyboardCoordinateGetter = (
 
     const filteredContainers: DroppableContainer[] = [];
 
-    Object.values(droppableContainers).forEach((entry) => {
+    droppableContainers.getEnabled().forEach((entry) => {
       if (!entry || entry?.disabled) {
         return;
       }
@@ -77,7 +77,7 @@ export const sortableKeyboardCoordinates: KeyboardCoordinateGetter = (
     });
 
     if (closestId) {
-      const newNode = droppableContainers[closestId]?.node.current;
+      const newNode = droppableContainers.get(closestId)?.node.current;
 
       if (newNode) {
         const newScrollAncestors = getScrollableAncestors(newNode);


### PR DESCRIPTION
Fixes https://github.com/clauderic/dnd-kit/issues/125

Refactored `DroppableContainers` type from `Record<UniqueIdentifier, DroppableContainer` to a custom instance that extends the [`Map` constructor](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map) and adds a few other methods such as `toArray()`, `getEnabled()` and `getNodeFor(id)` 