### PR TITLE
Only use `ResizeObserver` if it is available in the execution context

### DIFF
--- a/.changeset/resizeobserver-execution-context.md
+++ b/.changeset/resizeobserver-execution-context.md
@@ -1,0 +1,5 @@
+---
+'@dnd-kit/core': patch
+---
+
+Only use `ResizeObserver` in `useDroppable` and `<DragOverlay>` if it is available in the execution environment.

--- a/packages/core/src/hooks/useDroppable.ts
+++ b/packages/core/src/hooks/useDroppable.ts
@@ -1,4 +1,4 @@
-import {useCallback, useContext, useEffect, useMemo, useRef} from 'react';
+import {useCallback, useContext, useEffect, useRef} from 'react';
 import {
   useIsomorphicLayoutEffect,
   useLatestValue,
@@ -8,6 +8,8 @@ import {
 
 import {InternalContext, Action, Data} from '../store';
 import type {ClientRect, UniqueIdentifier} from '../types';
+
+import {useResizeObserver} from './utilities';
 
 interface ResizeObserverConfig {
   /** Whether the ResizeObserver should be disabled entirely */
@@ -79,13 +81,10 @@ export function useDroppable({
     //eslint-disable-next-line react-hooks/exhaustive-deps
     [resizeObserverTimeout]
   );
-  const resizeObserver = useMemo(
-    () =>
-      !active || resizeObserverDisabled
-        ? null
-        : new ResizeObserver(handleResize),
-    [active, handleResize, resizeObserverDisabled]
-  );
+  const resizeObserver = useResizeObserver({
+    onResize: handleResize,
+    disabled: resizeObserverDisabled || !active,
+  });
   const handleNodeChange = useCallback(
     (newElement: HTMLElement | null, previousElement: HTMLElement | null) => {
       if (!resizeObserver) {

--- a/packages/core/src/hooks/utilities/index.ts
+++ b/packages/core/src/hooks/utilities/index.ts
@@ -12,6 +12,7 @@ export {
   MeasuringStrategy,
 } from './useDroppableMeasuring';
 export type {DroppableMeasuring} from './useDroppableMeasuring';
+export {useResizeObserver} from './useResizeObserver';
 export {useScrollOffsets} from './useScrollOffsets';
 export {useScrollableAncestors} from './useScrollableAncestors';
 export {useSensorSetup} from './useSensorSetup';

--- a/packages/core/src/hooks/utilities/useDragOverlayMeasuring.ts
+++ b/packages/core/src/hooks/utilities/useDragOverlayMeasuring.ts
@@ -1,6 +1,7 @@
 import {useMemo, useCallback, useState} from 'react';
 import {isHTMLElement, useNodeRef} from '@dnd-kit/utilities';
 
+import {useResizeObserver} from './useResizeObserver';
 import {getMeasurableNode} from '../../utilities/nodes';
 import {getClientRect} from '../../utilities/rect';
 import type {PublicContextDescriptor} from '../../store';
@@ -31,17 +32,15 @@ export function useDragOverlayMeasuring({
     },
     [measure]
   );
-  const resizeObserver = useMemo(() => new ResizeObserver(handleResize), [
-    handleResize,
-  ]);
+  const resizeObserver = useResizeObserver({onResize: handleResize});
   const handleNodeChange = useCallback(
     (element) => {
       const node = getMeasurableNode(element);
 
-      resizeObserver.disconnect();
+      resizeObserver?.disconnect();
 
       if (node) {
-        resizeObserver.observe(node);
+        resizeObserver?.observe(node);
       }
 
       setRect(node ? measure(node) : null);

--- a/packages/core/src/hooks/utilities/useResizeObserver.ts
+++ b/packages/core/src/hooks/utilities/useResizeObserver.ts
@@ -1,0 +1,28 @@
+import {useMemo} from 'react';
+
+interface Arguments {
+  disabled?: boolean;
+  onResize: ResizeObserverCallback;
+}
+
+/**
+ * Returns a new ResizeObserver instance bound to the `onResize` callback.
+ * If `ResizeObserver` is undefined in the execution environment, returns `undefined`.
+ */
+export function useResizeObserver({onResize, disabled}: Arguments) {
+  const resizeObserver = useMemo(() => {
+    if (
+      disabled ||
+      typeof window === 'undefined' ||
+      typeof window.ResizeObserver === 'undefined'
+    ) {
+      return undefined;
+    }
+
+    const {ResizeObserver} = window;
+
+    return new ResizeObserver(onResize);
+  }, [disabled, onResize]);
+
+  return resizeObserver;
+}


### PR DESCRIPTION
Fixes https://github.com/clauderic/dnd-kit/issues/572