### PR TITLE
Exclude fixed position node's ancestors from getScrollableAncestors

### DIFF
--- a/.changeset/fixed-scrollable-ancestors.md
+++ b/.changeset/fixed-scrollable-ancestors.md
@@ -1,0 +1,5 @@
+---
+"@dnd-kit/core": minor
+---
+
+Prevent `getScrollableAncestors` from continuing to search if a fixed position node is found.

--- a/packages/core/src/utilities/scroll/getScrollableAncestors.ts
+++ b/packages/core/src/utilities/scroll/getScrollableAncestors.ts
@@ -1,3 +1,4 @@
+import {isFixed} from './isFixed';
 import {isScrollable} from './isScrollable';
 
 export function getScrollableAncestors(element: Node | null): Element[] {
@@ -28,6 +29,10 @@ export function getScrollableAncestors(element: Node | null): Element[] {
 
     if (isScrollable(node)) {
       scrollParents.push(node);
+    }
+
+    if (isFixed(node)) {
+      return scrollParents;
     }
 
     return findScrollableAncestors(node.parentNode);

--- a/packages/core/src/utilities/scroll/getScrollableAncestors.ts
+++ b/packages/core/src/utilities/scroll/getScrollableAncestors.ts
@@ -27,11 +27,13 @@ export function getScrollableAncestors(element: Node | null): Element[] {
       return scrollParents;
     }
 
-    if (isScrollable(node)) {
+    const computedStyle = window.getComputedStyle(node);
+
+    if (isScrollable(node, computedStyle)) {
       scrollParents.push(node);
     }
 
-    if (isFixed(node)) {
+    if (isFixed(node, computedStyle)) {
       return scrollParents;
     }
 

--- a/packages/core/src/utilities/scroll/isFixed.ts
+++ b/packages/core/src/utilities/scroll/isFixed.ts
@@ -1,0 +1,3 @@
+export function isFixed(node: HTMLElement): boolean {
+  return window.getComputedStyle(node).position === 'fixed';
+}

--- a/packages/core/src/utilities/scroll/isFixed.ts
+++ b/packages/core/src/utilities/scroll/isFixed.ts
@@ -1,3 +1,6 @@
-export function isFixed(node: HTMLElement): boolean {
-  return window.getComputedStyle(node).position === 'fixed';
+export function isFixed(
+  node: HTMLElement,
+  computedStyle: CSSStyleDeclaration = window.getComputedStyle(node)
+): boolean {
+  return computedStyle.position === 'fixed';
 }

--- a/packages/core/src/utilities/scroll/isScrollable.ts
+++ b/packages/core/src/utilities/scroll/isScrollable.ts
@@ -1,5 +1,7 @@
-export function isScrollable(node: HTMLElement): boolean {
-  const computedStyle = window.getComputedStyle(node);
+export function isScrollable(
+  node: HTMLElement,
+  computedStyle: CSSStyleDeclaration = window.getComputedStyle(node)
+): boolean {
   const overflowRegex = /(auto|scroll|overlay)/;
   const properties = ['overflow', 'overflowX', 'overflowY'];
 


### PR DESCRIPTION
As reported in #61 and #298 (any others?) positioning doesn't work as expected when the `DndContext` is inside a fixed position container.

This small change (preventing `getScrollableAncestors` from continuing to search if a fixed position node is found) seems to resolve the issues I had, but there may be some nuance I'm missing and I only tested it with my own project.