### PR TITLE
Refactor measuring and collision detection

### DIFF
--- a/.changeset/refactor-collision-detection.md
+++ b/.changeset/refactor-collision-detection.md
@@ -1,0 +1,28 @@
+---
+"@dnd-kit/core": major
+"@dnd-kit/sortable": major
+"@dnd-kit/utilities": minor
+"@dnd-kit/modifiers": minor
+---
+
+Major internal refactor of measuring and collision detection. 
+
+### Summary of changes
+Previously, all collision detection algorithms were relative to the top and left points of the document. While this approach worked in most situations, it broke down in a number of different use-cases, such as fixed position droppable containers and trying to drag between containers that had different scroll positions.
+
+This new approach changes the frame of comparison to be relative to the viewport. This is a major breaking change, and will need to be released under a new major version bump.
+
+### Breaking changes:
+
+- By default, `@dnd-kit` now ignores only the transforms applied to the draggable / droppable node itself, but considers all the transforms applied to its ancestors. This should provide the right balance of flexibility for most consumers.
+  - Transforms applied to the droppable and draggable nodes are ignored by default, because the recommended approach for moving items on the screen is to use the transform property, which can interfere with the calculation of collisions.
+  - Consumers can choose an alternate approach that does consider transforms for specific use-cases if needed by configuring the measuring prop of <DndContext>. Refer to the <Switch> example.
+- Reduced the number of concepts related to measuring from `ViewRect`, `LayoutRect` to just a single concept of `ClientRect`.
+  - The `ClientRect` interface no longer holds the `offsetTop` and `offsetLeft` properties. For most use-cases, you can replace `offsetTop` with `top` and `offsetLeft` with `left`.
+  - Replaced the following exports from the `@dnd-kit/core` package with `getClientRect`: 
+    - `getBoundingClientRect`
+    - `getViewRect`
+    - `getLayoutRect`
+    - `getViewportLayoutRect`
+- Removed `translatedRect` from the `SensorContext` interface. Replace usage with `collisionRect`.
+- Removed `activeNodeClientRect` on the `DndContext` interface. Replace with `activeNodeRect`.

--- a/packages/core/src/components/DragOverlay/hooks/index.ts
+++ b/packages/core/src/components/DragOverlay/hooks/index.ts
@@ -1,2 +1,2 @@
-export {useDropAnimation} from './useDropAnimation';
+export {useDropAnimation, defaultDropAnimation} from './useDropAnimation';
 export type {DropAnimation} from './useDropAnimation';

--- a/packages/core/src/components/DragOverlay/index.ts
+++ b/packages/core/src/components/DragOverlay/index.ts
@@ -1,3 +1,4 @@
-export {DragOverlay, defaultDropAnimation} from './DragOverlay';
+export {DragOverlay} from './DragOverlay';
 export type {Props} from './DragOverlay';
+export {defaultDropAnimation} from './hooks';
 export type {DropAnimation} from './hooks';

--- a/packages/core/src/hooks/useDraggable.ts
+++ b/packages/core/src/hooks/useDraggable.ts
@@ -1,5 +1,10 @@
-import {createContext, useContext, useEffect, useMemo} from 'react';
-import {Transform, useNodeRef, useUniqueId} from '@dnd-kit/utilities';
+import {createContext, useContext, useMemo} from 'react';
+import {
+  Transform,
+  useNodeRef,
+  useUniqueId,
+  useIsomorphicLayoutEffect,
+} from '@dnd-kit/utilities';
 
 import {Context, Data} from '../store';
 import {ActiveDraggableContext} from '../components/DndContext';
