### PR TITLE
Faster (and safer) equal implementation

### DIFF
--- a/packages/sortable/src/components/SortableContext.tsx
+++ b/packages/sortable/src/components/SortableContext.tsx
@@ -104,5 +104,13 @@ export function SortableContext({
 }
 
 function isEqual(arr1: string[], arr2: string[]) {
-  return arr1.join() === arr2.join();
+  if (arr1 === arr2) return true;
+  if (arr1.length !== arr2.length) return false;
+  for (let i = 0; i < arr1.length; i++) {
+    if (arr1[i] !== arr2[i]) {
+      return false;
+    }
+  }
+  return true;
 }
+


### PR DESCRIPTION
Hello! Love dnd-kit, it's working great in my application.

I'm dealing with quite a lot of data - benchmarking with 40,000 items in a sortable list. dnd-kit is mostly not a bottleneck, but I have noticed that, since I'm using uuids and quite a lot of items, the `isEqual` method takes up an appreciable amount of the performance profile, and the size of the strings generated can trigger a GC.

Hence: a non-join based isEqual implementation. I did bench this to make sure that it resolves the performance issues - seems to, about a 15x gain, not counting the reduced memory pressure.

```
joinEqual/short x 1,613,252 ops/sec ±0.66% (89 runs sampled)
joinEqual/equal x 1,808 ops/sec ±0.65% (90 runs sampled)
joinEqual/notEqual x 1,891 ops/sec ±0.59% (93 runs sampled)
joinEqual/differentLength x 1,879 ops/sec ±0.89% (90 runs sampled)
iterativeEqual/short x 23,996,960 ops/sec ±2.75% (87 runs sampled)
iterativeEqual/equal x 28,280 ops/sec ±2.18% (85 runs sampled)
iterativeEqual/notEqual x 24,164,244 ops/sec ±0.64% (91 runs sampled)
iterativeEqual/differentLength x 24,280,053 ops/sec ±0.52% (90 runs sampled)
```

[Benchmark here](https://gist.github.com/tmcw/b62db4b8ec5fffa39b6ac4cff7c056ff)

This also fixes a bug in dnd-kit, in which you could have different ID sequences that join to the same thing. For example, if you had: [a, bb, c], and the updated item ids were [ab, b, c] or any other combination of (abbc) then you'd get a false 'equal' through the join-based method.