### PR TITLE
[SortableContext] Always request measuring when items change

### DIFF
--- a/.changeset/always-request-measuring.md
+++ b/.changeset/always-request-measuring.md
@@ -1,0 +1,5 @@
+---
+'@dnd-kit/sortable': minor
+---
+
+`SortableContext` now always requests measuring of droppable containers when its `items` prop changes, regardless of whether or not dragging is in progress. Measuring will occur if the measuring configuration allows for it.

--- a/.changeset/respect-measuring-config.md
+++ b/.changeset/respect-measuring-config.md
@@ -1,0 +1,5 @@
+---
+'@dnd-kit/core': minor
+---
+
+The `measureDroppableContainers` method now properly respects the MeasuringStrategy defined on `<DndContext />` and will not measure containers while measuring is disabled.

--- a/packages/core/src/hooks/utilities/useDroppableMeasuring.ts
+++ b/packages/core/src/hooks/utilities/useDroppableMeasuring.ts
@@ -1,5 +1,5 @@
 import {useCallback, useEffect, useRef, useState} from 'react';
-import {useLazyMemo} from '@dnd-kit/utilities';
+import {useLatestValue, useLazyMemo} from '@dnd-kit/utilities';
 
 import {Rect, getTransformAgnosticClientRect} from '../../utilities/rect';
 import type {DroppableContainer, RectMap} from '../../store/types';
@@ -51,15 +51,21 @@ export function useDroppableMeasuring(
     ...config,
   };
   const containersRef = useRef(containers);
+  const disabled = isDisabled();
+  const disabledRef = useLatestValue(disabled);
   const measureDroppableContainers = useCallback(
-    (ids: UniqueIdentifier[] = []) =>
+    (ids: UniqueIdentifier[] = []) => {
+      if (disabledRef.current) {
+        return;
+      }
+
       setContainerIdsScheduledForMeasurement((value) =>
         value ? value.concat(ids) : ids
-      ),
-    []
+      );
+    },
+    [disabledRef]
   );
   const timeoutId = useRef<NodeJS.Timeout | null>(null);
-  const disabled = isDisabled();
   const droppableRects = useLazyMemo<RectMap>(
     (previousValue) => {
       if (disabled && !dragging) {

--- a/packages/sortable/src/components/SortableContext.tsx
+++ b/packages/sortable/src/components/SortableContext.tsx
@@ -60,7 +60,6 @@ export function SortableContext({
       ),
     [userDefinedItems]
   );
-  const isDragging = active != null;
   const activeIndex = active ? items.indexOf(active.id) : -1;
   const overIndex = over ? items.indexOf(over.id) : -1;
   const previousItemsRef = useRef(items);
@@ -69,16 +68,10 @@ export function SortableContext({
     (overIndex !== -1 && activeIndex === -1) || itemsHaveChanged;
 
   useIsomorphicLayoutEffect(() => {
-    if (itemsHaveChanged && isDragging && !measuringScheduled) {
+    if (itemsHaveChanged && !measuringScheduled) {
       measureDroppableContainers(items);
     }
-  }, [
-    itemsHaveChanged,
-    items,
-    isDragging,
-    measureDroppableContainers,
-    measuringScheduled,
-  ]);
+  }, [itemsHaveChanged, items, measureDroppableContainers, measuringScheduled]);
 
   useEffect(() => {
     previousItemsRef.current = items;


### PR DESCRIPTION
This change makes it so that SortableContext always requests that items be measured when the order or contents of the items array changes.

We defer to `useDroppableMeasuring` to decide whether to measure or not depending on the measuring strategy.