### PR TITLE
Refactor `CollisionDetection` to return an array of `Collision`s

### DIFF
--- a/.changeset/array-of-collisions.md
+++ b/.changeset/array-of-collisions.md
@@ -1,12 +1,15 @@
 ---
-"@dnd-kit/core": major
-"@dnd-kit/sortable": minor
+'@dnd-kit/core': major
+'@dnd-kit/sortable': minor
 ---
 
 Refactor of the `CollisionDetection` interface to return an array of `Collision`s:
 
 ```diff
-+export type Collision = [UniqueIdentifier, number];
++export interface Collision {
++  id: UniqueIdentifier;
++  data?: Record<string, any>;
++}
 
 export type CollisionDetection = (args: {
   active: Active;

--- a/.changeset/array-of-collisions.md
+++ b/.changeset/array-of-collisions.md
@@ -1,0 +1,26 @@
+---
+"@dnd-kit/core": major
+"@dnd-kit/sortable": minor
+---
+
+Refactor of the `CollisionDetection` interface to return an array of `Collision`s:
+
+```diff
++export type Collision = [UniqueIdentifier, number];
+
+export type CollisionDetection = (args: {
+  active: Active;
+  collisionRect: ClientRect;
+  droppableContainers: DroppableContainer[];
+  pointerCoordinates: Coordinates | null;
+-}) => UniqueIdentifier;
++}) => Collision[];
+```
+
+This is a breaking change that requires all collision detection strategies to be updated to return an array of `Collision` rather than a single `UniqueIdentifier`
+
+The `over` property remains a single `UniqueIdentifier`, and is set to the first item in returned in the collisions array.
+
+Consumers can also access the `collisions` property which can be used to implement use-cases such as combining droppables in user-land.
+
+The `onDragMove`, `onDragOver` and `onDragEnd` callbacks are also updated to receive the collisions array property.

--- a/.changeset/array-of-collisions.md
+++ b/.changeset/array-of-collisions.md
@@ -27,3 +27,15 @@ The `over` property remains a single `UniqueIdentifier`, and is set to the first
 Consumers can also access the `collisions` property which can be used to implement use-cases such as combining droppables in user-land.
 
 The `onDragMove`, `onDragOver` and `onDragEnd` callbacks are also updated to receive the collisions array property.
+
+Built-in collision detections such as rectIntersection, closestCenter, closestCorners and pointerWithin adhere to the CollisionDescriptor interface, which extends the Collision interface:
+
+```ts
+export interface CollisionDescriptor extends Collision {
+  data: {
+    droppableContainer: DroppableContainer;
+    value: number;
+    [key: string]: any;
+  };
+}
+```

--- a/packages/core/src/components/DndContext/DndContext.tsx
+++ b/packages/core/src/components/DndContext/DndContext.tsx
@@ -209,6 +209,7 @@ export const DndContext = memo(function DndContext({
     active: null,
     activeNode,
     collisionRect: null,
+    collisions: null,
     droppableRects,
     draggableNodes,
     draggingNode: null,
@@ -282,7 +283,7 @@ export const DndContext = memo(function DndContext({
     ? getAdjustedRect(draggingNodeRect, modifiedTranslate)
     : null;
 
-  const overId =
+  const collisions =
     active && collisionRect
       ? collisionDetection({
           active,
@@ -291,6 +292,7 @@ export const DndContext = memo(function DndContext({
           pointerCoordinates,
         })
       : null;
+  const overId = collisions && collisions.length > 0 ? collisions[0][0] : null;
   const [over, setOver] = useState<Over | null>(null);
 
   const transform = adjustScale(
@@ -368,7 +370,12 @@ export const DndContext = memo(function DndContext({
 
       function createHandler(type: Action.DragEnd | Action.DragCancel) {
         return async function handler() {
-          const {active, over, scrollAdjustedTranslate} = sensorContext.current;
+          const {
+            active,
+            collisions,
+            over,
+            scrollAdjustedTranslate,
+          } = sensorContext.current;
           let event: DragEndEvent | null = null;
 
           if (active && scrollAdjustedTranslate) {
@@ -376,6 +383,7 @@ export const DndContext = memo(function DndContext({
 
             event = {
               active: active,
+              collisions,
               delta: scrollAdjustedTranslate,
               over,
             };
@@ -480,7 +488,7 @@ export const DndContext = memo(function DndContext({
 
   useEffect(() => {
     const {onDragMove} = latestProps.current;
-    const {active, over} = sensorContext.current;
+    const {active, collisions, over} = sensorContext.current;
 
     if (!active) {
       return;
@@ -488,6 +496,7 @@ export const DndContext = memo(function DndContext({
 
     const event: DragMoveEvent = {
       active,
+      collisions,
       delta: {
         x: scrollAdjustedTranslate.x,
         y: scrollAdjustedTranslate.y,
@@ -503,6 +512,7 @@ export const DndContext = memo(function DndContext({
     () => {
       const {
         active,
+        collisions,
         droppableContainers,
         scrollAdjustedTranslate,
       } = sensorContext.current;
@@ -524,6 +534,7 @@ export const DndContext = memo(function DndContext({
           : null;
       const event: DragOverEvent = {
         active,
+        collisions,
         delta: {
           x: scrollAdjustedTranslate.x,
           y: scrollAdjustedTranslate.y,
@@ -546,6 +557,7 @@ export const DndContext = memo(function DndContext({
       active,
       activeNode,
       collisionRect,
+      collisions,
       droppableRects,
       draggableNodes,
       draggingNode,
@@ -563,6 +575,7 @@ export const DndContext = memo(function DndContext({
   }, [
     active,
     activeNode,
+    collisions,
     collisionRect,
     draggableNodes,
     draggingNode,
@@ -592,6 +605,7 @@ export const DndContext = memo(function DndContext({
       ariaDescribedById: {
         draggable: draggableDescribedById,
       },
+      collisions,
       containerNodeRect,
       dispatch,
       dragOverlay,
@@ -613,6 +627,7 @@ export const DndContext = memo(function DndContext({
     activeNodeRect,
     activatorEvent,
     activators,
+    collisions,
     containerNodeRect,
     dragOverlay,
     dispatch,

--- a/packages/core/src/components/DndContext/DndContext.tsx
+++ b/packages/core/src/components/DndContext/DndContext.tsx
@@ -59,6 +59,7 @@ import {
   defaultCoordinates,
   getAdjustedRect,
   getRectDelta,
+  getFirstCollision,
   rectIntersection,
 } from '../../utilities';
 import {getTransformAgnosticClientRect} from '../../utilities/rect';
@@ -292,7 +293,7 @@ export const DndContext = memo(function DndContext({
           pointerCoordinates,
         })
       : null;
-  const overId = collisions && collisions.length > 0 ? collisions[0][0] : null;
+  const overId = getFirstCollision(collisions, 'id');
   const [over, setOver] = useState<Over | null>(null);
 
   const transform = adjustScale(

--- a/packages/core/src/hooks/useDroppable.ts
+++ b/packages/core/src/hooks/useDroppable.ts
@@ -23,7 +23,7 @@ export function useDroppable({
   id,
 }: UseDroppableArguments) {
   const key = useUniqueId(ID_PREFIX);
-  const {active, dispatch, over} = useContext(Context);
+  const {active, collisions, dispatch, over} = useContext(Context);
   const rect = useRef<ClientRect | null>(null);
   const [nodeRef, setNodeRef] = useNodeRef();
   const dataRef = useData(data);
@@ -68,6 +68,7 @@ export function useDroppable({
 
   return {
     active,
+    collisions,
     rect,
     isOver: over?.id === id,
     node: nodeRef,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -94,10 +94,15 @@ export type {
 export {
   defaultCoordinates,
   getClientRect,
+  getFirstCollision,
   getScrollableAncestors,
   closestCenter,
   closestCorners,
   rectIntersection,
   pointerWithin,
 } from './utilities';
-export type {Collision, CollisionDetection} from './utilities';
+export type {
+  Collision,
+  CollisionDescriptor,
+  CollisionDetection,
+} from './utilities';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -100,4 +100,4 @@ export {
   rectIntersection,
   pointerWithin,
 } from './utilities';
-export type {CollisionDetection} from './utilities';
+export type {Collision, CollisionDetection} from './utilities';

--- a/packages/core/src/sensors/pointer/AbstractPointerSensor.ts
+++ b/packages/core/src/sensors/pointer/AbstractPointerSensor.ts
@@ -5,6 +5,7 @@ import {
   getWindow,
 } from '@dnd-kit/utilities';
 
+import {defaultCoordinates} from '../../utilities';
 import {
   getEventListenerTarget,
   hasExceededDistance,
@@ -80,7 +81,7 @@ export class AbstractPointerSensor implements SensorInstance {
     this.documentListeners = new Listeners(this.document);
     this.listeners = new Listeners(listenerTarget);
     this.windowListeners = new Listeners(getWindow(target));
-    this.initialCoordinates = getEventCoordinates(event);
+    this.initialCoordinates = getEventCoordinates(event) ?? defaultCoordinates;
     this.handleStart = this.handleStart.bind(this);
     this.handleMove = this.handleMove.bind(this);
     this.handleEnd = this.handleEnd.bind(this);
@@ -174,7 +175,7 @@ export class AbstractPointerSensor implements SensorInstance {
       return;
     }
 
-    const coordinates = getEventCoordinates(event);
+    const coordinates = getEventCoordinates(event) ?? defaultCoordinates;
     const delta = getCoordinatesDelta(initialCoordinates, coordinates);
 
     if (!activated && activationConstraint) {

--- a/packages/core/src/sensors/types.ts
+++ b/packages/core/src/sensors/types.ts
@@ -14,6 +14,7 @@ import type {
   UniqueIdentifier,
   ClientRect,
 } from '../types';
+import type {Collision} from '../utilities/algorithms';
 
 export enum Response {
   Start = 'start',
@@ -25,6 +26,7 @@ export type SensorContext = {
   active: Active | null;
   activeNode: HTMLElement | null;
   collisionRect: ClientRect | null;
+  collisions: Collision[] | null;
   draggableNodes: DraggableNodes;
   draggingNode: HTMLElement | null;
   draggingNodeRect: ClientRect | null;

--- a/packages/core/src/store/context.ts
+++ b/packages/core/src/store/context.ts
@@ -13,6 +13,7 @@ export const Context = createContext<DndContextDescriptor>({
   ariaDescribedById: {
     draggable: '',
   },
+  collisions: null,
   containerNodeRect: null,
   dispatch: noop,
   draggableNodes: {},

--- a/packages/core/src/store/types.ts
+++ b/packages/core/src/store/types.ts
@@ -1,6 +1,7 @@
 import type {MutableRefObject} from 'react';
 
 import type {Coordinates, ClientRect, UniqueIdentifier} from '../types';
+import type {Collision} from '../utilities/algorithms';
 import type {SyntheticListeners} from '../hooks/utilities';
 import type {Actions} from './actions';
 import type {DroppableContainersMap} from './constructors';
@@ -80,6 +81,7 @@ export interface DndContextDescriptor {
   ariaDescribedById: {
     draggable: UniqueIdentifier;
   };
+  collisions: Collision[] | null;
   containerNodeRect: ClientRect | null;
   draggableNodes: DraggableNodes;
   droppableContainers: DroppableContainers;

--- a/packages/core/src/types/events.ts
+++ b/packages/core/src/types/events.ts
@@ -1,8 +1,11 @@
 import type {Active, Over} from '../store';
+import type {Collision} from '../utilities/algorithms';
+
 import type {Translate} from './coordinates';
 
 interface DragEvent {
   active: Active;
+  collisions: Collision[] | null;
   delta: Translate;
   over: Over | null;
 }

--- a/packages/core/src/utilities/algorithms/closestCenter.ts
+++ b/packages/core/src/utilities/algorithms/closestCenter.ts
@@ -1,7 +1,8 @@
 import {distanceBetween} from '../coordinates';
-import type {Coordinates, ClientRect, UniqueIdentifier} from '../../types';
+import type {Coordinates, ClientRect} from '../../types';
 
-import type {CollisionDetection} from './types';
+import type {Collision, CollisionDetection} from './types';
+import {sortCollisionsAsc} from './helpers';
 
 /**
  * Returns the coordinates of the center of a given ClientRect
@@ -18,7 +19,7 @@ function centerOfRectangle(
 }
 
 /**
- * Returns the closest rectangle from an array of rectangles to the center of a given
+ * Returns the closest rectangles from an array of rectangles to the center of a given
  * rectangle.
  */
 export const closestCenter: CollisionDetection = ({
@@ -30,23 +31,20 @@ export const closestCenter: CollisionDetection = ({
     collisionRect.left,
     collisionRect.top
   );
-  let minDistanceToCenter = Infinity;
-  let minDroppableContainer: UniqueIdentifier | null = null;
+  const collisions: Collision[] = [];
 
   for (const droppableContainer of droppableContainers) {
     const {
+      id,
       rect: {current: rect},
     } = droppableContainer;
 
     if (rect) {
       const distBetween = distanceBetween(centerOfRectangle(rect), centerRect);
 
-      if (distBetween < minDistanceToCenter) {
-        minDistanceToCenter = distBetween;
-        minDroppableContainer = droppableContainer.id;
-      }
+      collisions.push([id, distBetween]);
     }
   }
 
-  return minDroppableContainer;
+  return collisions.sort(sortCollisionsAsc);
 };

--- a/packages/core/src/utilities/algorithms/closestCenter.ts
+++ b/packages/core/src/utilities/algorithms/closestCenter.ts
@@ -1,7 +1,7 @@
 import {distanceBetween} from '../coordinates';
 import type {Coordinates, ClientRect} from '../../types';
 
-import type {Collision, CollisionDetection} from './types';
+import type {CollisionDescriptor, CollisionDetection} from './types';
 import {sortCollisionsAsc} from './helpers';
 
 /**
@@ -31,7 +31,7 @@ export const closestCenter: CollisionDetection = ({
     collisionRect.left,
     collisionRect.top
   );
-  const collisions: Collision[] = [];
+  const collisions: CollisionDescriptor[] = [];
 
   for (const droppableContainer of droppableContainers) {
     const {
@@ -42,7 +42,7 @@ export const closestCenter: CollisionDetection = ({
     if (rect) {
       const distBetween = distanceBetween(centerOfRectangle(rect), centerRect);
 
-      collisions.push([id, distBetween]);
+      collisions.push({id, data: {droppableContainer, value: distBetween}});
     }
   }
 

--- a/packages/core/src/utilities/algorithms/closestCorners.ts
+++ b/packages/core/src/utilities/algorithms/closestCorners.ts
@@ -1,38 +1,7 @@
-import type {ClientRect} from '../../types';
 import {distanceBetween} from '../coordinates';
 
-import type {Collision, CollisionDetection} from './types';
-import {sortCollisionsAsc} from './helpers';
-
-/**
- * Returns the coordinates of the corners of a given rectangle:
- * [TopLeft {x, y}, TopRight {x, y}, BottomLeft {x, y}, BottomRight {x, y}]
- */
-
-function cornersOfRectangle(
-  rect: ClientRect,
-  left = rect.left,
-  top = rect.top
-) {
-  return [
-    {
-      x: left,
-      y: top,
-    },
-    {
-      x: left + rect.width,
-      y: top,
-    },
-    {
-      x: left,
-      y: top + rect.height,
-    },
-    {
-      x: left + rect.width,
-      y: top + rect.height,
-    },
-  ];
-}
+import type {CollisionDescriptor, CollisionDetection} from './types';
+import {cornersOfRectangle, sortCollisionsAsc} from './helpers';
 
 /**
  * Returns the closest rectangles from an array of rectangles to the corners of
@@ -42,12 +11,8 @@ export const closestCorners: CollisionDetection = ({
   collisionRect,
   droppableContainers,
 }) => {
-  const corners = cornersOfRectangle(
-    collisionRect,
-    collisionRect.left,
-    collisionRect.top
-  );
-  const collisions: Collision[] = [];
+  const corners = cornersOfRectangle(collisionRect);
+  const collisions: CollisionDescriptor[] = [];
 
   for (const droppableContainer of droppableContainers) {
     const {
@@ -56,13 +21,16 @@ export const closestCorners: CollisionDetection = ({
     } = droppableContainer;
 
     if (rect) {
-      const rectCorners = cornersOfRectangle(rect, rect.left, rect.top);
+      const rectCorners = cornersOfRectangle(rect);
       const distances = corners.reduce((accumulator, corner, index) => {
         return accumulator + distanceBetween(rectCorners[index], corner);
       }, 0);
       const effectiveDistance = Number((distances / 4).toFixed(4));
 
-      collisions.push([id, effectiveDistance]);
+      collisions.push({
+        id,
+        data: {droppableContainer, value: effectiveDistance},
+      });
     }
   }
 

--- a/packages/core/src/utilities/algorithms/closestCorners.ts
+++ b/packages/core/src/utilities/algorithms/closestCorners.ts
@@ -1,7 +1,8 @@
-import type {ClientRect, UniqueIdentifier} from '../../types';
+import type {ClientRect} from '../../types';
 import {distanceBetween} from '../coordinates';
 
-import type {CollisionDetection} from './types';
+import type {Collision, CollisionDetection} from './types';
+import {sortCollisionsAsc} from './helpers';
 
 /**
  * Returns the coordinates of the corners of a given rectangle:
@@ -34,23 +35,23 @@ function cornersOfRectangle(
 }
 
 /**
- * Returns the closest rectangle from an array of rectangles to the corners of
+ * Returns the closest rectangles from an array of rectangles to the corners of
  * another rectangle.
  */
 export const closestCorners: CollisionDetection = ({
   collisionRect,
   droppableContainers,
 }) => {
-  let minDistanceToCorners = Infinity;
-  let minDistanceContainer: UniqueIdentifier | null = null;
   const corners = cornersOfRectangle(
     collisionRect,
     collisionRect.left,
     collisionRect.top
   );
+  const collisions: Collision[] = [];
 
   for (const droppableContainer of droppableContainers) {
     const {
+      id,
       rect: {current: rect},
     } = droppableContainer;
 
@@ -61,12 +62,9 @@ export const closestCorners: CollisionDetection = ({
       }, 0);
       const effectiveDistance = Number((distances / 4).toFixed(4));
 
-      if (effectiveDistance < minDistanceToCorners) {
-        minDistanceToCorners = effectiveDistance;
-        minDistanceContainer = droppableContainer.id;
-      }
+      collisions.push([id, effectiveDistance]);
     }
   }
 
-  return minDistanceContainer;
+  return collisions.sort(sortCollisionsAsc);
 };

--- a/packages/core/src/utilities/algorithms/helpers.ts
+++ b/packages/core/src/utilities/algorithms/helpers.ts
@@ -1,0 +1,39 @@
+import type {ClientRect} from '../../types';
+
+import type {Collision} from './types';
+
+export function sortCollisionsAsc([, a]: Collision, [, b]: Collision) {
+  return a - b;
+}
+
+export function sortCollisionsDesc([, a]: Collision, [, b]: Collision) {
+  return b - a;
+}
+
+/**
+ * Returns the intersecting rectangle area between two rectangles
+ */
+export function getIntersectionRatio(
+  entry: ClientRect,
+  target: ClientRect
+): number {
+  const top = Math.max(target.top, entry.top);
+  const left = Math.max(target.left, entry.left);
+  const right = Math.min(target.left + target.width, entry.left + entry.width);
+  const bottom = Math.min(target.top + target.height, entry.top + entry.height);
+  const width = right - left;
+  const height = bottom - top;
+
+  if (left < right && top < bottom) {
+    const targetArea = target.width * target.height;
+    const entryArea = entry.width * entry.height;
+    const intersectionArea = width * height;
+    const intersectionRatio =
+      intersectionArea / (targetArea + entryArea - intersectionArea);
+
+    return Number(intersectionRatio.toFixed(4));
+  }
+
+  // Rectangles do not overlap, or overlap has an area of zero (edge/corner overlap)
+  return 0;
+}

--- a/packages/core/src/utilities/algorithms/helpers.ts
+++ b/packages/core/src/utilities/algorithms/helpers.ts
@@ -1,39 +1,73 @@
+/* eslint-disable no-redeclare */
 import type {ClientRect} from '../../types';
 
-import type {Collision} from './types';
+import type {Collision, CollisionDescriptor} from './types';
 
-export function sortCollisionsAsc([, a]: Collision, [, b]: Collision) {
+/**
+ * Sort collisions from smallest to greatest value
+ */
+export function sortCollisionsAsc(
+  {data: {value: a}}: CollisionDescriptor,
+  {data: {value: b}}: CollisionDescriptor
+) {
   return a - b;
 }
 
-export function sortCollisionsDesc([, a]: Collision, [, b]: Collision) {
+/**
+ * Sort collisions from greatest to smallest value
+ */
+export function sortCollisionsDesc(
+  {data: {value: a}}: CollisionDescriptor,
+  {data: {value: b}}: CollisionDescriptor
+) {
   return b - a;
 }
 
 /**
- * Returns the intersecting rectangle area between two rectangles
+ * Returns the coordinates of the corners of a given rectangle:
+ * [TopLeft {x, y}, TopRight {x, y}, BottomLeft {x, y}, BottomRight {x, y}]
  */
-export function getIntersectionRatio(
-  entry: ClientRect,
-  target: ClientRect
-): number {
-  const top = Math.max(target.top, entry.top);
-  const left = Math.max(target.left, entry.left);
-  const right = Math.min(target.left + target.width, entry.left + entry.width);
-  const bottom = Math.min(target.top + target.height, entry.top + entry.height);
-  const width = right - left;
-  const height = bottom - top;
+export function cornersOfRectangle({left, top, height, width}: ClientRect) {
+  return [
+    {
+      x: left,
+      y: top,
+    },
+    {
+      x: left + width,
+      y: top,
+    },
+    {
+      x: left,
+      y: top + height,
+    },
+    {
+      x: left + width,
+      y: top + height,
+    },
+  ];
+}
 
-  if (left < right && top < bottom) {
-    const targetArea = target.width * target.height;
-    const entryArea = entry.width * entry.height;
-    const intersectionArea = width * height;
-    const intersectionRatio =
-      intersectionArea / (targetArea + entryArea - intersectionArea);
-
-    return Number(intersectionRatio.toFixed(4));
+/**
+ * Returns the first collision, or null if there isn't one.
+ * If a property is specified, returns the specified property of the first collision.
+ */
+export function getFirstCollision(
+  collisions: Collision[] | null | undefined
+): Collision | null;
+export function getFirstCollision<T extends keyof Collision>(
+  collisions: Collision[] | null | undefined,
+  property: T
+): Collision[T] | null;
+export function getFirstCollision(
+  collisions: Collision[] | null | undefined,
+  property?: keyof Collision
+) {
+  if (!collisions || collisions.length === 0) {
+    return null;
   }
 
-  // Rectangles do not overlap, or overlap has an area of zero (edge/corner overlap)
-  return 0;
+  const [firstCollision] = collisions;
+
+  return property ? firstCollision[property] : firstCollision;
 }

--- a/packages/core/src/utilities/algorithms/index.ts
+++ b/packages/core/src/utilities/algorithms/index.ts
@@ -2,4 +2,4 @@ export {closestCenter} from './closestCenter';
 export {closestCorners} from './closestCorners';
 export {rectIntersection} from './rectIntersection';
 export {pointerWithin} from './pointerWithin';
-export type {CollisionDetection} from './types';
+export type {Collision, CollisionDetection} from './types';

--- a/packages/core/src/utilities/algorithms/index.ts
+++ b/packages/core/src/utilities/algorithms/index.ts
@@ -2,4 +2,5 @@ export {closestCenter} from './closestCenter';
 export {closestCorners} from './closestCorners';
 export {rectIntersection} from './rectIntersection';
 export {pointerWithin} from './pointerWithin';
-export type {Collision, CollisionDetection} from './types';
+export type {Collision, CollisionDescriptor, CollisionDetection} from './types';
+export {getFirstCollision} from './helpers';

--- a/packages/core/src/utilities/algorithms/pointerWithin.ts
+++ b/packages/core/src/utilities/algorithms/pointerWithin.ts
@@ -1,5 +1,7 @@
 import type {Coordinates, ClientRect} from '../../types';
-import type {CollisionDetection} from './types';
+
+import type {Collision, CollisionDetection} from './types';
+import {getIntersectionRatio, sortCollisionsDesc} from './helpers';
 
 /**
  * check if the given point is within the rectangle
@@ -19,23 +21,31 @@ function isPointerInside(
 }
 
 /**
- * Returns the rectangle that the pointer is hovering over
+ * Returns the rectangles that the pointer is hovering over
  */
 export const pointerWithin: CollisionDetection = ({
   droppableContainers,
+  collisionRect,
   pointerCoordinates,
 }) => {
-  if (!pointerCoordinates) return null;
+  if (!pointerCoordinates) {
+    return [];
+  }
+
+  const collisions: Collision[] = [];
 
   for (const droppableContainer of droppableContainers) {
     const {
+      id,
       rect: {current: rect},
     } = droppableContainer;
 
     if (rect && isPointerInside(rect, pointerCoordinates)) {
-      return droppableContainer.id;
+      const intersectionRatio = getIntersectionRatio(rect, collisionRect);
+
+      collisions.push([id, intersectionRatio]);
     }
   }
 
-  return null;
+  return collisions.sort(sortCollisionsDesc);
 };

--- a/packages/core/src/utilities/algorithms/rectIntersection.ts
+++ b/packages/core/src/utilities/algorithms/rectIntersection.ts
@@ -1,5 +1,35 @@
-import type {Collision, CollisionDetection} from './types';
-import {getIntersectionRatio, sortCollisionsDesc} from './helpers';
+import type {ClientRect} from '../../types';
+
+import type {CollisionDescriptor, CollisionDetection} from './types';
+import {sortCollisionsDesc} from './helpers';
+
+/**
+ * Returns the intersecting rectangle area between two rectangles
+ */
+export function getIntersectionRatio(
+  entry: ClientRect,
+  target: ClientRect
+): number {
+  const top = Math.max(target.top, entry.top);
+  const left = Math.max(target.left, entry.left);
+  const right = Math.min(target.left + target.width, entry.left + entry.width);
+  const bottom = Math.min(target.top + target.height, entry.top + entry.height);
+  const width = right - left;
+  const height = bottom - top;
+
+  if (left < right && top < bottom) {
+    const targetArea = target.width * target.height;
+    const entryArea = entry.width * entry.height;
+    const intersectionArea = width * height;
+    const intersectionRatio =
+      intersectionArea / (targetArea + entryArea - intersectionArea);
+
+    return Number(intersectionRatio.toFixed(4));
+  }
+
+  // Rectangles do not overlap, or overlap has an area of zero (edge/corner overlap)
+  return 0;
+}
 
 /**
  * Returns the rectangles that has the greatest intersection area with a given
@@ -9,7 +39,7 @@ export const rectIntersection: CollisionDetection = ({
   collisionRect,
   droppableContainers,
 }) => {
-  const collisions: Collision[] = [];
+  const collisions: CollisionDescriptor[] = [];
 
   for (const droppableContainer of droppableContainers) {
     const {
@@ -21,7 +51,10 @@ export const rectIntersection: CollisionDetection = ({
       const intersectionRatio = getIntersectionRatio(rect, collisionRect);
 
       if (intersectionRatio > 0) {
-        collisions.push([id, intersectionRatio]);
+        collisions.push({
+          id,
+          data: {droppableContainer, value: intersectionRatio},
+        });
       }
     }
   }

--- a/packages/core/src/utilities/algorithms/rectIntersection.ts
+++ b/packages/core/src/utilities/algorithms/rectIntersection.ts
@@ -1,57 +1,30 @@
-import type {ClientRect, UniqueIdentifier} from '../../types';
-
-import type {CollisionDetection} from './types';
-
-/**
- * Returns the intersecting rectangle area between two rectangles
- */
-function getIntersectionRatio(entry: ClientRect, target: ClientRect): number {
-  const top = Math.max(target.top, entry.top);
-  const left = Math.max(target.left, entry.left);
-  const right = Math.min(target.left + target.width, entry.left + entry.width);
-  const bottom = Math.min(target.top + target.height, entry.top + entry.height);
-  const width = right - left;
-  const height = bottom - top;
-
-  if (left < right && top < bottom) {
-    const targetArea = target.width * target.height;
-    const entryArea = entry.width * entry.height;
-    const intersectionArea = width * height;
-    const intersectionRatio =
-      intersectionArea / (targetArea + entryArea - intersectionArea);
-
-    return Number(intersectionRatio.toFixed(4));
-  }
-
-  // Rectangles do not overlap, or overlap has an area of zero (edge/corner overlap)
-  return 0;
-}
+import type {Collision, CollisionDetection} from './types';
+import {getIntersectionRatio, sortCollisionsDesc} from './helpers';
 
 /**
- * Returns the rectangle that has the greatest intersection area with a given
+ * Returns the rectangles that has the greatest intersection area with a given
  * rectangle in an array of rectangles.
  */
 export const rectIntersection: CollisionDetection = ({
   collisionRect,
   droppableContainers,
 }) => {
-  let maxIntersectionRatio = 0;
-  let maxIntersectingDroppableContainer: UniqueIdentifier | null = null;
+  const collisions: Collision[] = [];
 
   for (const droppableContainer of droppableContainers) {
     const {
+      id,
       rect: {current: rect},
     } = droppableContainer;
 
     if (rect) {
       const intersectionRatio = getIntersectionRatio(rect, collisionRect);
 
-      if (intersectionRatio > maxIntersectionRatio) {
-        maxIntersectionRatio = intersectionRatio;
-        maxIntersectingDroppableContainer = droppableContainer.id;
+      if (intersectionRatio > 0) {
+        collisions.push([id, intersectionRatio]);
       }
     }
   }
 
-  return maxIntersectingDroppableContainer;
+  return collisions.sort(sortCollisionsDesc);
 };

--- a/packages/core/src/utilities/algorithms/types.ts
+++ b/packages/core/src/utilities/algorithms/types.ts
@@ -1,7 +1,18 @@
-import type {Active, DroppableContainer} from '../../store';
+import type {Active, Data, DroppableContainer} from '../../store';
 import type {Coordinates, ClientRect, UniqueIdentifier} from '../../types';
 
-export type Collision = [UniqueIdentifier, number];
+export interface Collision {
+  id: UniqueIdentifier;
+  data?: Data;
+}
+
+export interface CollisionDescriptor extends Collision {
+  data: {
+    droppableContainer: DroppableContainer;
+    value: number;
+    [key: string]: any;
+  };
+}
 
 export type CollisionDetection = (args: {
   active: Active;

--- a/packages/core/src/utilities/algorithms/types.ts
+++ b/packages/core/src/utilities/algorithms/types.ts
@@ -1,9 +1,11 @@
 import type {Active, DroppableContainer} from '../../store';
 import type {Coordinates, ClientRect, UniqueIdentifier} from '../../types';
 
+export type Collision = [UniqueIdentifier, number];
+
 export type CollisionDetection = (args: {
   active: Active;
   collisionRect: ClientRect;
   droppableContainers: DroppableContainer[];
   pointerCoordinates: Coordinates | null;
-}) => UniqueIdentifier | null;
+}) => Collision[];

--- a/packages/core/src/utilities/coordinates/getRelativeTransformOrigin.ts
+++ b/packages/core/src/utilities/coordinates/getRelativeTransformOrigin.ts
@@ -1,15 +1,16 @@
-import {getEventCoordinates, isKeyboardEvent} from '@dnd-kit/utilities';
+import {getEventCoordinates} from '@dnd-kit/utilities';
 import type {ClientRect} from '../../types';
 
 export function getRelativeTransformOrigin(
   event: MouseEvent | TouchEvent | KeyboardEvent,
   rect: ClientRect
 ) {
-  if (isKeyboardEvent(event)) {
+  const eventCoordinates = getEventCoordinates(event);
+
+  if (!eventCoordinates) {
     return '0 0';
   }
 
-  const eventCoordinates = getEventCoordinates(event);
   const transformOrigin = {
     x: ((eventCoordinates.x - rect.left) / rect.width) * 100,
     y: ((eventCoordinates.y - rect.top) / rect.height) * 100,

--- a/packages/core/src/utilities/index.ts
+++ b/packages/core/src/utilities/index.ts
@@ -2,9 +2,14 @@ export {
   closestCenter,
   closestCorners,
   rectIntersection,
+  getFirstCollision,
   pointerWithin,
 } from './algorithms';
-export type {Collision, CollisionDetection} from './algorithms';
+export type {
+  Collision,
+  CollisionDescriptor,
+  CollisionDetection,
+} from './algorithms';
 
 export {
   defaultCoordinates,

--- a/packages/core/src/utilities/index.ts
+++ b/packages/core/src/utilities/index.ts
@@ -4,7 +4,7 @@ export {
   rectIntersection,
   pointerWithin,
 } from './algorithms';
-export type {CollisionDetection} from './algorithms';
+export type {Collision, CollisionDetection} from './algorithms';
 
 export {
   defaultCoordinates,

--- a/packages/modifiers/src/snapCenterToCursor.ts
+++ b/packages/modifiers/src/snapCenterToCursor.ts
@@ -1,22 +1,18 @@
 import type {Modifier} from '@dnd-kit/core';
-import {
-  getEventCoordinates,
-  isTouchEvent,
-  hasViewportRelativeCoordinates,
-} from '@dnd-kit/utilities';
+import {getEventCoordinates} from '@dnd-kit/utilities';
 
 export const snapCenterToCursor: Modifier = ({
   activatorEvent,
   activeNodeRect,
   transform,
 }) => {
-  if (
-    activeNodeRect &&
-    activatorEvent &&
-    (isTouchEvent(activatorEvent) ||
-      hasViewportRelativeCoordinates(activatorEvent))
-  ) {
+  if (activeNodeRect && activatorEvent) {
     const activatorCoordinates = getEventCoordinates(activatorEvent);
+
+    if (!activatorCoordinates) {
+      return transform;
+    }
+
     const offsetX = activatorCoordinates.x - activeNodeRect.left;
     const offsetY = activatorCoordinates.y - activeNodeRect.top;
 

--- a/packages/sortable/src/hooks/useSortable.ts
+++ b/packages/sortable/src/hooks/useSortable.ts
@@ -53,7 +53,13 @@ export function useSortable({
     () => ({sortable: {containerId, index, items}, ...customData}),
     [containerId, customData, index, items]
   );
-  const {rect, node, setNodeRef: setDroppableNodeRef} = useDroppable({
+  const {
+    collisions,
+    rect,
+    node,
+    isOver,
+    setNodeRef: setDroppableNodeRef,
+  } = useDroppable({
     id,
     data,
   });
@@ -143,10 +149,15 @@ export function useSortable({
 
   return {
     active,
+    activeIndex,
     attributes,
     activatorEvent,
+    collisions,
     rect,
     index,
+    newIndex,
+    items,
+    isOver,
     isSorting,
     isDragging,
     listeners,

--- a/packages/sortable/src/sensors/keyboard/sortableKeyboardCoordinates.ts
+++ b/packages/sortable/src/sensors/keyboard/sortableKeyboardCoordinates.ts
@@ -1,6 +1,7 @@
 import {
   closestCorners,
   getScrollableAncestors,
+  getFirstCollision,
   KeyboardCode,
   DroppableContainer,
   KeyboardCoordinateGetter,
@@ -67,9 +68,9 @@ export const sortableKeyboardCoordinates: KeyboardCoordinateGetter = (
       droppableContainers: filteredContainers,
       pointerCoordinates: null,
     });
-    const closestId = collisions.length > 0 ? collisions[0][0] : null;
+    const closestId = getFirstCollision(collisions, 'id');
 
-    if (closestId) {
+    if (closestId != null) {
       const newDroppable = droppableContainers.get(closestId);
       const newNode = newDroppable?.node.current;
       const newRect = newDroppable?.rect.current;

--- a/packages/sortable/src/sensors/keyboard/sortableKeyboardCoordinates.ts
+++ b/packages/sortable/src/sensors/keyboard/sortableKeyboardCoordinates.ts
@@ -61,12 +61,13 @@ export const sortableKeyboardCoordinates: KeyboardCoordinateGetter = (
       }
     });
 
-    const closestId = closestCorners({
+    const collisions = closestCorners({
       active,
       collisionRect: collisionRect,
       droppableContainers: filteredContainers,
       pointerCoordinates: null,
     });
+    const closestId = collisions.length > 0 ? collisions[0][0] : null;
 
     if (closestId) {
       const newDroppable = droppableContainers.get(closestId);

--- a/packages/utilities/src/coordinates/getEventCoordinates.ts
+++ b/packages/utilities/src/coordinates/getEventCoordinates.ts
@@ -4,7 +4,7 @@ import {isTouchEvent, hasViewportRelativeCoordinates} from '../event';
 /**
  * Returns the normalized x and y coordinates for mouse and touch events.
  */
-export function getEventCoordinates(event: Event): Coordinates {
+export function getEventCoordinates(event: Event): Coordinates | null {
   if (isTouchEvent(event)) {
     if (event.touches && event.touches.length) {
       const {clientX: x, clientY: y} = event.touches[0];
@@ -30,8 +30,5 @@ export function getEventCoordinates(event: Event): Coordinates {
     };
   }
 
-  return {
-    x: 0,
-    y: 0,
-  };
+  return null;
 }

--- a/stories/2 - Presets/Sortable/MultipleContainers.tsx
+++ b/stories/2 - Presets/Sortable/MultipleContainers.tsx
@@ -173,9 +173,6 @@ export function MultipleContainers({
   // Custom collision detection strategy optimized for multiple containers
   const collisionDetectionStrategy: CollisionDetection = useCallback(
     (args) => {
-      // Start by finding any intersecting droppable
-      let overId = rectIntersection(args);
-
       if (activeId && activeId in items) {
         return closestCenter({
           ...args,
@@ -185,11 +182,16 @@ export function MultipleContainers({
         });
       }
 
+      // Start by finding any intersecting droppable
+      const intersections = rectIntersection(args);
+      let overId =
+        intersections && intersections.length > 0 ? intersections[0][0] : null;
+
       if (overId != null) {
         if (overId === TRASH_ID) {
           // If the intersecting droppable is the trash, return early
           // Remove this if you're not using trashable functionality in your app
-          return overId;
+          return intersections;
         }
 
         if (overId in items) {
@@ -205,13 +207,13 @@ export function MultipleContainers({
                   container.id !== overId &&
                   containerItems.includes(container.id)
               ),
-            });
+            })[0][0];
           }
         }
 
         lastOverId.current = overId;
 
-        return overId;
+        return [[overId, 0]];
       }
 
       // When a draggable item moves to a new container, the layout may shift
@@ -223,7 +225,7 @@ export function MultipleContainers({
       }
 
       // If no droppable is matched, return the last match
-      return lastOverId.current;
+      return lastOverId.current ? [[lastOverId.current, 0]] : [];
     },
     [activeId, items]
   );

--- a/stories/2 - Presets/Sortable/MultipleContainers.tsx
+++ b/stories/2 - Presets/Sortable/MultipleContainers.tsx
@@ -3,12 +3,14 @@ import {createPortal, unstable_batchedUpdates} from 'react-dom';
 import {
   CancelDrop,
   closestCenter,
+  pointerWithin,
   rectIntersection,
   CollisionDetection,
   DndContext,
   DragOverlay,
   DropAnimation,
   defaultDropAnimation,
+  getFirstCollision,
   KeyboardSensor,
   MouseSensor,
   TouchSensor,
@@ -183,9 +185,10 @@ export function MultipleContainers({
       }
 
       // Start by finding any intersecting droppable
-      const intersections = rectIntersection(args);
-      let overId =
-        intersections && intersections.length > 0 ? intersections[0][0] : null;
+      const intersections = args.pointerCoordinates
+        ? pointerWithin(args)
+        : rectIntersection(args);
+      let overId = getFirstCollision(intersections, 'id');
 
       if (overId != null) {
         if (overId === TRASH_ID) {
@@ -207,13 +210,13 @@ export function MultipleContainers({
                   container.id !== overId &&
                   containerItems.includes(container.id)
               ),
-            })[0][0];
+            })[0]?.id;
           }
         }
 
         lastOverId.current = overId;
 
-        return [[overId, 0]];
+        return [{id: overId}];
       }
 
       // When a draggable item moves to a new container, the layout may shift
@@ -225,7 +228,7 @@ export function MultipleContainers({
       }
 
       // If no droppable is matched, return the last match
-      return lastOverId.current ? [[lastOverId.current, 0]] : [];
+      return lastOverId.current ? [{id: lastOverId.current}] : [];
     },
     [activeId, items]
   );

--- a/stories/3 - Examples/Tree/keyboardCoordinates.ts
+++ b/stories/3 - Examples/Tree/keyboardCoordinates.ts
@@ -103,11 +103,13 @@ export const sortableTreeKeyboardCoordinates: (
       });
     }
 
-    const closestId = closestCorners({
+    const collisions = closestCorners({
       active,
       collisionRect: collisionRect,
+      pointerCoordinates: null,
       droppableContainers: containers,
     });
+    const closestId = collisions.length > 0 ? collisions[0][0] : null;
 
     if (closestId && over?.id) {
       const newNode = droppableContainers.get(closestId)?.node.current;

--- a/stories/3 - Examples/Tree/keyboardCoordinates.ts
+++ b/stories/3 - Examples/Tree/keyboardCoordinates.ts
@@ -1,6 +1,7 @@
 import {
   closestCorners,
   getClientRect,
+  getFirstCollision,
   KeyboardCode,
   KeyboardCoordinateGetter,
   DroppableContainer,
@@ -109,7 +110,7 @@ export const sortableTreeKeyboardCoordinates: (
       pointerCoordinates: null,
       droppableContainers: containers,
     });
-    const closestId = collisions.length > 0 ? collisions[0][0] : null;
+    const closestId = getFirstCollision(collisions, 'id');
 
     if (closestId && over?.id) {
       const newNode = droppableContainers.get(closestId)?.node.current;


### PR DESCRIPTION
This PR refactors the `CollisionDetection` interface to return an array of `Collision`s:

```ts
export interface Collision {
  id: UniqueIdentifier;
  data?: Record<string, any>;
};

export type CollisionDetection = (args: {
  active: Active;
  collisionRect: ClientRect;
  droppableContainers: DroppableContainer[];
  pointerCoordinates: Coordinates | null;
}) => Collision[];
```

This is a breaking change that requires all collision detection strategies to be updated.

The `over` property remains a single `UniqueIdentifier`, and is set to the first item in returned in the collisions array.

Consumers can also access the `collisions` property which can be used to implement use-cases such as combining droppables in user-land.

The `onDragMove`, `onDragOver` and `onDragEnd` callbacks are also updated to receive the collisions array property.

Built-in collision detections such as `rectIntersection`, `closestCenter`, `closestCorners` and `pointerWithin` adhere to the `CollisionDescriptor` interface, which extends the `Collision` interface:

```ts
export interface CollisionDescriptor extends Collision {
  data: {
    droppableContainer: DroppableContainer;
    value: number;
    [key: string]: any;
  };
}
```