### PR TITLE
Fix duplicate scroll ancestor detection

### DIFF
--- a/.changeset/duplicate-scrollable-ancestor.md
+++ b/.changeset/duplicate-scrollable-ancestor.md
@@ -1,0 +1,5 @@
+---
+"@dnd-kit/core": patch
+---
+
+Fix duplicate scroll ancestor detection. In some scenarios, an element could be added twice to the list of detected scrollable ancestors, resulting in invalid offsets.

--- a/packages/core/src/utilities/scroll/getScrollableAncestors.ts
+++ b/packages/core/src/utilities/scroll/getScrollableAncestors.ts
@@ -8,13 +8,21 @@ export function getScrollableAncestors(element: Node | null): Element[] {
       return scrollParents;
     }
 
-    if (node instanceof Document && node.scrollingElement != null) {
+    if (
+      node instanceof Document &&
+      node.scrollingElement != null &&
+      !scrollParents.includes(node.scrollingElement)
+    ) {
       scrollParents.push(node.scrollingElement);
 
       return scrollParents;
     }
 
     if (!(node instanceof HTMLElement) || node instanceof SVGElement) {
+      return scrollParents;
+    }
+
+    if (scrollParents.includes(node)) {
       return scrollParents;
     }
 


### PR DESCRIPTION
Fixes https://github.com/clauderic/dnd-kit/issues/429

In some scenarios, an element could be added twice to the list of scrollable ancestors, resulting in invalid offsets.
