### PR TITLE
allow <DragOverlay /> consumers to provide custom drop animation

### DIFF
--- a/packages/core/src/components/DragOverlay/DragOverlay.tsx
+++ b/packages/core/src/components/DragOverlay/DragOverlay.tsx
@@ -18,6 +18,7 @@ export interface Props {
   children?: React.ReactNode;
   className?: string;
   dropAnimation?: DropAnimation | null | undefined;
+  useCustomDropAnimation?: typeof useDropAnimation | undefined;
   style?: React.CSSProperties;
   transition?: string | TransitionGetter;
   modifiers?: Modifiers;
@@ -43,6 +44,7 @@ export const DragOverlay = React.memo(
     adjustScale = false,
     children,
     dropAnimation = defaultDropAnimation,
+    useCustomDropAnimation = useDropAnimation,
     style: styleProp,
     transition = defaultTransition,
     modifiers,
@@ -147,7 +149,7 @@ export const DragOverlay = React.memo(
     const {children: finalChildren, transform: _, ...otherAttributes} =
       derivedAttributes ?? {};
     const prevActiveId = useRef(active?.id ?? null);
-    const dropAnimationComplete = useDropAnimation({
+    const dropAnimationComplete = useCustomDropAnimation({
       animate: Boolean(dropAnimation && prevActiveId.current && !active),
       adjustScale,
       activeId: prevActiveId.current,

--- a/packages/core/src/components/DragOverlay/index.ts
+++ b/packages/core/src/components/DragOverlay/index.ts
@@ -1,4 +1,4 @@
 export {DragOverlay} from './DragOverlay';
 export type {Props} from './DragOverlay';
-export {defaultDropAnimation} from './hooks';
+export {defaultDropAnimation, useDropAnimation} from './hooks';
 export type {DropAnimation} from './hooks';

--- a/packages/core/src/components/index.ts
+++ b/packages/core/src/components/index.ts
@@ -7,5 +7,9 @@ export type {
   DraggableMeasuring,
   MeasuringConfiguration,
 } from './DndContext';
-export {DragOverlay, defaultDropAnimation} from './DragOverlay';
+export {
+  DragOverlay,
+  defaultDropAnimation,
+  useDropAnimation,
+} from './DragOverlay';
 export type {DropAnimation, Props as DragOverlayProps} from './DragOverlay';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -3,6 +3,7 @@ export {
   DragOverlay,
   defaultAnnouncements,
   defaultDropAnimation,
+  useDropAnimation,
 } from './components';
 export type {
   Announcements,
@@ -101,6 +102,8 @@ export {
   closestCorners,
   rectIntersection,
   pointerWithin,
+  getTransformAgnosticClientRect,
+  getMeasurableNode,
 } from './utilities';
 export type {
   Collision,

--- a/packages/core/src/utilities/index.ts
+++ b/packages/core/src/utilities/index.ts
@@ -39,3 +39,5 @@ export {
   getScrollPosition,
   isDocumentScrollingElement,
 } from './scroll';
+
+export {getMeasurableNode} from './nodes';

--- a/stories/1 - Core/Draggable/2-DragOverlay.story.tsx
+++ b/stories/1 - Core/Draggable/2-DragOverlay.story.tsx
@@ -4,16 +4,20 @@ import {
   DndContext,
   DragOverlay,
   DropAnimation,
+  useDropAnimation,
   defaultDropAnimation,
   Modifiers,
   useDraggable,
   Translate,
+  getTransformAgnosticClientRect,
+  getMeasurableNode,
 } from '@dnd-kit/core';
 import {
   restrictToHorizontalAxis,
   restrictToVerticalAxis,
   restrictToWindowEdges,
 } from '@dnd-kit/modifiers';
+import {CSS, useIsomorphicLayoutEffect} from '@dnd-kit/utilities';
 
 import {Axis, Draggable, Wrapper} from '../../components';
 
@@ -25,6 +29,7 @@ interface Props {
   axis?: Axis;
   dragOverlayModifiers?: Modifiers;
   dropAnimation?: DropAnimation | null;
+  useCustomDropAnimation?: typeof useDropAnimation;
   handle?: boolean;
   label?: string;
   modifiers?: Modifiers;
@@ -40,6 +45,7 @@ function DragOverlayExample({
   axis,
   dragOverlayModifiers,
   dropAnimation = defaultDropAnimationConfig,
+  useCustomDropAnimation,
   handle,
   label,
   modifiers,
@@ -60,6 +66,7 @@ function DragOverlayExample({
         <DragOverlay
           modifiers={dragOverlayModifiers}
           dropAnimation={dropAnimation}
+          useCustomDropAnimation={useCustomDropAnimation}
         >
           {isDragging ? <Draggable axis={axis} dragging dragOverlay /> : null}
         </DragOverlay>,
@@ -129,3 +136,140 @@ export const RestrictToWindowEdges = () => (
     modifiers={[restrictToWindowEdges]}
   />
 );
+
+export const OverrideDropAnimation = () => (
+  <DragOverlayExample
+    label="I will animate to the center of the window when dropped"
+    modifiers={[restrictToWindowEdges]}
+    useCustomDropAnimation={useDropAnimationCenterWindow}
+  />
+);
+
+const useDropAnimationCenterWindow: typeof useDropAnimation = ({
+  animate,
+  adjustScale,
+  activeId,
+  draggableNodes,
+  duration,
+  dragSourceOpacity,
+  easing,
+  node,
+  transform,
+}) => {
+  const [dropAnimationComplete, setDropAnimationComplete] = useState(false);
+
+  useIsomorphicLayoutEffect(() => {
+    if (!animate || !activeId || !easing || !duration) {
+      if (animate) {
+        setDropAnimationComplete(true);
+      }
+
+      return;
+    }
+
+    const finalNode = draggableNodes[activeId]?.node.current;
+
+    if (transform && node && finalNode && finalNode.parentNode !== null) {
+      const fromNode = getMeasurableNode(node);
+
+      if (fromNode) {
+        const from = fromNode.getBoundingClientRect();
+        const finalNodeRect = getTransformAgnosticClientRect(finalNode);
+        // Animate to the center of the window instead of the finalNode
+        const to = {
+          ...finalNodeRect,
+          left: window.innerWidth / 2 - node.offsetWidth / 2,
+          top: window.innerHeight / 2 - node.offsetHeight / 2,
+        };
+
+        const delta = {
+          x: from.left - to.left,
+          y: from.top - to.top,
+        };
+
+        if (Math.abs(delta.x) || Math.abs(delta.y)) {
+          const scaleDelta = {
+            scaleX: adjustScale
+              ? (to.width * transform.scaleX) / from.width
+              : 1,
+            scaleY: adjustScale
+              ? (to.height * transform.scaleY) / from.height
+              : 1,
+          };
+          const finalTransform = CSS.Transform.toString({
+            x: transform.x - delta.x,
+            y: transform.y - delta.y,
+            ...scaleDelta,
+          });
+          const originalOpacity = finalNode.style.opacity;
+
+          if (dragSourceOpacity != null) {
+            finalNode.style.opacity = `${dragSourceOpacity}`;
+          }
+
+          const nodeAnimation = node.animate(
+            [
+              {
+                opacity: 1,
+                transform: CSS.Transform.toString(transform),
+                transformOrigin: 'center',
+              },
+              {
+                opacity: 1,
+                offset: 0.7,
+              },
+              {
+                transform: finalTransform,
+                opacity: 0,
+              },
+            ],
+            {
+              easing,
+              duration,
+              fill: 'both',
+            }
+          );
+
+          nodeAnimation.onfinish = () => {
+            node.style.display = 'none';
+            setDropAnimationComplete(true);
+            if (finalNode && dragSourceOpacity != null) {
+              // Fade in the drag source
+              const finalNodeAnimation = finalNode.animate(
+                [{opacity: dragSourceOpacity}, {opacity: originalOpacity || 1}],
+                {
+                  duration: 150,
+                }
+              );
+
+              finalNodeAnimation.onfinish = () => {
+                finalNode.style.opacity = originalOpacity;
+              };
+            }
+          };
+          return;
+        }
+      }
+    }
+
+    setDropAnimationComplete(true);
+  }, [
+    animate,
+    activeId,
+    adjustScale,
+    draggableNodes,
+    duration,
+    easing,
+    dragSourceOpacity,
+    node,
+    transform,
+  ]);
+
+  useIsomorphicLayoutEffect(() => {
+    if (dropAnimationComplete) {
+      setDropAnimationComplete(false);
+    }
+  }, [dropAnimationComplete]);
+
+  return dropAnimationComplete;
+};


### PR DESCRIPTION
Allow `<DragOverlay />` consumers to provide their own `useDropAnimation` hook. This is a fairly risky API as I've never encountered passing hooks as props. The alternative is to really think hard about the `useDropAnimation` API and offer consumers different places to "hook into" the hook. ;)

***

This is just a stab at #129 . It does work, but I'm open to suggestions.

Fixes #129 