@@ -55,7 +60,7 @@ export function useDraggable({
   const listeners = useSyntheticListeners(activators, id);
   const dataRef = useData(data);
 
-  useEffect(
+  useIsomorphicLayoutEffect(
     () => {
       draggableNodes[id] = {id, key, node, data: dataRef};
 

--- a/packages/core/src/hooks/useDroppable.ts
+++ b/packages/core/src/hooks/useDroppable.ts
@@ -6,7 +6,7 @@ import {
 } from '@dnd-kit/utilities';
 
 import {Context, Action, Data} from '../store';
-import type {LayoutRect} from '../types';
+import type {ClientRect} from '../types';
 import {useData} from './utilities';
 
 export interface UseDroppableArguments {
@@ -24,7 +24,7 @@ export function useDroppable({
 }: UseDroppableArguments) {
   const key = useUniqueId(ID_PREFIX);
   const {active, dispatch, over} = useContext(Context);
-  const rect = useRef<LayoutRect | null>(null);
+  const rect = useRef<ClientRect | null>(null);
   const [nodeRef, setNodeRef] = useNodeRef();
   const dataRef = useData(data);
 

--- a/packages/core/src/hooks/utilities/index.ts
+++ b/packages/core/src/hooks/utilities/index.ts
@@ -22,5 +22,5 @@ export type {
   SyntheticListeners,
   SyntheticListenerMap,
 } from './useSyntheticListeners';
-export {useRect, useClientRect, useClientRects, useViewRect} from './useRect';
+export {useRect, useClientRect, useClientRects, useWindowRect} from './useRect';
 export {useDragOverlayMeasuring} from './useDragOverlayMeasuring';

--- a/packages/core/src/hooks/utilities/useAutoScroller.ts
+++ b/packages/core/src/hooks/utilities/useAutoScroller.ts
@@ -2,7 +2,7 @@ import {useCallback, useEffect, useMemo, useRef} from 'react';
 import {useInterval} from '@dnd-kit/utilities';
 
 import {getScrollDirectionAndSpeed, defaultCoordinates} from '../../utilities';
-import type {Coordinates, Direction, ViewRect} from '../../types';
+import type {Coordinates, Direction, ClientRect} from '../../types';
 
 export type ScrollAncestorSortingFn = (ancestors: Element[]) => Element[];
 
@@ -25,11 +25,11 @@ export interface Options {
 }
 
 interface Arguments extends Options {
-  draggingRect: ViewRect | null;
+  draggingRect: ClientRect | null;
   enabled: boolean;
   pointerCoordinates: Coordinates | null;
   scrollableAncestors: Element[];
-  scrollableAncestorRects: ViewRect[];
+  scrollableAncestorRects: ClientRect[];
 }
 
 export type CanScroll = (element: Element) => boolean;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -80,24 +80,20 @@ export type {
 } from './store';
 
 export type {
+  ClientRect,
   DistanceMeasurement,
   DragEndEvent,
   DragMoveEvent,
   DragOverEvent,
   DragStartEvent,
   DragCancelEvent,
-  LayoutRect,
   Translate,
   UniqueIdentifier,
-  ViewRect,
 } from './types';
 
 export {
   defaultCoordinates,
-  getBoundingClientRect,
-  getViewRect,
-  getLayoutRect,
-  getViewportLayoutRect,
+  getClientRect,
   getScrollableAncestors,
   closestCenter,
   closestCorners,

--- a/packages/core/src/modifiers/types.ts
+++ b/packages/core/src/modifiers/types.ts
@@ -1,17 +1,17 @@
 import type {Transform} from '@dnd-kit/utilities';
 import type {Active, Over} from '../store';
-import type {ClientRect, ViewRect} from '../types';
+import type {ClientRect} from '../types';
 
 export type Modifier = (args: {
   activatorEvent: Event | null;
   active: Active | null;
-  activeNodeRect: ViewRect | null;
-  draggingNodeRect: ViewRect | null;
-  containerNodeRect: ViewRect | null;
+  activeNodeRect: ClientRect | null;
+  draggingNodeRect: ClientRect | null;
+  containerNodeRect: ClientRect | null;
   over: Over | null;
-  overlayNodeRect: ViewRect | null;
+  overlayNodeRect: ClientRect | null;
   scrollableAncestors: Element[];
-  scrollableAncestorRects: ViewRect[];
+  scrollableAncestorRects: ClientRect[];
   transform: Transform;
   windowRect: ClientRect | null;
 }) => Transform;

--- a/packages/core/src/sensors/keyboard/KeyboardSensor.ts
+++ b/packages/core/src/sensors/keyboard/KeyboardSensor.ts
@@ -9,7 +9,7 @@ import {
 import type {Coordinates} from '../../types';
 import {
   defaultCoordinates,
-  getBoundingClientRect,
+  getTransformAgnosticClientRect,
   getScrollPosition,
   getScrollElementRect,
 } from '../../utilities';
@@ -68,7 +68,9 @@ export class KeyboardSensor implements SensorInstance {
       throw new Error('Active draggable node is undefined');
     }
 
-    const activeNodeRect = getBoundingClientRect(activeNode.node.current);
+    const activeNodeRect = getTransformAgnosticClientRect(
+      activeNode.node.current
+    );
     const coordinates = {
       x: activeNodeRect.left,
       y: activeNodeRect.top,

--- a/packages/core/src/sensors/types.ts
+++ b/packages/core/src/sensors/types.ts
@@ -5,15 +5,14 @@ import type {
   DraggableNode,
   DraggableNodes,
   DroppableContainers,
-  LayoutRectMap,
+  RectMap,
 } from '../store';
 import type {
   Coordinates,
-  LayoutRect,
   SyntheticEventName,
   Translate,
   UniqueIdentifier,
-  ViewRect,
+  ClientRect,
 } from '../types';
 
 export enum Response {
@@ -25,15 +24,15 @@ export enum Response {
 export type SensorContext = {
   active: Active | null;
   activeNode: HTMLElement | null;
-  collisionRect: ViewRect | null;
+  collisionRect: ClientRect | null;
   draggableNodes: DraggableNodes;
-  draggingNodeRect: LayoutRect | null;
-  droppableRects: LayoutRectMap;
+  draggingNode: HTMLElement | null;
+  draggingNodeRect: ClientRect | null;
+  droppableRects: RectMap;
   droppableContainers: DroppableContainers;
   over: Over | null;
   scrollableAncestors: Element[];
   scrollAdjustedTranslate: Translate | null;
-  translatedRect: ViewRect | null;
 };
 
 export type SensorOptions = {};

--- a/packages/core/src/store/context.ts
+++ b/packages/core/src/store/context.ts
@@ -9,7 +9,6 @@ export const Context = createContext<DndContextDescriptor>({
   active: null,
   activeNode: null,
   activeNodeRect: null,
-  activeNodeClientRect: null,
   activators: [],
   ariaDescribedById: {
     draggable: '',

--- a/packages/core/src/store/index.ts
+++ b/packages/core/src/store/index.ts
@@ -11,7 +11,7 @@ export type {
   DroppableContainer,
   DroppableContainers,
   DndContextDescriptor,
-  LayoutRectMap,
+  RectMap,
   Over,
   State,
 } from './types';

--- a/packages/core/src/store/types.ts
+++ b/packages/core/src/store/types.ts
@@ -1,12 +1,6 @@
 import type {MutableRefObject} from 'react';
 
-import type {
-  Coordinates,
-  ViewRect,
-  ClientRect,
-  LayoutRect,
-  UniqueIdentifier,
-} from '../types';
+import type {Coordinates, ClientRect, UniqueIdentifier} from '../types';
 import type {SyntheticListeners} from '../hooks/utilities';
 import type {Actions} from './actions';
 import type {DroppableContainersMap} from './constructors';
@@ -29,21 +23,21 @@ export interface DroppableContainer {
   data: DataRef;
   disabled: boolean;
   node: MutableRefObject<HTMLElement | null>;
-  rect: MutableRefObject<LayoutRect | null>;
+  rect: MutableRefObject<ClientRect | null>;
 }
 
 export interface Active {
   id: UniqueIdentifier;
   data: DataRef;
   rect: MutableRefObject<{
-    initial: ViewRect | null;
-    translated: ViewRect | null;
+    initial: ClientRect | null;
+    translated: ClientRect | null;
   }>;
 }
 
 export interface Over {
   id: UniqueIdentifier;
-  rect: LayoutRect;
+  rect: ClientRect;
   disabled: boolean;
   data: DataRef;
 }
@@ -62,7 +56,7 @@ export type DraggableNodes = Record<
 
 export type DroppableContainers = DroppableContainersMap;
 
-export type LayoutRectMap = Map<UniqueIdentifier, LayoutRect>;
+export type RectMap = Map<UniqueIdentifier, ClientRect>;
 
 export interface State {
   droppable: {
@@ -82,23 +76,22 @@ export interface DndContextDescriptor {
   activatorEvent: Event | null;
   active: Active | null;
   activeNode: HTMLElement | null;
-  activeNodeRect: ViewRect | null;
-  activeNodeClientRect: ClientRect | null;
+  activeNodeRect: ClientRect | null;
   ariaDescribedById: {
     draggable: UniqueIdentifier;
   };
-  containerNodeRect: ViewRect | null;
+  containerNodeRect: ClientRect | null;
   draggableNodes: DraggableNodes;
   droppableContainers: DroppableContainers;
-  droppableRects: LayoutRectMap;
+  droppableRects: RectMap;
   over: Over | null;
   dragOverlay: {
     nodeRef: MutableRefObject<HTMLElement | null>;
-    rect: ViewRect | null;
+    rect: ClientRect | null;
     setRef: (element: HTMLElement | null) => void;
   };
   scrollableAncestors: Element[];
-  scrollableAncestorRects: ViewRect[];
+  scrollableAncestorRects: ClientRect[];
   recomputeLayouts(): void;
   willRecomputeLayouts: boolean;
   windowRect: ClientRect | null;

--- a/packages/core/src/types/coordinates.ts
+++ b/packages/core/src/types/coordinates.ts
@@ -10,22 +10,6 @@ export type DistanceMeasurement =
 
 export type Translate = Coordinates;
 
-export interface LayoutRect {
-  width: number;
-  height: number;
-  offsetLeft: number;
-  offsetTop: number;
-}
-
-export interface ViewRect extends LayoutRect {
-  top: number;
-  left: number;
-  right: number;
-  bottom: number;
-}
-
-export interface ClientRect extends ViewRect {}
-
 export interface ScrollCoordinates {
   initial: Coordinates;
   current: Coordinates;

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -1,9 +1,6 @@
 export type {
   Coordinates,
-  ClientRect,
   DistanceMeasurement,
-  LayoutRect,
-  ViewRect,
   Translate,
   ScrollCoordinates,
 } from './coordinates';
@@ -17,3 +14,4 @@ export type {
 } from './events';
 export type {UniqueIdentifier} from './other';
 export type {SyntheticEventName} from './react';
+export type {ClientRect} from './rect';

--- a/packages/core/src/types/rect.ts
+++ b/packages/core/src/types/rect.ts
@@ -1,0 +1,8 @@
+export interface ClientRect {
+  width: number;
+  height: number;
+  top: number;
+  left: number;
+  right: number;
+  bottom: number;
+}

--- a/packages/core/src/utilities/algorithms/closestCenter.ts
+++ b/packages/core/src/utilities/algorithms/closestCenter.ts
@@ -1,5 +1,5 @@
 import {distanceBetween} from '../coordinates';
-import type {Coordinates, LayoutRect, UniqueIdentifier} from '../../types';
+import type {Coordinates, ClientRect, UniqueIdentifier} from '../../types';
 
 import type {CollisionDetection} from './types';
 
@@ -7,9 +7,9 @@ import type {CollisionDetection} from './types';
  * Returns the coordinates of the center of a given ClientRect
  */
 function centerOfRectangle(
-  rect: LayoutRect,
-  left = rect.offsetLeft,
-  top = rect.offsetTop
+  rect: ClientRect,
+  left = rect.left,
+  top = rect.top
 ): Coordinates {
   return {
     x: left + rect.width * 0.5,

--- a/packages/core/src/utilities/algorithms/closestCorners.ts
+++ b/packages/core/src/utilities/algorithms/closestCorners.ts
@@ -1,6 +1,5 @@
-import type {LayoutRect, UniqueIdentifier} from '../../types';
+import type {ClientRect, UniqueIdentifier} from '../../types';
 import {distanceBetween} from '../coordinates';
-import {isViewRect} from '../rect';
 
 import type {CollisionDetection} from './types';
 
@@ -10,9 +9,9 @@ import type {CollisionDetection} from './types';
  */
 
 function cornersOfRectangle(
-  rect: LayoutRect,
-  left = rect.offsetLeft,
-  top = rect.offsetTop
+  rect: ClientRect,
+  left = rect.left,
+  top = rect.top
 ) {
   return [
     {
@@ -56,11 +55,7 @@ export const closestCorners: CollisionDetection = ({
     } = droppableContainer;
 
     if (rect) {
-      const rectCorners = cornersOfRectangle(
-        rect,
-        isViewRect(rect) ? rect.left : undefined,
-        isViewRect(rect) ? rect.top : undefined
-      );
+      const rectCorners = cornersOfRectangle(rect, rect.left, rect.top);
       const distances = corners.reduce((accumulator, corner, index) => {
         return accumulator + distanceBetween(rectCorners[index], corner);
       }, 0);

--- a/packages/core/src/utilities/algorithms/rectIntersection.ts
+++ b/packages/core/src/utilities/algorithms/rectIntersection.ts
@@ -1,21 +1,15 @@
-import type {LayoutRect, UniqueIdentifier, ViewRect} from '../../types';
+import type {ClientRect, UniqueIdentifier} from '../../types';
 
 import type {CollisionDetection} from './types';
 
 /**
  * Returns the intersecting rectangle area between two rectangles
  */
-function getIntersectionRatio(entry: LayoutRect, target: ViewRect): number {
-  const top = Math.max(target.top, entry.offsetTop);
-  const left = Math.max(target.left, entry.offsetLeft);
-  const right = Math.min(
-    target.left + target.width,
-    entry.offsetLeft + entry.width
-  );
-  const bottom = Math.min(
-    target.top + target.height,
-    entry.offsetTop + entry.height
-  );
+function getIntersectionRatio(entry: ClientRect, target: ClientRect): number {
+  const top = Math.max(target.top, entry.top);
+  const left = Math.max(target.left, entry.left);
+  const right = Math.min(target.left + target.width, entry.left + entry.width);
+  const bottom = Math.min(target.top + target.height, entry.top + entry.height);
   const width = right - left;
   const height = bottom - top;
 

--- a/packages/core/src/utilities/algorithms/types.ts
+++ b/packages/core/src/utilities/algorithms/types.ts
@@ -1,8 +1,8 @@
 import type {Active, DroppableContainer} from '../../store';
-import type {UniqueIdentifier, ViewRect} from '../../types';
+import type {UniqueIdentifier, ClientRect} from '../../types';
 
 export type CollisionDetection = (args: {
   active: Active;
-  collisionRect: ViewRect;
+  collisionRect: ClientRect;
   droppableContainers: DroppableContainer[];
 }) => UniqueIdentifier | null;

--- a/packages/core/src/utilities/coordinates/getRelativeTransformOrigin.ts
+++ b/packages/core/src/utilities/coordinates/getRelativeTransformOrigin.ts
@@ -1,4 +1,5 @@
 import {getEventCoordinates, isKeyboardEvent} from '@dnd-kit/utilities';
+import type {ClientRect} from '../../types';
 
 export function getRelativeTransformOrigin(
   event: MouseEvent | TouchEvent | KeyboardEvent,

--- a/packages/core/src/utilities/index.ts
+++ b/packages/core/src/utilities/index.ts
@@ -8,14 +8,13 @@ export {
 } from './coordinates';
 
 export {
+  Rect,
   adjustScale,
   getAdjustedRect,
+  getClientRect,
+  getTransformAgnosticClientRect,
+  getWindowClientRect,
   getRectDelta,
-  getLayoutRect,
-  getViewportLayoutRect,
-  getBoundingClientRect,
-  getViewRect,
-  isViewRect,
 } from './rect';
 
 export {noop} from './other';

--- a/packages/core/src/utilities/rect/Rect.ts
+++ b/packages/core/src/utilities/rect/Rect.ts
@@ -1,0 +1,55 @@
+import type {ClientRect} from '../../types/rect';
+import {
+  getScrollableAncestors,
+  getScrollOffsets,
+  getScrollXOffset,
+  getScrollYOffset,
+} from '../scroll';
+
+const properties = [
+  ['x', ['left', 'right'], getScrollXOffset],
+  ['y', ['top', 'bottom'], getScrollYOffset],
+] as const;
+
+export class Rect {
+  constructor(rect: ClientRect, element: HTMLElement) {
+    const scrollableAncestors = getScrollableAncestors(element);
+    const scrollOffsets = getScrollOffsets(scrollableAncestors);
+
+    this.rect = {...rect};
+    this.width = rect.width;
+    this.height = rect.height;
+
+    for (const [axis, keys, getScrollOffset] of properties) {
+      for (const key of keys) {
+        Object.defineProperty(this, key, {
+          get: () => {
+            const currentOffsets = getScrollOffset(scrollableAncestors);
+            const scrollOffsetsDeltla = scrollOffsets[axis] - currentOffsets;
+
+            return this.rect[key] + scrollOffsetsDeltla;
+          },
+          enumerable: true,
+        });
+      }
+    }
+
+    Object.defineProperty(this, 'rect', {enumerable: false});
+  }
+
+  private rect: ClientRect;
+
+  public width: number;
+
+  public height: number;
+
+  // The below properties are set by the `Object.defineProperty` calls in the constructor
+  // @ts-ignore
+  public top: number;
+  // @ts-ignore
+  public bottom: number;
+  // @ts-ignore
+  public right: number;
+  // @ts-ignore
+  public left: number;
+}

--- a/packages/core/src/utilities/rect/adjustScale.ts
+++ b/packages/core/src/utilities/rect/adjustScale.ts
@@ -1,10 +1,10 @@
 import type {Transform} from '@dnd-kit/utilities';
-import type {LayoutRect} from '../../types';
+import type {ClientRect} from '../../types';
 
 export function adjustScale(
   transform: Transform,
-  rect1: LayoutRect | null,
-  rect2: LayoutRect | null
+  rect1: ClientRect | null,
+  rect2: ClientRect | null
 ): Transform {
   return {
     ...transform,

--- a/packages/core/src/utilities/rect/getRect.ts
+++ b/packages/core/src/utilities/rect/getRect.ts
@@ -1,112 +1,54 @@
-import {isHTMLElement, isWindow} from '@dnd-kit/utilities';
+import {getWindow} from '@dnd-kit/utilities';
 
-import type {Coordinates, ClientRect, LayoutRect, ViewRect} from '../../types';
-import {getScrollableAncestors, getScrollOffsets} from '../scroll';
-import {defaultCoordinates} from '../coordinates';
+import type {ClientRect} from '../../types';
+import {inverseTransform} from '../transform';
 
-function getEdgeOffset(
-  node: HTMLElement | null,
-  parent: (Node & ParentNode) | null,
-  offset = defaultCoordinates
-): Coordinates {
-  if (!node || !isHTMLElement(node)) {
-    return offset;
+interface Options {
+  ignoreTransform?: boolean;
+}
+
+const defaultOptions: Options = {ignoreTransform: false};
+
+/**
+ * Returns the bounding client rect of an element relative to the viewport.
+ */
+export function getClientRect(
+  element: HTMLElement,
+  options: Options = defaultOptions
+) {
+  let rect: ClientRect = element.getBoundingClientRect();
+
+  if (options.ignoreTransform) {
+    const {getComputedStyle} = getWindow(element);
+    const {transform, transformOrigin} = getComputedStyle(element);
+
+    if (transform) {
+      rect = inverseTransform(rect, transform, transformOrigin);
+    }
   }
 
-  const nodeOffset = {
-    x: offset.x + node.offsetLeft,
-    y: offset.y + node.offsetTop,
-  };
-
-  if (node.offsetParent === parent) {
-    return nodeOffset;
-  }
-
-  return getEdgeOffset(node.offsetParent as HTMLElement, parent, nodeOffset);
-}
-
-export function getLayoutRect(element: HTMLElement): LayoutRect {
-  const {offsetWidth: width, offsetHeight: height} = element;
-  const {x: offsetLeft, y: offsetTop} = getEdgeOffset(element, null);
+  const {top, left, width, height, bottom, right} = rect;
 
   return {
+    top,
+    left,
     width,
     height,
-    offsetTop,
-    offsetLeft,
+    bottom,
+    right,
   };
 }
 
-export function getViewportLayoutRect(element: HTMLElement): LayoutRect {
-  const {width, height, top, left} = element.getBoundingClientRect();
-  const scrollableAncestors = getScrollableAncestors(element);
-  const scrollOffsets = getScrollOffsets(scrollableAncestors);
-
-  return {
-    width,
-    height,
-    offsetTop: top + scrollOffsets.y,
-    offsetLeft: left + scrollOffsets.x,
-  };
-}
-
-export function getBoundingClientRect(
-  element: HTMLElement | typeof window
+/**
+ * Returns the bounding client rect of an element relative to the viewport.
+ *
+ * @remarks
+ * The ClientRect returned by this method does not take into account transforms
+ * applied to the element it measures.
+ *
+ */
+export function getTransformAgnosticClientRect(
+  element: HTMLElement
 ): ClientRect {
-  if (isWindow(element)) {
-    const width = window.innerWidth;
-    const height = window.innerHeight;
-
-    return {
-      top: 0,
-      left: 0,
-      right: width,
-      bottom: height,
-      width,
-      height,
-      offsetTop: 0,
-      offsetLeft: 0,
-    };
-  }
-
-  const {offsetTop, offsetLeft} = getLayoutRect(element);
-  const {
-    width,
-    height,
-    top,
-    bottom,
-    left,
-    right,
-  } = element.getBoundingClientRect();
-
-  return {
-    width,
-    height,
-    top,
-    bottom,
-    right,
-    left,
-    offsetTop,
-    offsetLeft,
-  };
-}
-
-export function getViewRect(element: HTMLElement): ViewRect {
-  const {width, height, offsetTop, offsetLeft} = getLayoutRect(element);
-  const scrollableAncestors = getScrollableAncestors(element);
-  const scrollOffsets = getScrollOffsets(scrollableAncestors);
-
-  const top = offsetTop - scrollOffsets.y;
-  const left = offsetLeft - scrollOffsets.x;
-
-  return {
-    width,
-    height,
-    top,
-    bottom: top + height,
-    right: left + width,
-    left,
-    offsetTop,
-    offsetLeft,
-  };
+  return getClientRect(element, {ignoreTransform: true});
 }

--- a/packages/core/src/utilities/rect/getRectDelta.ts
+++ b/packages/core/src/utilities/rect/getRectDelta.ts
@@ -1,9 +1,9 @@
-import type {Coordinates, ViewRect} from '../../types';
+import type {Coordinates, ClientRect} from '../../types';
 import {defaultCoordinates} from '../coordinates';
 
 export function getRectDelta(
-  rect1: ViewRect | null,
-  rect2: ViewRect | null
+  rect1: ClientRect | null,
+  rect2: ClientRect | null
 ): Coordinates {
   return rect1 && rect2
     ? {

--- a/packages/core/src/utilities/rect/getWindowClientRect.ts
+++ b/packages/core/src/utilities/rect/getWindowClientRect.ts
@@ -1,0 +1,15 @@
+import type {ClientRect} from '../../types';
+
+export function getWindowClientRect(element: typeof window): ClientRect {
+  const width = element.innerWidth;
+  const height = element.innerHeight;
+
+  return {
+    top: 0,
+    left: 0,
+    right: width,
+    bottom: height,
+    width,
+    height,
+  };
+}

--- a/packages/core/src/utilities/rect/index.ts
+++ b/packages/core/src/utilities/rect/index.ts
@@ -4,11 +4,8 @@ export {getRectDelta} from './getRectDelta';
 
 export {getAdjustedRect} from './rectAdjustment';
 
-export {
-  getBoundingClientRect,
-  getLayoutRect,
-  getViewportLayoutRect,
-  getViewRect,
-} from './getRect';
+export {getClientRect, getTransformAgnosticClientRect} from './getRect';
 
-export {isViewRect} from './isViewRect';
+export {getWindowClientRect} from './getWindowClientRect';
+
+export {Rect} from './Rect';

--- a/packages/core/src/utilities/rect/isViewRect.ts
+++ b/packages/core/src/utilities/rect/isViewRect.ts
@@ -1,5 +1,0 @@
-import type {LayoutRect, ViewRect} from '../../types';
-
-export function isViewRect(entry: LayoutRect | ViewRect): entry is ViewRect {
-  return 'top' in entry;
-}

--- a/packages/core/src/utilities/rect/rectAdjustment.ts
+++ b/packages/core/src/utilities/rect/rectAdjustment.ts
@@ -1,21 +1,19 @@
-import type {Coordinates, ViewRect} from '../../types';
+import type {Coordinates, ClientRect} from '../../types';
 
 export function createRectAdjustmentFn(modifier: number) {
-  return function adjustViewRect(
-    viewRect: ViewRect,
+  return function adjustClientRect(
+    rect: ClientRect,
     ...adjustments: Coordinates[]
-  ): ViewRect {
-    return adjustments.reduce<ViewRect>(
+  ): ClientRect {
+    return adjustments.reduce<ClientRect>(
       (acc, adjustment) => ({
         ...acc,
         top: acc.top + modifier * adjustment.y,
         bottom: acc.bottom + modifier * adjustment.y,
         left: acc.left + modifier * adjustment.x,
         right: acc.right + modifier * adjustment.x,
-        offsetLeft: acc.offsetLeft + modifier * adjustment.x,
-        offsetTop: acc.offsetTop + modifier * adjustment.y,
       }),
-      {...viewRect}
+      {...rect}
     );
   };
 }

--- a/packages/core/src/utilities/scroll/getScrollCoordinates.ts
+++ b/packages/core/src/utilities/scroll/getScrollCoordinates.ts
@@ -2,18 +2,27 @@ import {isWindow} from '@dnd-kit/utilities';
 
 import type {Coordinates} from '../../types';
 
+export function getScrollXCoordinate(element: Element | typeof window): number {
+  if (isWindow(element)) {
+    return element.scrollX;
+  }
+
+  return element.scrollLeft;
+}
+
+export function getScrollYCoordinate(element: Element | typeof window): number {
+  if (isWindow(element)) {
+    return element.scrollY;
+  }
+
+  return element.scrollTop;
+}
+
 export function getScrollCoordinates(
   element: Element | typeof window
 ): Coordinates {
-  if (isWindow(element)) {
-    return {
-      x: element.scrollX,
-      y: element.scrollY,
-    };
-  }
-
   return {
-    x: element.scrollLeft,
-    y: element.scrollTop,
+    x: getScrollXCoordinate(element),
+    y: getScrollYCoordinate(element),
   };
 }

--- a/packages/core/src/utilities/scroll/getScrollDirectionAndSpeed.ts
+++ b/packages/core/src/utilities/scroll/getScrollDirectionAndSpeed.ts
@@ -1,8 +1,9 @@
-import {Direction, ViewRect} from '../../types';
+import {Direction, ClientRect} from '../../types';
 import {getScrollPosition} from './getScrollPosition';
 import {isDocumentScrollingElement} from './documentScrollingElement';
 
-interface Rect extends Pick<ViewRect, 'top' | 'left' | 'right' | 'bottom'> {}
+interface PositionalCoordinates
+  extends Pick<ClientRect, 'top' | 'left' | 'right' | 'bottom'> {}
 
 const defaultThreshold = {
   x: 0.2,
@@ -11,8 +12,8 @@ const defaultThreshold = {
 
 export function getScrollDirectionAndSpeed(
   scrollContainer: Element,
-  scrollContainerRect: ViewRect,
-  {top, left, right, bottom}: Rect,
+  scrollContainerRect: ClientRect,
+  {top, left, right, bottom}: PositionalCoordinates,
   acceleration = 10,
   thresholdPercentage = defaultThreshold
 ) {

--- a/packages/core/src/utilities/scroll/getScrollOffsets.ts
+++ b/packages/core/src/utilities/scroll/getScrollOffsets.ts
@@ -1,11 +1,27 @@
 import {add} from '@dnd-kit/utilities';
 
 import type {Coordinates} from '../../types';
-import {getScrollCoordinates} from './getScrollCoordinates';
+import {
+  getScrollCoordinates,
+  getScrollXCoordinate,
+  getScrollYCoordinate,
+} from './getScrollCoordinates';
 import {defaultCoordinates} from '../coordinates';
 
 export function getScrollOffsets(scrollableAncestors: Element[]): Coordinates {
   return scrollableAncestors.reduce<Coordinates>((acc, node) => {
     return add(acc, getScrollCoordinates(node));
   }, defaultCoordinates);
+}
+
+export function getScrollXOffset(scrollableAncestors: Element[]): number {
+  return scrollableAncestors.reduce<number>((acc, node) => {
+    return acc + getScrollXCoordinate(node);
+  }, 0);
+}
+
+export function getScrollYOffset(scrollableAncestors: Element[]): number {
+  return scrollableAncestors.reduce<number>((acc, node) => {
+    return acc + getScrollYCoordinate(node);
+  }, 0);
 }

--- a/packages/core/src/utilities/scroll/getScrollableAncestors.ts
+++ b/packages/core/src/utilities/scroll/getScrollableAncestors.ts
@@ -1,4 +1,9 @@
-import {isDocument, isHTMLElement, isSVGElement} from '@dnd-kit/utilities';
+import {
+  getWindow,
+  isDocument,
+  isHTMLElement,
+  isSVGElement,
+} from '@dnd-kit/utilities';
 
 import {isFixed} from './isFixed';
 import {isScrollable} from './isScrollable';
@@ -29,10 +34,13 @@ export function getScrollableAncestors(element: Node | null): Element[] {
       return scrollParents;
     }
 
-    const computedStyle = window.getComputedStyle(node);
+    const {getComputedStyle} = getWindow(node);
+    const computedStyle = getComputedStyle(node);
 
-    if (isScrollable(node, computedStyle)) {
-      scrollParents.push(node);
+    if (node !== element) {
+      if (isScrollable(node, computedStyle)) {
+        scrollParents.push(node);
+      }
     }
 
     if (isFixed(node, computedStyle)) {
@@ -42,5 +50,9 @@ export function getScrollableAncestors(element: Node | null): Element[] {
     return findScrollableAncestors(node.parentNode);
   }
 
-  return element ? findScrollableAncestors(element.parentNode) : scrollParents;
+  if (!element) {
+    return scrollParents;
+  }
+
+  return findScrollableAncestors(element);
 }

--- a/packages/core/src/utilities/scroll/index.ts
+++ b/packages/core/src/utilities/scroll/index.ts
@@ -3,7 +3,11 @@ export {getScrollableElement} from './getScrollableElement';
 export {getScrollCoordinates} from './getScrollCoordinates';
 export {getScrollDirectionAndSpeed} from './getScrollDirectionAndSpeed';
 export {getScrollElementRect} from './getScrollElementRect';
-export {getScrollOffsets} from './getScrollOffsets';
+export {
+  getScrollOffsets,
+  getScrollXOffset,
+  getScrollYOffset,
+} from './getScrollOffsets';
 export {getScrollPosition} from './getScrollPosition';
 export {isDocumentScrollingElement} from './documentScrollingElement';
 export {isScrollable} from './isScrollable';

--- a/packages/core/src/utilities/scroll/isFixed.ts
+++ b/packages/core/src/utilities/scroll/isFixed.ts
@@ -1,6 +1,8 @@
+import {getWindow} from '@dnd-kit/utilities';
+
 export function isFixed(
   node: HTMLElement,
-  computedStyle: CSSStyleDeclaration = window.getComputedStyle(node)
+  computedStyle: CSSStyleDeclaration = getWindow(node).getComputedStyle(node)
 ): boolean {
   return computedStyle.position === 'fixed';
 }

--- a/packages/core/src/utilities/scroll/isScrollable.ts
+++ b/packages/core/src/utilities/scroll/isScrollable.ts
@@ -1,6 +1,10 @@
+import {getWindow} from '@dnd-kit/utilities';
+
 export function isScrollable(
-  node: HTMLElement,
-  computedStyle: CSSStyleDeclaration = window.getComputedStyle(node)
+  element: HTMLElement,
+  computedStyle: CSSStyleDeclaration = getWindow(element).getComputedStyle(
+    element
+  )
 ): boolean {
   const overflowRegex = /(auto|scroll|overlay)/;
   const properties = ['overflow', 'overflowX', 'overflowY'];

--- a/packages/core/src/utilities/transform/index.ts
+++ b/packages/core/src/utilities/transform/index.ts
@@ -1,0 +1,1 @@
+export {inverseTransform} from './inverseTransform';

--- a/packages/core/src/utilities/transform/inverseTransform.ts
+++ b/packages/core/src/utilities/transform/inverseTransform.ts
@@ -1,0 +1,43 @@
+import type {ClientRect} from '../../types';
+
+export function inverseTransform(
+  rect: ClientRect,
+  transform: string,
+  transformOrigin: string
+): ClientRect {
+  let ta, sx, sy, dx, dy;
+
+  if (transform.startsWith('matrix3d(')) {
+    ta = transform.slice(9, -1).split(/, /);
+    sx = +ta[0];
+    sy = +ta[5];
+    dx = +ta[12];
+    dy = +ta[13];
+  } else if (transform.startsWith('matrix(')) {
+    ta = transform.slice(7, -1).split(/, /);
+    sx = +ta[0];
+    sy = +ta[3];
+    dx = +ta[4];
+    dy = +ta[5];
+  } else {
+    return rect;
+  }
+
+  const x = rect.left - dx - (1 - sx) * parseFloat(transformOrigin);
+  const y =
+    rect.top -
+    dy -
+    (1 - sy) *
+      parseFloat(transformOrigin.slice(transformOrigin.indexOf(' ') + 1));
+  const w = sx ? rect.width / sx : rect.width;
+  const h = sy ? rect.height / sy : rect.height;
+
+  return {
+    width: w,
+    height: h,
+    top: y,
+    right: x + w,
+    bottom: y + h,
+    left: x,
+  };
+}

--- a/packages/modifiers/src/utilities/restrictToBoundingRect.ts
+++ b/packages/modifiers/src/utilities/restrictToBoundingRect.ts
@@ -1,10 +1,10 @@
-import type {ViewRect} from '@dnd-kit/core';
+import type {ClientRect} from '@dnd-kit/core';
 import type {Transform} from '@dnd-kit/utilities';
 
 export function restrictToBoundingRect(
   transform: Transform,
-  rect: ViewRect,
-  boundingRect: ViewRect
+  rect: ClientRect,
+  boundingRect: ClientRect
 ): Transform {
   const value = {
     ...transform,

--- a/packages/modifiers/test/modifiers.test.tsx
+++ b/packages/modifiers/test/modifiers.test.tsx
@@ -1,18 +1,16 @@
-import type {Modifier, ViewRect} from '@dnd-kit/core';
+import type {Modifier, ClientRect} from '@dnd-kit/core';
 import type {FirstArgument, Transform} from '@dnd-kit/utilities';
 
 import {restrictToHorizontalAxis, restrictToVerticalAxis} from '../src';
 
 describe('@dnd-kit/modifiers', () => {
-  const defaultRect: ViewRect = {
+  const defaultRect: ClientRect = {
     left: 0,
     right: 0,
     top: 0,
     bottom: 0,
     width: 0,
     height: 0,
-    offsetLeft: 0,
-    offsetTop: 0,
   };
   const defaultTransform: Transform = {
     x: 0,

--- a/packages/sortable/src/components/SortableContext.tsx
+++ b/packages/sortable/src/components/SortableContext.tsx
@@ -1,5 +1,5 @@
 import React, {MutableRefObject, useEffect, useMemo, useRef} from 'react';
-import {useDndContext, LayoutRect, UniqueIdentifier} from '@dnd-kit/core';
+import {useDndContext, ClientRect, UniqueIdentifier} from '@dnd-kit/core';
 import {useIsomorphicLayoutEffect, useUniqueId} from '@dnd-kit/utilities';
 
 import type {SortingStrategy} from '../types';
@@ -22,7 +22,7 @@ interface ContextDescriptor {
   items: UniqueIdentifier[];
   overIndex: number;
   useDragOverlay: boolean;
-  sortedRects: LayoutRect[];
+  sortedRects: ClientRect[];
   strategy: SortingStrategy;
   wasDragging: MutableRefObject<boolean>;
 }

--- a/packages/sortable/src/hooks/useSortable.ts
+++ b/packages/sortable/src/hooks/useSortable.ts
@@ -91,7 +91,7 @@ export function useSortable({
   const finalTransform = displaceItem
     ? dragSourceDisplacement ??
       strategy({
-        layoutRects: sortedRects,
+        rects: sortedRects,
         activeNodeRect,
         activeIndex,
         overIndex,

--- a/packages/sortable/src/hooks/utilities/useDerivedTransform.ts
+++ b/packages/sortable/src/hooks/utilities/useDerivedTransform.ts
@@ -1,9 +1,9 @@
 import {useEffect, useRef, useState} from 'react';
-import {getBoundingClientRect, LayoutRect} from '@dnd-kit/core';
+import {getClientRect, ClientRect} from '@dnd-kit/core';
 import {Transform, useIsomorphicLayoutEffect} from '@dnd-kit/utilities';
 
 interface Arguments {
-  rect: React.MutableRefObject<LayoutRect | null>;
+  rect: React.MutableRefObject<ClientRect | null>;
   disabled: boolean;
   index: number;
   node: React.MutableRefObject<HTMLElement | null>;
@@ -24,11 +24,13 @@ export function useDerivedTransform({disabled, index, node, rect}: Arguments) {
       const initial = rect.current;
 
       if (initial) {
-        const current = getBoundingClientRect(node.current);
+        const current = getClientRect(node.current, {
+          ignoreTransform: true,
+        });
 
         const delta = {
-          x: initial.offsetLeft - current.offsetLeft,
-          y: initial.offsetTop - current.offsetTop,
+          x: initial.left - current.left,
+          y: initial.top - current.top,
           scaleX: initial.width / current.width,
           scaleY: initial.height / current.height,
         };

--- a/packages/sortable/src/strategies/horizontalListSorting.ts
+++ b/packages/sortable/src/strategies/horizontalListSorting.ts
@@ -1,4 +1,4 @@
-import type {LayoutRect} from '@dnd-kit/core';
+import type {ClientRect} from '@dnd-kit/core';
 import type {SortingStrategy} from '../types';
 
 // To-do: We should be calculating scale transformation
@@ -8,22 +8,22 @@ const defaultScale = {
 };
 
 export const horizontalListSortingStrategy: SortingStrategy = ({
-  layoutRects,
+  rects,
   activeNodeRect: fallbackActiveRect,
   activeIndex,
   overIndex,
   index,
 }) => {
-  const activeNodeRect = layoutRects[activeIndex] ?? fallbackActiveRect;
+  const activeNodeRect = rects[activeIndex] ?? fallbackActiveRect;
 
   if (!activeNodeRect) {
     return null;
   }
 
-  const itemGap = getItemGap(layoutRects, index, activeIndex);
+  const itemGap = getItemGap(rects, index, activeIndex);
 
   if (index === activeIndex) {
-    const newIndexRect = layoutRects[overIndex];
+    const newIndexRect = rects[overIndex];
 
     if (!newIndexRect) {
       return null;
@@ -32,10 +32,10 @@ export const horizontalListSortingStrategy: SortingStrategy = ({
     return {
       x:
         activeIndex < overIndex
-          ? newIndexRect.offsetLeft +
+          ? newIndexRect.left +
             newIndexRect.width -
-            (activeNodeRect.offsetLeft + activeNodeRect.width)
-          : newIndexRect.offsetLeft - activeNodeRect.offsetLeft,
+            (activeNodeRect.left + activeNodeRect.width)
+          : newIndexRect.left - activeNodeRect.left,
       y: 0,
       ...defaultScale,
     };
@@ -64,14 +64,10 @@ export const horizontalListSortingStrategy: SortingStrategy = ({
   };
 };
 
-function getItemGap(
-  layoutRects: LayoutRect[],
-  index: number,
-  activeIndex: number
-) {
-  const currentRect: LayoutRect | undefined = layoutRects[index];
-  const previousRect: LayoutRect | undefined = layoutRects[index - 1];
-  const nextRect: LayoutRect | undefined = layoutRects[index + 1];
+function getItemGap(rects: ClientRect[], index: number, activeIndex: number) {
+  const currentRect: ClientRect | undefined = rects[index];
+  const previousRect: ClientRect | undefined = rects[index - 1];
+  const nextRect: ClientRect | undefined = rects[index + 1];
 
   if (!currentRect || (!previousRect && !nextRect)) {
     return 0;
@@ -79,11 +75,11 @@ function getItemGap(
 
   if (activeIndex < index) {
     return previousRect
-      ? currentRect.offsetLeft - (previousRect.offsetLeft + previousRect.width)
-      : nextRect.offsetLeft - (currentRect.offsetLeft + currentRect.width);
+      ? currentRect.left - (previousRect.left + previousRect.width)
+      : nextRect.left - (currentRect.left + currentRect.width);
   }
 
   return nextRect
-    ? nextRect.offsetLeft - (currentRect.offsetLeft + currentRect.width)
-    : currentRect.offsetLeft - (previousRect.offsetLeft + previousRect.width);
+    ? nextRect.left - (currentRect.left + currentRect.width)
+    : currentRect.left - (previousRect.left + previousRect.width);
 }

--- a/packages/sortable/src/strategies/rectSorting.ts
+++ b/packages/sortable/src/strategies/rectSorting.ts
@@ -2,14 +2,14 @@ import {arrayMove} from '../utilities';
 import type {SortingStrategy} from '../types';
 
 export const rectSortingStrategy: SortingStrategy = ({
-  layoutRects,
+  rects,
   activeIndex,
   overIndex,
   index,
 }) => {
-  const newRects = arrayMove(layoutRects, overIndex, activeIndex);
+  const newRects = arrayMove(rects, overIndex, activeIndex);
 
-  const oldRect = layoutRects[index];
+  const oldRect = rects[index];
   const newRect = newRects[index];
 
   if (!newRect || !oldRect) {
@@ -17,8 +17,8 @@ export const rectSortingStrategy: SortingStrategy = ({
   }
 
   return {
-    x: newRect.offsetLeft - oldRect.offsetLeft,
-    y: newRect.offsetTop - oldRect.offsetTop,
+    x: newRect.left - oldRect.left,
+    y: newRect.top - oldRect.top,
     scaleX: newRect.width / oldRect.width,
     scaleY: newRect.height / oldRect.height,
   };

--- a/packages/sortable/src/strategies/rectSwapping.ts
+++ b/packages/sortable/src/strategies/rectSwapping.ts
@@ -3,20 +3,20 @@ import type {SortingStrategy} from '../types';
 export const rectSwappingStrategy: SortingStrategy = ({
   activeIndex,
   index,
-  layoutRects,
+  rects,
   overIndex,
 }) => {
   let oldRect;
   let newRect;
 
   if (index === activeIndex) {
-    oldRect = layoutRects[index];
-    newRect = layoutRects[overIndex];
+    oldRect = rects[index];
+    newRect = rects[overIndex];
   }
 
   if (index === overIndex) {
-    oldRect = layoutRects[index];
-    newRect = layoutRects[activeIndex];
+    oldRect = rects[index];
+    newRect = rects[activeIndex];
   }
 
   if (!newRect || !oldRect) {
@@ -24,8 +24,8 @@ export const rectSwappingStrategy: SortingStrategy = ({
   }
 
   return {
-    x: newRect.offsetLeft - oldRect.offsetLeft,
-    y: newRect.offsetTop - oldRect.offsetTop,
+    x: newRect.left - oldRect.left,
+    y: newRect.top - oldRect.top,
     scaleX: newRect.width / oldRect.width,
     scaleY: newRect.height / oldRect.height,
   };

--- a/packages/sortable/src/strategies/verticalListSorting.ts
+++ b/packages/sortable/src/strategies/verticalListSorting.ts
@@ -1,4 +1,4 @@
-import type {LayoutRect} from '@dnd-kit/core';
+import type {ClientRect} from '@dnd-kit/core';
 import type {SortingStrategy} from '../types';
 
 // To-do: We should be calculating scale transformation
@@ -11,17 +11,17 @@ export const verticalListSortingStrategy: SortingStrategy = ({
   activeIndex,
   activeNodeRect: fallbackActiveRect,
   index,
-  layoutRects,
+  rects,
   overIndex,
 }) => {
-  const activeNodeRect = layoutRects[activeIndex] ?? fallbackActiveRect;
+  const activeNodeRect = rects[activeIndex] ?? fallbackActiveRect;
 
   if (!activeNodeRect) {
     return null;
   }
 
   if (index === activeIndex) {
-    const overIndexRect = layoutRects[overIndex];
+    const overIndexRect = rects[overIndex];
 
     if (!overIndexRect) {
       return null;
@@ -31,15 +31,15 @@ export const verticalListSortingStrategy: SortingStrategy = ({
       x: 0,
       y:
         activeIndex < overIndex
-          ? overIndexRect.offsetTop +
+          ? overIndexRect.top +
             overIndexRect.height -
-            (activeNodeRect.offsetTop + activeNodeRect.height)
-          : overIndexRect.offsetTop - activeNodeRect.offsetTop,
+            (activeNodeRect.top + activeNodeRect.height)
+          : overIndexRect.top - activeNodeRect.top,
       ...defaultScale,
     };
   }
 
-  const itemGap = getItemGap(layoutRects, index, activeIndex);
+  const itemGap = getItemGap(rects, index, activeIndex);
 
   if (index > activeIndex && index <= overIndex) {
     return {
@@ -65,13 +65,13 @@ export const verticalListSortingStrategy: SortingStrategy = ({
 };
 
 function getItemGap(
-  layoutRects: LayoutRect[],
+  clientRects: ClientRect[],
   index: number,
   activeIndex: number
 ) {
-  const currentRect: LayoutRect | undefined = layoutRects[index];
-  const previousRect: LayoutRect | undefined = layoutRects[index - 1];
-  const nextRect: LayoutRect | undefined = layoutRects[index + 1];
+  const currentRect: ClientRect | undefined = clientRects[index];
+  const previousRect: ClientRect | undefined = clientRects[index - 1];
+  const nextRect: ClientRect | undefined = clientRects[index + 1];
 
   if (!currentRect) {
     return 0;
@@ -79,15 +79,15 @@ function getItemGap(
 
   if (activeIndex < index) {
     return previousRect
-      ? currentRect.offsetTop - (previousRect.offsetTop + previousRect.height)
+      ? currentRect.top - (previousRect.top + previousRect.height)
       : nextRect
-      ? nextRect.offsetTop - (currentRect.offsetTop + currentRect.height)
+      ? nextRect.top - (currentRect.top + currentRect.height)
       : 0;
   }
 
   return nextRect
-    ? nextRect.offsetTop - (currentRect.offsetTop + currentRect.height)
+    ? nextRect.top - (currentRect.top + currentRect.height)
     : previousRect
-    ? currentRect.offsetTop - (previousRect.offsetTop + previousRect.height)
+    ? currentRect.top - (previousRect.top + previousRect.height)
     : 0;
 }

--- a/packages/sortable/src/types/index.ts
+++ b/packages/sortable/src/types/index.ts
@@ -1,10 +1,10 @@
-import type {LayoutRect, ViewRect} from '@dnd-kit/core';
+import type {ClientRect} from '@dnd-kit/core';
 import type {Transform} from '@dnd-kit/utilities';
 
 export type SortingStrategy = (args: {
-  activeNodeRect: ViewRect | null;
+  activeNodeRect: ClientRect | null;
   activeIndex: number;
   index: number;
-  layoutRects: LayoutRect[];
+  rects: ClientRect[];
   overIndex: number;
 }) => Transform | null;

--- a/packages/sortable/src/utilities/getSortedRects.ts
+++ b/packages/sortable/src/utilities/getSortedRects.ts
@@ -1,18 +1,18 @@
 import type {
-  LayoutRect,
+  ClientRect,
   UniqueIdentifier,
   UseDndContextReturnValue,
 } from '@dnd-kit/core';
 
 export function getSortedRects(
   items: UniqueIdentifier[],
-  layoutRects: UseDndContextReturnValue['droppableRects']
+  rects: UseDndContextReturnValue['droppableRects']
 ) {
-  return items.reduce<LayoutRect[]>((accumulator, id, index) => {
-    const layoutRect = layoutRects.get(id);
+  return items.reduce<ClientRect[]>((accumulator, id, index) => {
+    const rect = rects.get(id);
 
-    if (layoutRect) {
-      accumulator[index] = layoutRect;
+    if (rect) {
+      accumulator[index] = rect;
     }
 
     return accumulator;

--- a/packages/utilities/src/hooks/useNodeRef.ts
+++ b/packages/utilities/src/hooks/useNodeRef.ts
@@ -1,10 +1,14 @@
 import {useRef, useCallback} from 'react';
 
-export function useNodeRef() {
+export function useNodeRef(onChange?: (element: HTMLElement | null) => void) {
   const node = useRef<HTMLElement | null>(null);
-  const setNodeRef = useCallback((element: HTMLElement | null) => {
-    node.current = element;
-  }, []);
+  const setNodeRef = useCallback(
+    (element: HTMLElement | null) => {
+      node.current = element;
+      onChange?.(element);
+    },
+    [onChange]
+  );
 
   return [node, setNodeRef] as const;
 }

--- a/stories/2 - Presets/Sortable/1-Vertical.story.tsx
+++ b/stories/2 - Presets/Sortable/1-Vertical.story.tsx
@@ -163,3 +163,9 @@ export const RemovableItems = () => {
     />
   );
 };
+
+export const TransformedContainer = () => {
+  return (
+    <Sortable {...props} style={{transform: 'translate3d(100px, 100px, 0)'}} />
+  );
+};

--- a/stories/2 - Presets/Sortable/5-Virtualized.story.tsx
+++ b/stories/2 - Presets/Sortable/5-Virtualized.story.tsx
@@ -77,6 +77,7 @@ function Sortable({
             className={styles.VirtualList}
             itemCount={items.length}
             itemSize={64}
+            stickyIndices={activeId ? [items.indexOf(activeId)] : undefined}
             renderItem={({index, style}) => {
               const id = items[index];
 
@@ -88,10 +89,10 @@ function Sortable({
                   handle={handle}
                   wrapperStyle={() => ({
                     ...style,
-                    opacity: id === activeId ? 0 : undefined,
                     padding: 5,
                   })}
                   style={getItemStyles}
+                  useDragOverlay
                 />
               );
             }}

--- a/stories/2 - Presets/Sortable/MultipleContainers.tsx
+++ b/stories/2 - Presets/Sortable/MultipleContainers.tsx
@@ -314,8 +314,8 @@ export function MultipleContainers({
               const isBelowOverItem =
                 over &&
                 active.rect.current.translated &&
-                active.rect.current.translated.offsetTop >
-                  over.rect.offsetTop + over.rect.height;
+                active.rect.current.translated.top >
+                  over.rect.top + over.rect.height;
 
               const modifier = isBelowOverItem ? 1 : 0;
 

--- a/stories/2 - Presets/Sortable/Sortable.tsx
+++ b/stories/2 - Presets/Sortable/Sortable.tsx
@@ -51,6 +51,7 @@ export interface Props {
   removable?: boolean;
   reorderItems?: typeof arrayMove;
   strategy?: SortingStrategy;
+  style?: React.CSSProperties;
   useDragOverlay?: boolean;
   getItemStyles?(args: {
     id: UniqueIdentifier;
@@ -100,6 +101,7 @@ export function Sortable({
   renderItem,
   reorderItems = arrayMove,
   strategy = rectSortingStrategy,
+  style,
   useDragOverlay = true,
   wrapperStyle = () => ({}),
 }: Props) {
@@ -199,7 +201,7 @@ export function Sortable({
       measuring={measuring}
       modifiers={modifiers}
     >
-      <Wrapper center>
+      <Wrapper style={style} center>
         <SortableContext items={items} strategy={strategy}>
           <Container>
             {items.map((value, index) => (

--- a/stories/3 - Examples/FormElements/Switch/Switch.tsx
+++ b/stories/3 - Examples/FormElements/Switch/Switch.tsx
@@ -3,7 +3,7 @@ import {
   DndContext,
   DragEndEvent,
   DragOverEvent,
-  getBoundingClientRect,
+  getClientRect,
   MeasuringConfiguration,
   PointerSensor,
   useSensor,
@@ -32,7 +32,7 @@ export interface Props {
 const modifiers = [restrictToParentElement, restrictToHorizontalAxis];
 const measuring: MeasuringConfiguration = {
   draggable: {
-    measure: getBoundingClientRect,
+    measure: getClientRect,
   },
 };
 

--- a/stories/3 - Examples/Games/PlayingCards/PlayingCard/PlayingCard.module.css
+++ b/stories/3 - Examples/Games/PlayingCards/PlayingCard/PlayingCard.module.css
@@ -3,10 +3,9 @@ $box-shadow: 1px 1px 0 1px #f9f9fb, -1px 0 28px 0 rgba(34, 33, 81, 0.01),
 
 .Wrapper {
   position: relative;
-  width: 1px;
+  width: 140px;
   height: 180px;
   margin-bottom: -145px;
-  transform: translate3d(0, var(--translate-y, 0), 0);
 }
 
 .PlayingCard {
@@ -22,9 +21,9 @@ $box-shadow: 1px 1px 0 1px #f9f9fb, -1px 0 28px 0 rgba(34, 33, 81, 0.01),
   font-family: 'Roboto Slab', Helvetica, sans-serif;
   user-select: none;
   transform-origin: 0 0;
-  transform: scale(var(--scale, 1)) translate3d(var(--translate-x, 0), 0, 0)
+  transform: scale(var(--scale, 1)) translate3d(var(--translate-x, 0), var(--translate-y, 0), 0)
     rotateX(60deg) rotateZ(33deg);
-  transition: transform 250ms ease;
+  transition: var(--transition, transform 250ms ease);
 
   &:hover:not(.pickedUp) {
     --translate-x: 5px;
@@ -50,7 +49,8 @@ $box-shadow: 1px 1px 0 1px #f9f9fb, -1px 0 28px 0 rgba(34, 33, 81, 0.01),
   }
 
   &.pickedUp {
-    margin-left: 0;
+    --translate-x: 15px;
+
     opacity: 0.95;
     animation: pop-transform 250ms cubic-bezier(0.18, 0.67, 0.6, 1.22);
     transition: box-shadow 250ms ease;
@@ -99,12 +99,12 @@ sub {
 
 @keyframes pop-transform {
   0% {
-    transform: scale(1) rotateX(60deg) rotateZ(33deg);
+    transform: scale(1) translate3d(var(--translate-x, 0), 0, 0) rotateX(60deg) rotateZ(33deg);
     box-shadow: 1px 1px 0 1px #f9f9fb, -1px 0 28px 0 rgba(34, 33, 81, 0.01),
       28px 28px 28px 0 rgba(34, 33, 81, 0.25);
   }
   100% {
-    transform: scale(1.075) rotateX(60deg) rotateZ(33deg);
+    transform: scale(1.075) translate3d(var(--translate-x, 0), 0, 0) rotateX(60deg) rotateZ(33deg);
     box-shadow: $box-shadow;
   }
 }

--- a/stories/3 - Examples/Games/PlayingCards/PlayingCard/PlayingCard.tsx
+++ b/stories/3 - Examples/Games/PlayingCards/PlayingCard/PlayingCard.tsx
@@ -45,8 +45,8 @@ export const PlayingCard = forwardRef<HTMLDivElement, Props>(
           {
             '--translate-y': transform ? `${transform.y}px` : undefined,
             '--index': index,
+            '--transition': transition,
             zIndex: style?.zIndex,
-            transition,
           } as React.CSSProperties
         }
       >

--- a/stories/3 - Examples/Tree/SortableTree.tsx
+++ b/stories/3 - Examples/Tree/SortableTree.tsx
@@ -13,7 +13,6 @@ import {
   DragMoveEvent,
   DragEndEvent,
   DragOverEvent,
-  Measuring,
   MeasuringStrategy,
   DropAnimation,
   defaultDropAnimation,
@@ -173,7 +172,6 @@ export function SortableTree({
     <DndContext
       announcements={announcements}
       sensors={sensors}
-      modifiers={indicator ? [adjustTranslate] : undefined}
       collisionDetection={closestCenter}
       measuring={measuring}
       onDragStart={handleDragStart}
@@ -201,7 +199,10 @@ export function SortableTree({
           />
         ))}
         {createPortal(
-          <DragOverlay dropAnimation={dropAnimation}>
+          <DragOverlay
+            dropAnimation={dropAnimation}
+            modifiers={indicator ? [adjustTranslate] : undefined}
+          >
             {activeId && activeItem ? (
               <TreeItem
                 depth={activeItem.depth}
@@ -283,7 +284,6 @@ export function SortableTree({
   function handleCollapse(id: string) {
     setItems((items) =>
       setProperty(items, id, 'collapsed', (value) => {
-        console.log(value);
         return !value;
       })
     );

--- a/stories/3 - Examples/Tree/components/TreeItem/TreeItem.module.css
+++ b/stories/3 - Examples/Tree/components/TreeItem/TreeItem.module.css
@@ -7,7 +7,8 @@
   &.clone {
     display: inline-block;
     pointer-events: none;
-    padding: 5px;
+    padding: 0;
+    margin-left: 10px;
 
     .TreeItem {
       --vertical-padding: 5px;


### PR DESCRIPTION
This PR reduces the number of concepts related to measuring from `ViewRect`, `LayoutRect` to just a single concept of `ClientRect`.

Previously, all collision detection algorithms were relative to the top and left points of the document. While this approach worked in most situations, it broke down in a number of different use-cases: #43, #73, #98, #263, #325, #483, etc.

This new approach changes the frame of comparison to be relative to the viewport. This is a major breaking change, and will need to be released under a new major version bump.

This PR also introduces a changed approach to measuring the `ClientRect` of draggable and droppable elements. Previously, the `offsetTop` and `offsetLeft` properties of an element and all of its positioned ancestors were used to compute the rect that was used for collision detection. This approach had a number of limitations however, and failed when the draggable or droppable elements were positioned within transformed elements (since `offsetTop` and `offsetLeft` properties do not take into account transforms): #464 

By default, @dnd-kit now ignores only the `transforms` applied to the draggable / droppable node itself, but considers all the transforms applied to its ancestors. This should provide the right balance of flexibility for most consumers. 

Transforms applied to the droppable and draggable nodes are ignored by default, because the recommended approach for moving items on the screen is to use the `transform` property, which can interfere with the calculation of collisions. 

Consumers can choose an alternate approach that does consider transforms for specific use-cases if needed by configuring the `measuring` prop of `<DndContext>`. Refer to the `<Switch>` example.