### PR TITLE
Stop propagation of click events on draggable node once activation constraints are met

### DIFF
--- a/.changeset/prevent-click-propagation.md
+++ b/.changeset/prevent-click-propagation.md
@@ -1,0 +1,5 @@
+---
+"@dnd-kit/core": minor
+---
+
+Pointer, Mouse and Touch sensors now stop propagation of click events on the draggable node once activation constraints are met

--- a/packages/core/src/sensors/events.ts
+++ b/packages/core/src/sensors/events.ts
@@ -1,6 +1,15 @@
 export enum EventName {
+  Click = 'click',
   Keydown = 'keydown',
   ContextMenu = 'contextmenu',
   Resize = 'resize',
   VisibilityChange = 'visibilitychange',
+}
+
+export function preventDefault(event: Event) {
+  event.preventDefault();
+}
+
+export function stopPropagation(event: Event) {
+  event.stopPropagation();
 }

--- a/packages/core/src/sensors/utilities/Listeners.ts
+++ b/packages/core/src/sensors/utilities/Listeners.ts
@@ -1,23 +1,24 @@
 export class Listeners {
-  private listeners: {
-    eventName: string;
-    handler: EventListenerOrEventListenerObject;
-  }[] = [];
+  private listeners: [
+    string,
+    EventListenerOrEventListenerObject,
+    AddEventListenerOptions | boolean | undefined
+  ][] = [];
 
-  constructor(private target: EventTarget) {}
+  constructor(private target: EventTarget | null) {}
 
-  public add(
+  public add<T extends Event>(
     eventName: string,
-    handler: EventListenerOrEventListenerObject,
-    options?: AddEventListenerOptions | false
+    handler: (event: T) => void,
+    options?: AddEventListenerOptions | boolean
   ) {
-    this.target.addEventListener(eventName, handler, options);
-    this.listeners.push({eventName, handler});
+    this.target?.addEventListener(eventName, handler as EventListener, options);
+    this.listeners.push([eventName, handler as EventListener, options]);
   }
 
-  public removeAll() {
-    this.listeners.forEach(({eventName, handler}) =>
-      this.target.removeEventListener(eventName, handler)
+  public removeAll = () => {
+    this.listeners.forEach((listener) =>
+      this.target?.removeEventListener(...listener)
     );
-  }
+  };
 }


### PR DESCRIPTION
Fixes https://github.com/clauderic/dnd-kit/issues/172

This PR adds a `click` event listener to the draggable node to stop propagation of click events once activation constraints are met.

If activation constraints are not met, `click` events fire as they should.