### PR TITLE
Disconnect `ResizeObserver` in effect cleanup

### DIFF
--- a/.changeset/resizeobserver-unmount-cleanup.md
+++ b/.changeset/resizeobserver-unmount-cleanup.md
@@ -1,0 +1,5 @@
+---
+'@dnd-kit/core': minor
+---
+
+- Fixed React warning in development when unmounting a component that uses the `useDraggable` hook by ensuring that the `ResizeObserver` is disconnected in a cleanup effect.

--- a/packages/core/src/hooks/utilities/useResizeObserver.ts
+++ b/packages/core/src/hooks/utilities/useResizeObserver.ts
@@ -1,4 +1,4 @@
-import {useMemo} from 'react';
+import {useEffect, useMemo} from 'react';
 
 interface Arguments {
   disabled?: boolean;
@@ -23,6 +23,10 @@ export function useResizeObserver({onResize, disabled}: Arguments) {
 
     return new ResizeObserver(onResize);
   }, [disabled, onResize]);
+
+  useEffect(() => {
+    return () => resizeObserver?.disconnect();
+  }, [resizeObserver]);
 
   return resizeObserver;
 }


### PR DESCRIPTION
Fixes https://github.com/clauderic/dnd-kit/issues/637

The `ResizeObserver` in `useResizeObserver` needs to be disconnected in a cleanup effect. This fixes the React console errors that happen in development when unmounting a component that uses `useDroppable`.