### PR TITLE
fix: pass willRecomputeLayouts to useClientRect call for overlayNodeRect

### DIFF
--- a/packages/core/src/components/DndContext/DndContext.tsx
+++ b/packages/core/src/components/DndContext/DndContext.tsx
@@ -228,7 +228,8 @@ export const DndContext = memo(function DndContext({
 
   const [overlayNodeRef, setOverlayNodeRef] = useNodeRef();
   const overlayNodeRect = useClientRect(
-    activeId ? getMeasurableNode(overlayNodeRef.current) : null
+    activeId ? getMeasurableNode(overlayNodeRef.current) : null,
+    willRecomputeLayouts
   );
 
   // Use the rect of the drag overlay if it is mounted


### PR DESCRIPTION
Thanks for the additional investigation done for #408 @clauderic. It looks like removing `willRecomputeLayouts` from the `useClientRect` call of `overlayNodeRect` rebreaks our case, however. Reading over the methodology/cause of the changes you made, I'm not sure why this argument was removed, but adding it back in seems to fix things. It seems to me that recomputing the layout rect of the measurable child is required as the overlay moves.