### PR TITLE
Fix timeout callback when inactive

### DIFF
--- a/packages/core/src/hooks/useDroppable.ts
+++ b/packages/core/src/hooks/useDroppable.ts
@@ -71,6 +71,10 @@ export function useDroppable({
         clearTimeout(callbackId.current);
       }
 
+      if (!active) {
+        return;
+      }
+      
       callbackId.current = setTimeout(() => {
         measureDroppableContainers(
           typeof ids.current === 'string' ? [ids.current] : ids.current


### PR DESCRIPTION
To prevent following behavior.
Using DndContext/Sortable within a modal element.

When closing modal:

- no new resizerObserver is created (because disabled property)
- previous resizer callback is triggered (handleResize) causing timeout callback (measureDroppableContainers) to be called
- inside which a setState occurs whereas component is unmounted..

My approach is a quick fix, perhaps a better management should more suitable...