### PR TITLE
fixes #436 - Add PointerEvent support to `getEventCoordinates` method

### DIFF
--- a/.changeset/fix-pointerseensor-cypress.md
+++ b/.changeset/fix-pointerseensor-cypress.md
@@ -1,0 +1,6 @@
+---
+"@dnd-kit/modifiers": patch
+"@dnd-kit/utilities": patch
+---
+
+Added PointerEvent support to the `getEventCoordinates` method. This fixes testing the PointerSensor with Cypress (#436)

--- a/packages/modifiers/src/snapCenterToCursor.ts
+++ b/packages/modifiers/src/snapCenterToCursor.ts
@@ -3,6 +3,7 @@ import {
   getEventCoordinates,
   isTouchEvent,
   isMouseEvent,
+  isPointerEvent,
 } from '@dnd-kit/utilities';
 
 export const snapCenterToCursor: Modifier = ({
@@ -13,7 +14,9 @@ export const snapCenterToCursor: Modifier = ({
   if (
     activeNodeRect &&
     activatorEvent &&
-    (isTouchEvent(activatorEvent) || isMouseEvent(activatorEvent))
+    (isTouchEvent(activatorEvent) ||
+      isMouseEvent(activatorEvent) ||
+      isPointerEvent(activatorEvent))
   ) {
     const activatorCoordinates = getEventCoordinates(activatorEvent);
     const offsetX = activatorCoordinates.x - activeNodeRect.left;

--- a/packages/modifiers/src/snapCenterToCursor.ts
+++ b/packages/modifiers/src/snapCenterToCursor.ts
@@ -2,8 +2,7 @@ import type {Modifier} from '@dnd-kit/core';
 import {
   getEventCoordinates,
   isTouchEvent,
-  isMouseEvent,
-  isPointerEvent,
+  hasViewportRelativeCoordinates,
 } from '@dnd-kit/utilities';
 
 export const snapCenterToCursor: Modifier = ({
@@ -15,8 +14,7 @@ export const snapCenterToCursor: Modifier = ({
     activeNodeRect &&
     activatorEvent &&
     (isTouchEvent(activatorEvent) ||
-      isMouseEvent(activatorEvent) ||
-      isPointerEvent(activatorEvent))
+      hasViewportRelativeCoordinates(activatorEvent))
   ) {
     const activatorCoordinates = getEventCoordinates(activatorEvent);
     const offsetX = activatorCoordinates.x - activeNodeRect.left;

--- a/packages/utilities/src/coordinates/getEventCoordinates.ts
+++ b/packages/utilities/src/coordinates/getEventCoordinates.ts
@@ -1,5 +1,5 @@
 import type {Coordinates} from './types';
-import {isMouseEvent, isTouchEvent} from '../event';
+import {isMouseEvent, isPointerEvent, isTouchEvent} from '../event';
 
 /**
  * Returns the normalized x and y coordinates for mouse and touch events.
@@ -23,7 +23,7 @@ export function getEventCoordinates(event: Event): Coordinates {
     }
   }
 
-  if (isMouseEvent(event)) {
+  if (isMouseEvent(event) || isPointerEvent(event)) {
     return {
       x: event.clientX,
       y: event.clientY,

--- a/packages/utilities/src/coordinates/getEventCoordinates.ts
+++ b/packages/utilities/src/coordinates/getEventCoordinates.ts
@@ -1,5 +1,5 @@
 import type {Coordinates} from './types';
-import {isMouseEvent, isPointerEvent, isTouchEvent} from '../event';
+import {isTouchEvent} from '../event';
 
 /**
  * Returns the normalized x and y coordinates for mouse and touch events.
@@ -23,10 +23,11 @@ export function getEventCoordinates(event: Event): Coordinates {
     }
   }
 
-  if (isMouseEvent(event) || isPointerEvent(event)) {
+  // In case of MouseEvent or PointerEvent.
+  if ('clientX' in event && 'clientY' in event) {
     return {
-      x: event.clientX,
-      y: event.clientY,
+      x: (event as MouseEvent).clientX,
+      y: (event as MouseEvent).clientY,
     };
   }
 

--- a/packages/utilities/src/coordinates/getEventCoordinates.ts
+++ b/packages/utilities/src/coordinates/getEventCoordinates.ts
@@ -1,5 +1,5 @@
 import type {Coordinates} from './types';
-import {isTouchEvent} from '../event';
+import {isTouchEvent, hasViewportRelativeCoordinates} from '../event';
 
 /**
  * Returns the normalized x and y coordinates for mouse and touch events.
@@ -23,11 +23,10 @@ export function getEventCoordinates(event: Event): Coordinates {
     }
   }
 
-  // In case of MouseEvent or PointerEvent.
-  if ('clientX' in event && 'clientY' in event) {
+  if (hasViewportRelativeCoordinates(event)) {
     return {
-      x: (event as MouseEvent).clientX,
-      y: (event as MouseEvent).clientY,
+      x: event.clientX,
+      y: event.clientY,
     };
   }
 

--- a/packages/utilities/src/event/hasViewportRelativeCoordinates.ts
+++ b/packages/utilities/src/event/hasViewportRelativeCoordinates.ts
@@ -1,0 +1,5 @@
+export function hasViewportRelativeCoordinates(
+  event: Event
+): event is Event & Pick<PointerEvent, 'clientX' | 'clientY'> {
+  return 'clientX' in event && 'clientY' in event;
+}

--- a/packages/utilities/src/event/index.ts
+++ b/packages/utilities/src/event/index.ts
@@ -1,3 +1,2 @@
 export {isMouseEvent} from './isMouseEvent';
-export {isPointerEvent} from './isPointerEvent';
 export {isTouchEvent} from './isTouchEvent';

--- a/packages/utilities/src/event/index.ts
+++ b/packages/utilities/src/event/index.ts
@@ -1,3 +1,2 @@
-export {isMouseEvent} from './isMouseEvent';
-export {isPointerEvent} from './isPointerEvent';
+export {hasViewportRelativeCoordinates} from './hasViewportRelativeCoordinates';
 export {isTouchEvent} from './isTouchEvent';

--- a/packages/utilities/src/event/index.ts
+++ b/packages/utilities/src/event/index.ts
@@ -1,2 +1,3 @@
 export {isMouseEvent} from './isMouseEvent';
+export {isPointerEvent} from './isPointerEvent';
 export {isTouchEvent} from './isTouchEvent';

--- a/packages/utilities/src/event/isMouseEvent.ts
+++ b/packages/utilities/src/event/isMouseEvent.ts
@@ -1,6 +1,0 @@
-export function isMouseEvent(event: Event): event is MouseEvent {
-  return (
-    (window?.MouseEvent && event instanceof MouseEvent) ||
-    event.type.includes('mouse')
-  );
-}

--- a/packages/utilities/src/event/isPointerEvent.ts
+++ b/packages/utilities/src/event/isPointerEvent.ts
@@ -1,0 +1,6 @@
+export function isPointerEvent(event: Event): event is PointerEvent {
+  return (
+    (window?.PointerEvent && event instanceof PointerEvent) ||
+    event.type.includes('pointer')
+  );
+}

--- a/packages/utilities/src/event/isPointerEvent.ts
+++ b/packages/utilities/src/event/isPointerEvent.ts
@@ -1,6 +1,0 @@
-export function isPointerEvent(event: Event): event is PointerEvent {
-  return (
-    (window?.PointerEvent && event instanceof PointerEvent) ||
-    event.type.includes('pointer')
-  );
-}

--- a/packages/utilities/src/index.ts
+++ b/packages/utilities/src/index.ts
@@ -12,6 +12,6 @@ export type {Coordinates} from './coordinates';
 export {getEventCoordinates} from './coordinates';
 export {CSS} from './css';
 export type {Transform, Transition} from './css';
-export {isMouseEvent, isTouchEvent} from './event';
+export {isMouseEvent, isPointerEvent, isTouchEvent} from './event';
 export {canUseDOM} from './execution-context';
 export type {Arguments, FirstArgument, Without} from './types';

--- a/packages/utilities/src/index.ts
+++ b/packages/utilities/src/index.ts
@@ -12,6 +12,6 @@ export type {Coordinates} from './coordinates';
 export {getEventCoordinates} from './coordinates';
 export {CSS} from './css';
 export type {Transform, Transition} from './css';
-export {isMouseEvent, isPointerEvent, isTouchEvent} from './event';
+export {hasViewportRelativeCoordinates, isTouchEvent} from './event';
 export {canUseDOM} from './execution-context';
 export type {Arguments, FirstArgument, Without} from './types';


### PR DESCRIPTION
In order to test DnD with Pointer events - like mentioned here - https://github.com/clauderic/dnd-kit/issues/208 we need to change how `getEventCoordinates` handles `pointer*` events (right now we are getting always `{x:0, y:0}`.