### PR TITLE
fix SortableContext performance

### DIFF
--- a/.changeset/fix-sortablecontext-performance.md
+++ b/.changeset/fix-sortablecontext-performance.md
@@ -1,0 +1,5 @@
+---
+"@dnd-kit/sortable": patch
+---
+
+Fixed an issue that affected `SortableContext` performance. The `sortedRects` property of the `SortableContext` provider were being recomputed whenever coordinates changed rather than only when the order of the items changed.

--- a/packages/sortable/src/components/SortableContext.tsx
+++ b/packages/sortable/src/components/SortableContext.tsx
@@ -64,7 +64,6 @@ export function SortableContext({
   const activeIndex = active ? items.indexOf(active.id) : -1;
   const overIndex = over ? items.indexOf(over.id) : -1;
   const previousItemsRef = useRef(items);
-  const sortedRects = getSortedRects(items, droppableRects);
   const itemsHaveChanged = !isEqual(items, previousItemsRef.current);
   const disableTransforms =
     (overIndex !== -1 && activeIndex === -1) || itemsHaveChanged;
@@ -93,7 +92,7 @@ export function SortableContext({
       items,
       overIndex,
       useDragOverlay,
-      sortedRects,
+      sortedRects: getSortedRects(items, droppableRects),
       strategy,
     }),
     [
@@ -102,7 +101,7 @@ export function SortableContext({
       disableTransforms,
       items,
       overIndex,
-      sortedRects,
+      droppableRects,
       useDragOverlay,
       strategy,
     ]


### PR DESCRIPTION
Is there any reason to recompute `sortedRects` on every update?

At the moment, `sortedRects` causes context change. This will result in updating all components using `useSortable` hook on every `pointermove` event.
