### PR TITLE
Disable droppable when disabled is flagged on useSortable

### DIFF
--- a/.changeset/fresh-lizards-destroy.md
+++ b/.changeset/fresh-lizards-destroy.md
@@ -1,0 +1,5 @@
+---
+'@dnd-kit/sortable': patch
+---
+
+Setting disabled with useSortable will now disable dropping on the sortable item.

--- a/packages/sortable/src/hooks/useSortable.ts
+++ b/packages/sortable/src/hooks/useSortable.ts
@@ -71,6 +71,7 @@ export function useSortable({
       updateMeasurementsFor: itemsAfterCurrentSortable,
       ...resizeObserverConfig,
     },
+    disabled,
   });
   const {
     active,


### PR DESCRIPTION
I'm not sure if this was left off on purpose, but when `disabled` flag is set on `useSortable`, `useDroppable` was not being disabled.

This proved problematic for me where I want to programmatically disable dropping onto sortable items.

@clauderic There may be a use case to disable one or the other (dragging vs dropping), however to me it makes sense that when you set `useSortable({ disabled: true })`, then both dragging and dropping is disabled.