### PR TITLE
Separate context into Public and Internal context providers

### DIFF
--- a/.changeset/array-of-collisions.md
+++ b/.changeset/array-of-collisions.md
@@ -39,3 +39,13 @@ export interface CollisionDescriptor extends Collision {
   };
 }
 ```
+
+Consumers can also access the array of collisions in components wrapped by `<DndContext>` via the `useDndContext()` hook:
+
+```ts
+import {useDndContext} from '@dnd-kit/core';
+
+function MyComponent() {
+  const {collisions} = useDndContext();
+}
+```

--- a/.changeset/separate-context-providers.md
+++ b/.changeset/separate-context-providers.md
@@ -1,0 +1,24 @@
+---
+'@dnd-kit/core': major
+'@dnd-kit/sortable': major
+---
+
+Separated context into public and internal context providers. Certain properties that used to be available on the public `DndContextDescriptor` interface have been moved to the internal context provider and are no longer exposed to consumers:
+
+```ts
+interface DndContextDescriptor {
+-  dispatch: React.Dispatch<Actions>;
+-  activators: SyntheticListeners;
+-  ariaDescribedById: {
+-    draggable: UniqueIdentifier;
+-  };
+}
+```
+
+Having two distinct context providers will allow to keep certain internals such as `dispatch` hidden from consumers.
+
+It also serves as an optimization until context selectors are implemented in React, properties that change often, such as the droppable containers and droppable rects, the transform value and array of collisions should be stored on a different context provider to limit un-necessary re-renders in `useDraggable`, `useDroppable` and `useSortable`.
+
+The `<InternalContext.Provider>` is also reset to its default values within `<DragOverlay>`. This paves the way towards being able to seamlessly use components that use hooks such as `useDraggable` and `useDroppable` as children of `<DragOverlay>` without causing interference or namespace collisions.
+
+Consumers can still make calls to `useDndContext()` to get the `active` or `over` properties if they wish to re-render the component rendered within `DragOverlay` in response to user interaction, since those use the `PublicContext`

--- a/packages/core/src/components/DndContext/DndContext.tsx
+++ b/packages/core/src/components/DndContext/DndContext.tsx
@@ -19,8 +19,10 @@ import {
 
 import {
   Action,
-  Context,
-  DndContextDescriptor,
+  PublicContext,
+  InternalContext,
+  PublicContextDescriptor,
+  InternalContextDescriptor,
   getInitialState,
   reducer,
 } from '../../store';
@@ -596,19 +598,14 @@ export const DndContext = memo(function DndContext({
     scrollableAncestorRects,
   });
 
-  const contextValue = useMemo(() => {
-    const memoizedContext: DndContextDescriptor = {
+  const publicContext = useMemo(() => {
+    const context: PublicContextDescriptor = {
       active,
       activeNode,
       activeNodeRect,
       activatorEvent,
-      activators,
-      ariaDescribedById: {
-        draggable: draggableDescribedById,
-      },
       collisions,
       containerNodeRect,
-      dispatch,
       dragOverlay,
       draggableNodes,
       droppableContainers,
@@ -621,19 +618,16 @@ export const DndContext = memo(function DndContext({
       windowRect,
     };
 
-    return memoizedContext;
+    return context;
   }, [
     active,
     activeNode,
     activeNodeRect,
     activatorEvent,
-    activators,
     collisions,
     containerNodeRect,
     dragOverlay,
-    dispatch,
     draggableNodes,
-    draggableDescribedById,
     droppableContainers,
     droppableRects,
     over,
@@ -644,13 +638,41 @@ export const DndContext = memo(function DndContext({
     windowRect,
   ]);
 
+  const internalContext = useMemo(() => {
+    const context: InternalContextDescriptor = {
+      active,
+      activeNodeRect,
+      activators,
+      ariaDescribedById: {
+        draggable: draggableDescribedById,
+      },
+      dispatch,
+      draggableNodes,
+      over,
+      measureDroppableContainers,
+    };
+
+    return context;
+  }, [
+    active,
+    activeNodeRect,
+    activators,
+    dispatch,
+    draggableDescribedById,
+    draggableNodes,
+    over,
+    measureDroppableContainers,
+  ]);
+
   return (
     <DndMonitorContext.Provider value={monitorState}>
-      <Context.Provider value={contextValue}>
-        <ActiveDraggableContext.Provider value={transform}>
-          {children}
-        </ActiveDraggableContext.Provider>
-      </Context.Provider>
+      <InternalContext.Provider value={internalContext}>
+        <PublicContext.Provider value={publicContext}>
+          <ActiveDraggableContext.Provider value={transform}>
+            {children}
+          </ActiveDraggableContext.Provider>
+        </PublicContext.Provider>
+      </InternalContext.Provider>
       <Accessibility
         announcements={announcements}
         hiddenTextDescribedById={draggableDescribedById}

--- a/packages/core/src/components/DragOverlay/DragOverlay.tsx
+++ b/packages/core/src/components/DragOverlay/DragOverlay.tsx
@@ -1,6 +1,7 @@
 import React, {useContext, useEffect, useRef} from 'react';
-import {CSS, isKeyboardEvent, useLazyMemo} from '@dnd-kit/utilities';
+import {CSS, isKeyboardEvent, Transform, useLazyMemo} from '@dnd-kit/utilities';
 
+import {InternalContext, defaultInternalContext} from '../../store';
 import {getRelativeTransformOrigin} from '../../utilities';
 import {applyModifiers, Modifiers} from '../../modifiers';
 import {ActiveDraggableContext} from '../DndContext';
@@ -23,6 +24,13 @@ export interface Props {
   wrapperElement?: keyof JSX.IntrinsicElements;
   zIndex?: number;
 }
+
+const defaultTransform: Transform = {
+  x: 0,
+  y: 0,
+  scaleX: 1,
+  scaleY: 1,
+};
 
 const defaultTransition: TransitionGetter = (activatorEvent) => {
   const isKeyboardActivator = isKeyboardEvent(activatorEvent);
@@ -169,13 +177,19 @@ export const DragOverlay = React.memo(
       return null;
     }
 
-    return React.createElement(
-      wrapperElement,
-      {
-        ...otherAttributes,
-        ref: dragOverlay.setRef,
-      },
-      finalChildren
+    return (
+      <InternalContext.Provider value={defaultInternalContext}>
+        <ActiveDraggableContext.Provider value={defaultTransform}>
+          {React.createElement(
+            wrapperElement,
+            {
+              ...otherAttributes,
+              ref: dragOverlay.setRef,
+            },
+            finalChildren
+          )}
+        </ActiveDraggableContext.Provider>
+      </InternalContext.Provider>
     );
   }
 );

--- a/packages/core/src/hooks/useDndContext.ts
+++ b/packages/core/src/hooks/useDndContext.ts
@@ -1,8 +1,8 @@
 import {ContextType, useContext} from 'react';
-import {Context} from '../store';
+import {PublicContext} from '../store';
 
 export function useDndContext() {
-  return useContext(Context);
+  return useContext(PublicContext);
 }
 
-export type UseDndContextReturnValue = ContextType<typeof Context>;
+export type UseDndContextReturnValue = ContextType<typeof PublicContext>;

--- a/packages/core/src/hooks/useDraggable.ts
+++ b/packages/core/src/hooks/useDraggable.ts
@@ -7,7 +7,7 @@ import {
   useUniqueId,
 } from '@dnd-kit/utilities';
 
-import {Context, Data} from '../store';
+import {InternalContext, Data} from '../store';
 import {ActiveDraggableContext} from '../components/DndContext';
 import {useSyntheticListeners, SyntheticListenerMap} from './utilities';
 
@@ -38,15 +38,13 @@ export function useDraggable({
 }: UseDraggableArguments) {
   const key = useUniqueId(ID_PREFIX);
   const {
+    activators,
     active,
     activeNodeRect,
-    activatorEvent,
     ariaDescribedById,
     draggableNodes,
-    droppableRects,
-    activators,
     over,
-  } = useContext(Context);
+  } = useContext(InternalContext);
   const {role = defaultRole, roleDescription = 'draggable', tabIndex = 0} =
     attributes ?? {};
   const isDragging = active?.id === id;
@@ -87,9 +85,7 @@ export function useDraggable({
   return {
     active,
     activeNodeRect,
-    activatorEvent,
     attributes: memoizedAttributes,
-    droppableRects,
     isDragging,
     listeners: disabled ? undefined : listeners,
     node,

--- a/packages/core/src/hooks/useDroppable.ts
+++ b/packages/core/src/hooks/useDroppable.ts
@@ -6,7 +6,7 @@ import {
   useUniqueId,
 } from '@dnd-kit/utilities';
 
-import {Context, Action, Data} from '../store';
+import {InternalContext, Action, Data} from '../store';
 import type {ClientRect, UniqueIdentifier} from '../types';
 
 interface ResizeObserverConfig {
@@ -41,13 +41,9 @@ export function useDroppable({
   resizeObserverConfig,
 }: UseDroppableArguments) {
   const key = useUniqueId(ID_PREFIX);
-  const {
-    active,
-    collisions,
-    dispatch,
-    over,
-    measureDroppableContainers,
-  } = useContext(Context);
+  const {active, dispatch, over, measureDroppableContainers} = useContext(
+    InternalContext
+  );
   const resizeObserverConnected = useRef(false);
   const rect = useRef<ClientRect | null>(null);
   const callbackId = useRef<NodeJS.Timeout | null>(null);
@@ -160,7 +156,6 @@ export function useDroppable({
 
   return {
     active,
-    collisions,
     rect,
     isOver: over?.id === id,
     node: nodeRef,

--- a/packages/core/src/hooks/utilities/useDragOverlayMeasuring.ts
+++ b/packages/core/src/hooks/utilities/useDragOverlayMeasuring.ts
@@ -7,7 +7,7 @@ import {
 
 import {getMeasurableNode} from '../../utilities/nodes';
 import {getClientRect} from '../../utilities/rect';
-import type {DndContextDescriptor} from '../../store';
+import type {PublicContextDescriptor} from '../../store';
 import type {ClientRect} from '../../types';
 
 interface Arguments {
@@ -16,7 +16,7 @@ interface Arguments {
 
 export function useDragOverlayMeasuring({
   measure = getClientRect,
-}: Arguments): DndContextDescriptor['dragOverlay'] {
+}: Arguments): PublicContextDescriptor['dragOverlay'] {
   const [rect, setRect] = useState<ClientRect | null>(null);
   const measureRef = useRef(measure);
   const handleResize = useCallback(

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -72,7 +72,7 @@ export type {
 
 export type {
   Active,
-  DndContextDescriptor,
+  PublicContextDescriptor as DndContextDescriptor,
   DraggableNode,
   DroppableContainers,
   DroppableContainer,

--- a/packages/core/src/store/context.ts
+++ b/packages/core/src/store/context.ts
@@ -2,20 +2,15 @@ import {createContext} from 'react';
 
 import {noop} from '../utilities/other';
 import {DroppableContainersMap} from './constructors';
-import type {DndContextDescriptor} from './types';
+import type {InternalContextDescriptor, PublicContextDescriptor} from './types';
 
-export const Context = createContext<DndContextDescriptor>({
+export const defaultPublicContext: PublicContextDescriptor = {
   activatorEvent: null,
   active: null,
   activeNode: null,
   activeNodeRect: null,
-  activators: [],
-  ariaDescribedById: {
-    draggable: '',
-  },
   collisions: null,
   containerNodeRect: null,
-  dispatch: noop,
   draggableNodes: {},
   droppableRects: new Map(),
   droppableContainers: new DroppableContainersMap(),
@@ -32,4 +27,25 @@ export const Context = createContext<DndContextDescriptor>({
   measureDroppableContainers: noop,
   windowRect: null,
   measuringScheduled: false,
-});
+};
+
+export const defaultInternalContext: InternalContextDescriptor = {
+  active: null,
+  activeNodeRect: null,
+  activators: [],
+  ariaDescribedById: {
+    draggable: '',
+  },
+  dispatch: noop,
+  draggableNodes: {},
+  over: null,
+  measureDroppableContainers: noop,
+};
+
+export const InternalContext = createContext<InternalContextDescriptor>(
+  defaultInternalContext
+);
+
+export const PublicContext = createContext<PublicContextDescriptor>(
+  defaultPublicContext
+);

--- a/packages/core/src/store/index.ts
+++ b/packages/core/src/store/index.ts
@@ -1,5 +1,9 @@
 export {Action} from './actions';
-export {Context} from './context';
+export {
+  PublicContext,
+  InternalContext,
+  defaultInternalContext,
+} from './context';
 export {reducer, getInitialState} from './reducer';
 export type {
   Active,
@@ -10,7 +14,8 @@ export type {
   DraggableNodes,
   DroppableContainer,
   DroppableContainers,
-  DndContextDescriptor,
+  PublicContextDescriptor,
+  InternalContextDescriptor,
   RectMap,
   Over,
   State,

--- a/packages/core/src/store/types.ts
+++ b/packages/core/src/store/types.ts
@@ -71,16 +71,11 @@ export interface State {
   };
 }
 
-export interface DndContextDescriptor {
-  dispatch: React.Dispatch<Actions>;
-  activators: SyntheticListeners;
+export interface PublicContextDescriptor {
   activatorEvent: Event | null;
   active: Active | null;
   activeNode: HTMLElement | null;
   activeNodeRect: ClientRect | null;
-  ariaDescribedById: {
-    draggable: UniqueIdentifier;
-  };
   collisions: Collision[] | null;
   containerNodeRect: ClientRect | null;
   draggableNodes: DraggableNodes;
@@ -97,4 +92,17 @@ export interface DndContextDescriptor {
   measureDroppableContainers(ids: UniqueIdentifier[]): void;
   measuringScheduled: boolean;
   windowRect: ClientRect | null;
+}
+
+export interface InternalContextDescriptor {
+  activators: SyntheticListeners;
+  active: Active | null;
+  activeNodeRect: ClientRect | null;
+  ariaDescribedById: {
+    draggable: UniqueIdentifier;
+  };
+  dispatch: React.Dispatch<Actions>;
+  draggableNodes: DraggableNodes;
+  over: Over | null;
+  measureDroppableContainers(ids: UniqueIdentifier[]): void;
 }

--- a/packages/sortable/src/hooks/useSortable.ts
+++ b/packages/sortable/src/hooks/useSortable.ts
@@ -64,13 +64,7 @@ export function useSortable({
     () => items.slice(items.indexOf(id)),
     [items, id]
   );
-  const {
-    collisions,
-    rect,
-    node,
-    isOver,
-    setNodeRef: setDroppableNodeRef,
-  } = useDroppable({
+  const {rect, node, isOver, setNodeRef: setDroppableNodeRef} = useDroppable({
     id,
     data,
     resizeObserverConfig: {
@@ -81,7 +75,6 @@ export function useSortable({
   const {
     active,
     activeNodeRect,
-    activatorEvent,
     attributes,
     setNodeRef: setDraggableNodeRef,
     listeners,
@@ -168,8 +161,6 @@ export function useSortable({
     active,
     activeIndex,
     attributes,
-    activatorEvent,
-    collisions,
     rect,
     index,
     newIndex,

--- a/stories/3 - Examples/Tree/SortableTree.tsx
+++ b/stories/3 - Examples/Tree/SortableTree.tsx
@@ -35,7 +35,7 @@ import {
 } from './utilities';
 import type {FlattenedItem, SensorContext, TreeItems} from './types';
 import {sortableTreeKeyboardCoordinates} from './keyboardCoordinates';
-import {TreeItem, SortableTreeItem} from './components';
+import {SortableTreeItem} from './components';
 
 const initialItems: TreeItems = [
   {
@@ -204,7 +204,8 @@ export function SortableTree({
             modifiers={indicator ? [adjustTranslate] : undefined}
           >
             {activeId && activeItem ? (
-              <TreeItem
+              <SortableTreeItem
+                id={activeId}
                 depth={activeItem.depth}
                 clone
                 childCount={getChildCount(items, activeId) + 1}


### PR DESCRIPTION
Having two distinct context providers will allow to keep certain internals such as `dispatch` hidden from consumers. It also serves as an optimization until context selectors are implemented in React, properties that will change often, such as the droppable containers and droppable rects, the transform value and array of collisions should be stored on a different context provider to limit un-necessary re-renders in `useDraggable`, `useDroppable` and `useSortable`.


The `<InternalContext.Provider>` is also reset to its default values within `<DragOverlay>`. This paves the way towards being able to seamlessly use components that use hooks such as `useDraggable` and `useDroppable` as children of `<DragOverlay>` without causing interference or namespace collisions. Consumers can still make calls to `useDndContext()` to get the `active` or `over` properties if they wish to re-render the component rendered within `DragOverlay` in response to user interaction, since those use the `PublicContext`