### PR TITLE
Update modifiers to use `draggingNodeRect` instead of `activeNodeRect`

### DIFF
--- a/.changeset/modifiers-dragging-rect.md
+++ b/.changeset/modifiers-dragging-rect.md
@@ -1,0 +1,5 @@
+---
+"@dnd-kit/modifiers": minor
+---
+
+Update modifiers to use `draggingNodeRect` instead of `activeNodeRect`. Modifiers should be based on the rect of the node being dragged, whether it is the draggable node or drag overlay node.

--- a/packages/modifiers/src/restrictToFirstScrollableAncestor.ts
+++ b/packages/modifiers/src/restrictToFirstScrollableAncestor.ts
@@ -2,19 +2,19 @@ import type {Modifier} from '@dnd-kit/core';
 import {restrictToBoundingRect} from './utilities';
 
 export const restrictToFirstScrollableAncestor: Modifier = ({
+  draggingNodeRect,
   transform,
-  activeNodeRect,
   scrollableAncestorRects,
 }) => {
   const firstScrollableAncestorRect = scrollableAncestorRects[0];
 
-  if (!activeNodeRect || !firstScrollableAncestorRect) {
+  if (!draggingNodeRect || !firstScrollableAncestorRect) {
     return transform;
   }
 
   return restrictToBoundingRect(
     transform,
-    activeNodeRect,
+    draggingNodeRect,
     firstScrollableAncestorRect
   );
 };

--- a/packages/modifiers/src/restrictToParentElement.ts
+++ b/packages/modifiers/src/restrictToParentElement.ts
@@ -2,13 +2,13 @@ import type {Modifier} from '@dnd-kit/core';
 import {restrictToBoundingRect} from './utilities';
 
 export const restrictToParentElement: Modifier = ({
-  transform,
-  activeNodeRect,
   containerNodeRect,
+  draggingNodeRect,
+  transform,
 }) => {
-  if (!activeNodeRect || !containerNodeRect) {
+  if (!draggingNodeRect || !containerNodeRect) {
     return transform;
   }
 
-  return restrictToBoundingRect(transform, activeNodeRect, containerNodeRect);
+  return restrictToBoundingRect(transform, draggingNodeRect, containerNodeRect);
 };

--- a/packages/modifiers/src/restrictToWindowEdges.ts
+++ b/packages/modifiers/src/restrictToWindowEdges.ts
@@ -4,12 +4,12 @@ import {restrictToBoundingRect} from './utilities';
 
 export const restrictToWindowEdges: Modifier = ({
   transform,
-  activeNodeRect,
+  draggingNodeRect,
   windowRect,
 }) => {
-  if (!activeNodeRect || !windowRect) {
+  if (!draggingNodeRect || !windowRect) {
     return transform;
   }
 
-  return restrictToBoundingRect(transform, activeNodeRect, windowRect);
+  return restrictToBoundingRect(transform, draggingNodeRect, windowRect);
 };

--- a/packages/modifiers/src/snapCenterToCursor.ts
+++ b/packages/modifiers/src/snapCenterToCursor.ts
@@ -3,23 +3,23 @@ import {getEventCoordinates} from '@dnd-kit/utilities';
 
 export const snapCenterToCursor: Modifier = ({
   activatorEvent,
-  activeNodeRect,
+  draggingNodeRect,
   transform,
 }) => {
-  if (activeNodeRect && activatorEvent) {
+  if (draggingNodeRect && activatorEvent) {
     const activatorCoordinates = getEventCoordinates(activatorEvent);
 
     if (!activatorCoordinates) {
       return transform;
     }
 
-    const offsetX = activatorCoordinates.x - activeNodeRect.left;
-    const offsetY = activatorCoordinates.y - activeNodeRect.top;
+    const offsetX = activatorCoordinates.x - draggingNodeRect.left;
+    const offsetY = activatorCoordinates.y - draggingNodeRect.top;
 
     return {
       ...transform,
-      x: transform.x + offsetX - activeNodeRect.width / 2,
-      y: transform.y + offsetY - activeNodeRect.height / 2,
+      x: transform.x + offsetX - draggingNodeRect.width / 2,
+      y: transform.y + offsetY - draggingNodeRect.height / 2,
     };
   }
 


### PR DESCRIPTION
Modifiers should be based on the rect of the node being dragged, whether it is the draggable node or drag overlay node