### PR TITLE
fix: compute collision against DragOverlay child bounding rect

### DIFF
--- a/.changeset/dragoverlay-collision-rect.md
+++ b/.changeset/dragoverlay-collision-rect.md
@@ -1,0 +1,5 @@
+---
+"@dnd-kit/core": minor
+---
+
+The collision rect is now completely based on the position of the `DragOverlay` when it is used. Previously, only the `width` and `height` properties of the `DragOverlay` were used for the collision rect, while the `top`, `left`, `bottom` and `right` properties were derived from the active node rect. This new approach is more aligned with developers would expect, but could cause issues for consumers that were relying on the previous (incorrect) behavior.

--- a/packages/core/src/components/DndContext/DndContext.tsx
+++ b/packages/core/src/components/DndContext/DndContext.tsx
@@ -199,7 +199,6 @@ export const DndContext = memo(function DndContext({
   const activeNodeClientRect = useClientRect(activeNode);
   const initialActiveNodeRectRef = useRef<ViewRect | null>(null);
   const initialActiveNodeRect = initialActiveNodeRectRef.current;
-  const nodeRectDelta = getRectDelta(activeNodeRect, initialActiveNodeRect);
   const sensorContext = useRef<SensorContext>({
     active: null,
     activeNode,
@@ -229,11 +228,19 @@ export const DndContext = memo(function DndContext({
 
   const [overlayNodeRef, setOverlayNodeRef] = useNodeRef();
   const overlayNodeRect = useClientRect(
-    activeId ? getMeasurableNode(overlayNodeRef.current) : null,
-    willRecomputeLayouts
+    activeId ? getMeasurableNode(overlayNodeRef.current) : null
   );
 
+  // Use the rect of the drag overlay if it is mounted
   const draggingNodeRect = overlayNodeRect ?? activeNodeRect;
+
+  // The delta between the previous and new position of the draggable node
+  // is only relevant when there is no drag overlay
+  const nodeRectDelta =
+    draggingNodeRect === activeNodeRect
+      ? getRectDelta(activeNodeRect, initialActiveNodeRect)
+      : defaultCoordinates;
+
   const modifiedTranslate = applyModifiers(modifiers, {
     transform: {
       x: translate.x - nodeRectDelta.x,
@@ -261,7 +268,9 @@ export const DndContext = memo(function DndContext({
 
   const scrollAdjustedTranslate = add(modifiedTranslate, scrollAdjustment);
 
-  const translatedRect = draggingNodeRect ? getAdjustedRect(draggingNodeRect, modifiedTranslate) : null;
+  const translatedRect = draggingNodeRect
+    ? getAdjustedRect(draggingNodeRect, modifiedTranslate)
+    : null;
 
   const collisionRect = translatedRect
     ? getAdjustedRect(translatedRect, scrollAdjustment)

--- a/packages/core/src/components/DndContext/DndContext.tsx
+++ b/packages/core/src/components/DndContext/DndContext.tsx
@@ -261,20 +261,7 @@ export const DndContext = memo(function DndContext({
 
   const scrollAdjustedTranslate = add(modifiedTranslate, scrollAdjustment);
 
-  // The overlay node's position is based on the active node's position.
-  // We assume that any difference in positioning is for visual purposes only
-  // and shouldn't affect collision detection. However, the computed height of
-  // the overlay node should affect the collision rect.
-  const rect =
-    overlayNodeRect && activeNodeRect
-      ? {
-          ...activeNodeRect,
-          height: overlayNodeRect.height,
-          width: overlayNodeRect.width,
-        }
-      : activeNodeRect;
-
-  const translatedRect = rect ? getAdjustedRect(rect, modifiedTranslate) : null;
+  const translatedRect = draggingNodeRect ? getAdjustedRect(draggingNodeRect, modifiedTranslate) : null;
 
   const collisionRect = translatedRect
     ? getAdjustedRect(translatedRect, scrollAdjustment)


### PR DESCRIPTION
Fixes #401 

This PR corrects what is, I believe, an improper assumption made in `DnDContext`. Defending this decision is most expeditiously done by providing an example of bad behavior on the master branch:

![collision](https://user-images.githubusercontent.com/5509303/128900164-66026ad9-b14c-4c56-8e30-b591f808c45a.gif)

In this gif the black box with the text "1 item" is the first child of the `DragOverlay`, the blue box is the drag overlay itself, and the red box is the final computed collision rectangle. The drag overlay has the `snapToCenter` modifier applied, and has standard `display: flex` + centering styles applied to center the overlay child within the `DragOverlay`. The blue/red rectangle backgrounds exist purely for debugging/demonstration purposes and would not be visible to the end user. In practice, the user would visualize their cursor and the "1 item" element as the thing driving collision, but the current approach improperly (I believe) ignores the positioning of the overlay child and only adopts its width/height. If we remove the calculation of `rect` and just use `draggingNodeRect` the expected behavior occurs and the collision rectangle is positioned appropriately. 

It's not immediately obvious to me why this logic existed in the first place, so I wholly expect that there's a case I might be missing/am not thinking of, but ultimately this _feels_ like the correct behavior and the behavior I would expect as a developer making use of the library. I ultimately want collision to be measured against the bounding rect of the first child of `DragOverlay`. If I want that to be equivalent to the active node then all I have to do is not modify the position of the first child of the overlay and its bounding box will be the same.

As an aside, working through this has made me think that there might be long term value in providing some configuration option on `DragOverlay`(or a new component like `PointerOverlay`) that foregoes the relationship with the active node and instead just aligns with the cursor position. It would make this case a lot simpler to implement and wouldn't require the use of the `snapToCenter` modifier.
