### PR TITLE
Add pointer coordinates to collision detection

### DIFF
--- a/.changeset/pointer-within-algorithm.md
+++ b/.changeset/pointer-within-algorithm.md
@@ -1,0 +1,6 @@
+---
+'@dnd-kit/core': minor
+---
+
+- Added pointer coordinates to collision detection
+- Added `pointerWithin` collision algorithm

--- a/packages/core/src/components/DndContext/DndContext.tsx
+++ b/packages/core/src/components/DndContext/DndContext.tsx
@@ -288,6 +288,7 @@ export const DndContext = memo(function DndContext({
           active,
           collisionRect,
           droppableContainers: enabledDroppableContainers,
+          pointerCoordinates,
         })
       : null;
   const [over, setOver] = useState<Over | null>(null);

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -98,5 +98,6 @@ export {
   closestCenter,
   closestCorners,
   rectIntersection,
+  pointerWithin,
 } from './utilities';
 export type {CollisionDetection} from './utilities';

--- a/packages/core/src/utilities/algorithms/index.ts
+++ b/packages/core/src/utilities/algorithms/index.ts
@@ -1,4 +1,5 @@
 export {closestCenter} from './closestCenter';
 export {closestCorners} from './closestCorners';
 export {rectIntersection} from './rectIntersection';
+export {pointerWithin} from './pointerWithin';
 export type {CollisionDetection} from './types';

--- a/packages/core/src/utilities/algorithms/pointerWithin.ts
+++ b/packages/core/src/utilities/algorithms/pointerWithin.ts
@@ -1,0 +1,41 @@
+import type {Coordinates, ClientRect} from '../../types';
+import type {CollisionDetection} from './types';
+
+/**
+ * check if the given point is within the rectangle
+ */
+function isPointerInside(
+  entry: ClientRect,
+  pointerCoordinates: Coordinates
+): boolean {
+  const {top, left, bottom, right} = entry;
+
+  return (
+    top <= pointerCoordinates.y &&
+    pointerCoordinates.y <= bottom &&
+    left <= pointerCoordinates.x &&
+    pointerCoordinates.x <= right
+  );
+}
+
+/**
+ * Returns the rectangle that the pointer is hovering over
+ */
+export const pointerWithin: CollisionDetection = ({
+  droppableContainers,
+  pointerCoordinates,
+}) => {
+  if (!pointerCoordinates) return null;
+
+  for (const droppableContainer of droppableContainers) {
+    const {
+      rect: {current: rect},
+    } = droppableContainer;
+
+    if (rect && isPointerInside(rect, pointerCoordinates)) {
+      return droppableContainer.id;
+    }
+  }
+
+  return null;
+};

--- a/packages/core/src/utilities/algorithms/types.ts
+++ b/packages/core/src/utilities/algorithms/types.ts
@@ -1,8 +1,9 @@
 import type {Active, DroppableContainer} from '../../store';
-import type {UniqueIdentifier, ClientRect} from '../../types';
+import type {Coordinates, ClientRect, UniqueIdentifier} from '../../types';
 
 export type CollisionDetection = (args: {
   active: Active;
   collisionRect: ClientRect;
   droppableContainers: DroppableContainer[];
+  pointerCoordinates: Coordinates | null;
 }) => UniqueIdentifier | null;

--- a/packages/core/src/utilities/index.ts
+++ b/packages/core/src/utilities/index.ts
@@ -1,4 +1,9 @@
-export {closestCenter, closestCorners, rectIntersection} from './algorithms';
+export {
+  closestCenter,
+  closestCorners,
+  rectIntersection,
+  pointerWithin,
+} from './algorithms';
 export type {CollisionDetection} from './algorithms';
 
 export {

--- a/packages/sortable/src/sensors/keyboard/sortableKeyboardCoordinates.ts
+++ b/packages/sortable/src/sensors/keyboard/sortableKeyboardCoordinates.ts
@@ -65,6 +65,7 @@ export const sortableKeyboardCoordinates: KeyboardCoordinateGetter = (
       active,
       collisionRect: collisionRect,
       droppableContainers: filteredContainers,
+      pointerCoordinates: null,
     });
 
     if (closestId) {

--- a/stories/1 - Core/Droppable/Droppable.story.tsx
+++ b/stories/1 - Core/Droppable/Droppable.story.tsx
@@ -3,6 +3,7 @@ import {
   closestCenter,
   closestCorners,
   rectIntersection,
+  pointerWithin,
   DndContext,
   DragOverlay,
   useDraggable,
@@ -145,6 +146,17 @@ export const CollisionDetectionAlgorithms = () => {
             }
           />
           Closest Corners
+        </label>
+        <label>
+          <input
+            type="radio"
+            value="pointerWithin"
+            checked={algorithm === pointerWithin}
+            onClick={() =>
+              setCollisionDetectionAlgorithm({algorithm: pointerWithin})
+            }
+          />
+          Pointer Within
         </label>
       </div>
     </>


### PR DESCRIPTION
- added the current pointer coordinates to the collision detection feature
- implemented a `pointerWithin` collision algorithm (incl. Storybook)

With pointer coordinates, a droppable beneath the pointer can be detected for collision instead of relying only on the rectangles. In some cases this can be useful for more precice detection.

Consider use cases like a file explorer. The pointer is how for example Google Drive detects if a dragged item is above a droppable.