### PR TITLE
fix: correctly check whether an element is a window in electron context

### DIFF
--- a/.changeset/fix-electron-window.md
+++ b/.changeset/fix-electron-window.md
@@ -1,0 +1,5 @@
+---
+"@dnd-kit/utilities": patch
+---
+
+fix: `isWindow` has been updated to support checking wether an element is a window object in Electron applications.

--- a/packages/utilities/src/type-guards/isWindow.ts
+++ b/packages/utilities/src/type-guards/isWindow.ts
@@ -1,3 +1,8 @@
 export function isWindow(element: Object): element is typeof window {
-  return Object.prototype.toString.call(element) === '[object Window]';
+  const elementString = Object.prototype.toString.call(element);
+  return (
+    elementString === '[object Window]' ||
+    // In Electron context the Window object serializes to [object global]
+    elementString === '[object global]'
+  );
 }


### PR DESCRIPTION
Fixes https://github.com/clauderic/dnd-kit/issues/540

This PR just adds a check in the isWindow function to make sure the window object is correctly checked in an Electron context.