### PR TITLE
fix: Make isWindow work for electron

### DIFF
--- a/packages/utilities/src/type-guards/isWindow.ts
+++ b/packages/utilities/src/type-guards/isWindow.ts
@@ -1,3 +1,4 @@
 export function isWindow(element: Object): element is typeof window {
-  return Object.prototype.toString.call(element) === '[object Window]';
+  let str = Object.prototype.toString.call(element)
+  return str === '[object Window]' || str === '[object global]';
 }


### PR DESCRIPTION
Updates the `isWindow` check to also pass for Electron window objects.

Closes #540