### PR TITLE
Fix: Console error when unmounting a DndContext 

### DIFF
--- a/.changeset/fix-useDraggable-unmount.md
+++ b/.changeset/fix-useDraggable-unmount.md
@@ -1,0 +1,5 @@
+---
+'@dnd-kit/core': minor
+---
+
+- Added resizeObserver disconnection when useDraggable is unmounted

--- a/.changeset/fix-useDraggable-unmount.md
+++ b/.changeset/fix-useDraggable-unmount.md
@@ -1,5 +1,0 @@
----
-'@dnd-kit/core': minor
----
-
-- Added resizeObserver disconnection when useDraggable is unmounted

--- a/.changeset/fix-useDropable-unmount.md
+++ b/.changeset/fix-useDropable-unmount.md
@@ -1,0 +1,5 @@
+---
+'@dnd-kit/core': minor
+---
+
+- Added resizeObserver disconnection when useDroppable is unmounted

--- a/packages/core/src/hooks/useDroppable.ts
+++ b/packages/core/src/hooks/useDroppable.ts
@@ -113,6 +113,10 @@ export function useDroppable({
     resizeObserver.disconnect();
     resizeObserverConnected.current = false;
     resizeObserver.observe(nodeRef.current);
+
+    return () => {
+      resizeObserver.disconnect();
+    };
   }, [nodeRef, resizeObserver]);
 
   useIsomorphicLayoutEffect(


### PR DESCRIPTION
I fixed #637 

When the component with `useDroppable` is unmounted, Console error has been occurred.

The `resizeObserver` should `disconnect` or `unobserve` for preventing that error.

