### PR TITLE
Placeholders

### DIFF
--- a/packages/core/src/components/DndContext/DndContext.tsx
+++ b/packages/core/src/components/DndContext/DndContext.tsx
@@ -543,6 +543,8 @@ export const DndContext = memo(function DndContext({
               rect: overContainer.rect.current,
               data: overContainer.data,
               disabled: overContainer.disabled,
+              placeholderId: overContainer.placeholderDraggableId,
+              placeholderContainerId: overContainer.placeholderContainerId,
             }
           : null;
       const event: DragOverEvent = {

--- a/packages/core/src/components/DragOverlay/DragOverlay.tsx
+++ b/packages/core/src/components/DragOverlay/DragOverlay.tsx
@@ -150,7 +150,10 @@ export const DragOverlay = React.memo(
     const dropAnimationComplete = useDropAnimation({
       animate: Boolean(dropAnimation && prevActiveId.current && !active),
       adjustScale,
-      activeId: prevActiveId.current,
+      activeId:
+        over && over.placeholderId.current
+          ? over.placeholderId.current
+          : prevActiveId.current,
       draggableNodes,
       duration: dropAnimation?.duration,
       easing: dropAnimation?.easing,

--- a/packages/core/src/hooks/useDraggable.ts
+++ b/packages/core/src/hooks/useDraggable.ts
@@ -20,6 +20,8 @@ export interface UseDraggableArguments {
     roleDescription?: string;
     tabIndex?: number;
   };
+  placeholder?: boolean;
+  placeholderContainerId?: string;
 }
 
 export interface DraggableAttributes {
@@ -43,6 +45,8 @@ export function useDraggable({
   data,
   disabled = false,
   attributes,
+  placeholder = false,
+  placeholderContainerId,
 }: UseDraggableArguments) {
   const key = useUniqueId(ID_PREFIX);
   const {
@@ -56,7 +60,9 @@ export function useDraggable({
   } = useContext(InternalContext);
   const {role = defaultRole, roleDescription = 'draggable', tabIndex = 0} =
     attributes ?? {};
-  const isDragging = active?.id === id;
+  const isDragging = placeholder
+    ? over?.placeholderContainerId.current === placeholderContainerId
+    : active?.id === id;
   const transform: Transform | null = useContext(
     isDragging ? ActiveDraggableContext : NullContext
   );

--- a/packages/core/src/hooks/useDroppable.ts
+++ b/packages/core/src/hooks/useDroppable.ts
@@ -1,4 +1,4 @@
-import { useCallback, useContext, useEffect, useRef } from 'react';
+import {useCallback, useContext, useEffect, useRef} from 'react';
 import {
   useIsomorphicLayoutEffect,
   useLatestValue,
@@ -6,10 +6,10 @@ import {
   useUniqueId,
 } from '@dnd-kit/utilities';
 
-import { InternalContext, Action, Data } from '../store';
-import type { ClientRect, UniqueIdentifier } from '../types';
+import {InternalContext, Action, Data} from '../store';
+import type {ClientRect, UniqueIdentifier} from '../types';
 
-import { useResizeObserver } from './utilities';
+import {useResizeObserver} from './utilities';
 
 interface ResizeObserverConfig {
   /** Whether the ResizeObserver should be disabled entirely */
@@ -47,10 +47,10 @@ export function useDroppable({
   placeholderContainerId,
 }: UseDroppableArguments) {
   const key = useUniqueId(ID_PREFIX);
-  const { active, dispatch, over, measureDroppableContainers } = useContext(
+  const {active, dispatch, over, measureDroppableContainers} = useContext(
     InternalContext
   );
-  const previous = useRef({ disabled });
+  const previous = useRef({disabled});
   const resizeObserverConnected = useRef(false);
   const rect = useRef<ClientRect | null>(null);
   const callbackId = useRef<NodeJS.Timeout | null>(null);

--- a/packages/core/src/hooks/useDroppable.ts
+++ b/packages/core/src/hooks/useDroppable.ts
@@ -1,4 +1,4 @@
-import {useCallback, useContext, useEffect, useRef} from 'react';
+import { useCallback, useContext, useEffect, useRef } from 'react';
 import {
   useIsomorphicLayoutEffect,
   useLatestValue,
@@ -6,10 +6,10 @@ import {
   useUniqueId,
 } from '@dnd-kit/utilities';
 
-import {InternalContext, Action, Data} from '../store';
-import type {ClientRect, UniqueIdentifier} from '../types';
+import { InternalContext, Action, Data } from '../store';
+import type { ClientRect, UniqueIdentifier } from '../types';
 
-import {useResizeObserver} from './utilities';
+import { useResizeObserver } from './utilities';
 
 interface ResizeObserverConfig {
   /** Whether the ResizeObserver should be disabled entirely */
@@ -28,6 +28,8 @@ export interface UseDroppableArguments {
   disabled?: boolean;
   data?: Data;
   resizeObserverConfig?: ResizeObserverConfig;
+  placeholderDraggableId?: UniqueIdentifier;
+  placeholderContainerId?: UniqueIdentifier;
 }
 
 const ID_PREFIX = 'Droppable';
@@ -41,12 +43,14 @@ export function useDroppable({
   disabled = false,
   id,
   resizeObserverConfig,
+  placeholderDraggableId,
+  placeholderContainerId,
 }: UseDroppableArguments) {
   const key = useUniqueId(ID_PREFIX);
-  const {active, dispatch, over, measureDroppableContainers} = useContext(
+  const { active, dispatch, over, measureDroppableContainers } = useContext(
     InternalContext
   );
-  const previous = useRef({disabled});
+  const previous = useRef({ disabled });
   const resizeObserverConnected = useRef(false);
   const rect = useRef<ClientRect | null>(null);
   const callbackId = useRef<NodeJS.Timeout | null>(null);
@@ -105,6 +109,8 @@ export function useDroppable({
   );
   const [nodeRef, setNodeRef] = useNodeRef(handleNodeChange);
   const dataRef = useLatestValue(data);
+  const placeholderDraggableIdRef = useLatestValue(placeholderDraggableId);
+  const placeholderContainerIdRef = useLatestValue(placeholderContainerId);
 
   useEffect(() => {
     if (!resizeObserver || !nodeRef.current) {
@@ -127,6 +133,8 @@ export function useDroppable({
           node: nodeRef,
           rect,
           data: dataRef,
+          placeholderDraggableId: placeholderDraggableIdRef,
+          placeholderContainerId: placeholderContainerIdRef,
         },
       });
 

--- a/packages/core/src/store/types.ts
+++ b/packages/core/src/store/types.ts
@@ -25,6 +25,8 @@ export interface DroppableContainer {
   disabled: boolean;
   node: MutableRefObject<HTMLElement | null>;
   rect: MutableRefObject<ClientRect | null>;
+  placeholderDraggableId: MutableRefObject<UniqueIdentifier | undefined>;
+  placeholderContainerId: MutableRefObject<UniqueIdentifier | undefined>;
 }
 
 export interface Active {
@@ -41,6 +43,8 @@ export interface Over {
   rect: ClientRect;
   disabled: boolean;
   data: DataRef;
+  placeholderId: MutableRefObject<UniqueIdentifier | undefined>;
+  placeholderContainerId: MutableRefObject<UniqueIdentifier | undefined>;
 }
 
 export type DraggableNode = {

--- a/packages/sortable/src/hooks/defaults.ts
+++ b/packages/sortable/src/hooks/defaults.ts
@@ -30,7 +30,6 @@ export const defaultAnimateLayoutChanges: AnimateLayoutChanges = ({
     return false;
   }
 
-  // wenn items sich nur durch placeholder geändert hat -> nicht false returnen
   if (previousItems !== items && index === newIndex) {
     return false;
   }

--- a/packages/sortable/src/hooks/defaults.ts
+++ b/packages/sortable/src/hooks/defaults.ts
@@ -1,6 +1,6 @@
-import { CSS } from '@dnd-kit/utilities';
+import {CSS} from '@dnd-kit/utilities';
 
-import { arrayMove } from '../utilities';
+import {arrayMove} from '../utilities';
 
 import type {
   AnimateLayoutChanges,

--- a/packages/sortable/src/hooks/defaults.ts
+++ b/packages/sortable/src/hooks/defaults.ts
@@ -1,6 +1,6 @@
-import {CSS} from '@dnd-kit/utilities';
+import { CSS } from '@dnd-kit/utilities';
 
-import {arrayMove} from '../utilities';
+import { arrayMove } from '../utilities';
 
 import type {
   AnimateLayoutChanges,
@@ -30,6 +30,7 @@ export const defaultAnimateLayoutChanges: AnimateLayoutChanges = ({
     return false;
   }
 
+  // wenn items sich nur durch placeholder geändert hat -> nicht false returnen
   if (previousItems !== items && index === newIndex) {
     return false;
   }

--- a/stories/1 - Core/Droppable/Droppable.story.tsx
+++ b/stories/1 - Core/Droppable/Droppable.story.tsx
@@ -13,6 +13,7 @@ import {
 } from '@dnd-kit/core';
 
 import {Draggable, Droppable, GridContainer, Wrapper} from '../../components';
+import {useUniqueId} from '@dnd-kit/utilities';
 
 export default {
   title: 'Core/Droppable/useDroppable',
@@ -23,17 +24,21 @@ interface Props {
   containers?: string[];
   modifiers?: Modifiers;
   value?: string;
+  placeholder?: boolean;
 }
 
 function DroppableStory({
   containers = ['A'],
   collisionDetection,
   modifiers,
+  placeholder = false,
 }: Props) {
   const [isDragging, setIsDragging] = useState(false);
   const [parent, setParent] = useState<UniqueIdentifier | null>(null);
 
   const item = <DraggableItem />;
+
+  const placeholderId = useUniqueId('Placeholder');
 
   return (
     <DndContext
@@ -52,8 +57,19 @@ function DroppableStory({
         </Wrapper>
         <GridContainer columns={2}>
           {containers.map((id) => (
-            <Droppable key={id} id={id} dragging={isDragging}>
+            <Droppable
+              key={id}
+              id={id}
+              dragging={isDragging}
+              placeholderId={placeholderId}
+            >
               {parent === id ? item : null}
+              {parent !== id && placeholder && (
+                <PlaceholderItem
+                  placeholderId={placeholderId}
+                  placeholderContainerId={id}
+                />
+              )}
             </Droppable>
           ))}
         </GridContainer>
@@ -87,7 +103,33 @@ function DraggableItem({handle}: DraggableProps) {
   );
 }
 
+interface PlaceholderItemProps {
+  placeholderId: string;
+  placeholderContainerId: string;
+}
+
+function PlaceholderItem({
+  placeholderId,
+  placeholderContainerId,
+}: PlaceholderItemProps) {
+  const {isDragging, over, setNodeRef} = useDraggable({
+    id: placeholderId,
+    placeholder: true,
+    placeholderContainerId: placeholderContainerId,
+  });
+
+  const isPlaceholderActive = over?.id === placeholderContainerId;
+
+  if (!isPlaceholderActive) {
+    return null;
+  }
+
+  return <Draggable dragging={isDragging} ref={setNodeRef} />;
+}
+
 export const BasicSetup = () => <DroppableStory />;
+
+export const Placeholder = () => <DroppableStory placeholder />;
 
 export const MultipleDroppables = () => (
   <DroppableStory containers={['A', 'B', 'C']} />

--- a/stories/2 - Presets/Sortable/4-MultipleContainers.story.tsx
+++ b/stories/2 - Presets/Sortable/4-MultipleContainers.story.tsx
@@ -1,10 +1,11 @@
-import React from 'react';
+import React, {useState} from 'react';
 import type {CancelDrop} from '@dnd-kit/core';
 import {rectSortingStrategy} from '@dnd-kit/sortable';
 
 import {MultipleContainers, TRASH_ID} from './MultipleContainers';
 
 import {ConfirmModal} from '../../components';
+import {MultipleContainersWithPlaceholders} from './MultipleContainersWithPlaceholders';
 
 export default {
   title: 'Presets/Sortable/Multiple Containers',
@@ -23,6 +24,83 @@ export const ManyItems = () => (
 );
 
 export const Vertical = () => <MultipleContainers itemCount={5} vertical />;
+
+export const DynamicPlaceholder = () => {
+  const [customDragOverlayHeight, setCustomDragOverlayHeight] = useState(50);
+  const [activatePlaceholder, setActivatePlaceholder] = useState(true);
+  const [
+    activateCustomDragOverlayHeight,
+    setActivateCustomDragOverlayHeight,
+  ] = useState(false);
+  const [trackDragOverlayHeight, setTrackDragOverlayHeight] = useState(false);
+  const props = {
+    placeholder: activatePlaceholder,
+    customDragOverlayHeight,
+    activateCustomDragOverlayHeight,
+    trackDragOverlayHeight,
+  };
+  return (
+    <>
+      <MultipleContainersWithPlaceholders {...props} />
+      <div
+        style={{
+          position: 'absolute',
+          bottom: 20,
+          left: 20,
+          display: 'flex',
+          flexDirection: 'column',
+        }}
+      >
+        <h3>Features</h3>
+        <label>
+          <input
+            type="checkbox"
+            checked={activatePlaceholder}
+            onChange={(event) => setActivatePlaceholder(event?.target.checked)}
+          />
+          Activate Placeholder
+        </label>
+        <div
+          style={{
+            display: 'flex',
+            flexDirection: 'row',
+          }}
+        >
+          <label>
+            <input
+              type="checkbox"
+              value="closestCenter"
+              checked={activateCustomDragOverlayHeight}
+              onChange={(event) =>
+                setActivateCustomDragOverlayHeight(event?.target.checked)
+              }
+            />
+            UseCustom DragOverlay Height
+          </label>
+          <label style={{marginLeft: '1rem'}}>
+            <input
+              type="number"
+              value={customDragOverlayHeight}
+              onChange={(event) =>
+                setCustomDragOverlayHeight(parseInt(event.target.value))
+              }
+            />
+          </label>
+        </div>
+        <label>
+          <input
+            type="checkbox"
+            checked={trackDragOverlayHeight}
+            onChange={(event) =>
+              setTrackDragOverlayHeight(event?.target.checked)
+            }
+          />
+          Track DragOverlay height on Placeholder
+        </label>
+      </div>
+    </>
+  );
+};
 
 export const TrashableItems = ({confirmDrop}: {confirmDrop: boolean}) => {
   const [activeId, setActiveId] = React.useState<string | null>(null);

--- a/stories/2 - Presets/Sortable/MultipleContainersWithPlaceholders.tsx
+++ b/stories/2 - Presets/Sortable/MultipleContainersWithPlaceholders.tsx
@@ -1,0 +1,796 @@
+import React, {
+  CSSProperties,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
+import {createPortal, unstable_batchedUpdates} from 'react-dom';
+import {
+  CancelDrop,
+  closestCenter,
+  pointerWithin,
+  rectIntersection,
+  CollisionDetection,
+  DndContext,
+  DragOverlay,
+  DropAnimation,
+  defaultDropAnimation,
+  getFirstCollision,
+  KeyboardSensor,
+  MouseSensor,
+  TouchSensor,
+  Modifiers,
+  useDroppable,
+  UniqueIdentifier,
+  useSensors,
+  useSensor,
+  MeasuringStrategy,
+  KeyboardCoordinateGetter,
+  useDndContext,
+} from '@dnd-kit/core';
+import {
+  AnimateLayoutChanges,
+  SortableContext,
+  useSortable,
+  arrayMove,
+  defaultAnimateLayoutChanges,
+  verticalListSortingStrategy,
+  SortingStrategy,
+  horizontalListSortingStrategy,
+} from '@dnd-kit/sortable';
+import {CSS, useUniqueId} from '@dnd-kit/utilities';
+import {coordinateGetter as multipleContainersCoordinateGetter} from './multipleContainersKeyboardCoordinates';
+
+import {Item, Container, ContainerProps} from '../../components';
+
+import {createRange} from '../../utilities';
+
+export default {
+  title: 'Presets/Sortable/Multiple Containers',
+};
+
+const animateLayoutChanges: AnimateLayoutChanges = (args) =>
+  args.isSorting || args.wasDragging ? defaultAnimateLayoutChanges(args) : true;
+
+function DroppableContainer({
+  children,
+  columns = 1,
+  disabled,
+  id,
+  items,
+  style,
+  placeholderId,
+  ...props
+}: ContainerProps & {
+  disabled?: boolean;
+  id: string;
+  items: string[];
+  style?: React.CSSProperties;
+}) {
+  const {
+    attributes,
+    isDragging,
+    listeners,
+    over,
+    setNodeRef,
+    transition,
+    transform,
+  } = useSortable({
+    id,
+    data: {
+      type: 'container',
+      children: items,
+    },
+    animateLayoutChanges,
+    // placeholderId,
+  });
+  const overContainerId: string = over?.data.current?.sortable?.containerId;
+  const overId = overContainerId?.replace('sortable-', '');
+  const isOverContainer = overId === id || over?.id === id;
+
+  return (
+    <Container
+      ref={disabled ? undefined : setNodeRef}
+      style={{
+        ...style,
+        transition,
+        transform: CSS.Translate.toString(transform),
+        opacity: isDragging ? 0.5 : undefined,
+      }}
+      hover={isOverContainer}
+      handleProps={{
+        ...attributes,
+        ...listeners,
+      }}
+      columns={columns}
+      {...props}
+    >
+      {children}
+    </Container>
+  );
+}
+
+const dropAnimation: DropAnimation = {
+  ...defaultDropAnimation,
+  dragSourceOpacity: 0.5,
+};
+
+type Items = Record<string, string[]>;
+
+interface Props {
+  adjustScale?: boolean;
+  cancelDrop?: CancelDrop;
+  columns?: number;
+  containerStyle?: React.CSSProperties;
+  coordinateGetter?: KeyboardCoordinateGetter;
+  getItemStyles?(args: {
+    value: UniqueIdentifier;
+    index: number;
+    overIndex: number;
+    isDragging: boolean;
+    containerId: UniqueIdentifier;
+    isSorting: boolean;
+    isDragOverlay: boolean;
+  }): React.CSSProperties;
+  wrapperStyle?(args: {index: number}): React.CSSProperties;
+  itemCount?: number;
+  items?: Items;
+  handle?: boolean;
+  renderItem?: any;
+  strategy?: SortingStrategy;
+  modifiers?: Modifiers;
+  minimal?: boolean;
+  trashable?: boolean;
+  scrollable?: boolean;
+  vertical?: boolean;
+  placeholder?: boolean;
+  customDragOverlayHeight?: number;
+  activateCustomDragOverlayHeight?: boolean;
+  trackDragOverlayHeight?: boolean;
+}
+
+export const TRASH_ID = 'void';
+const PLACEHOLDER_ID = 'placeholder';
+const empty: UniqueIdentifier[] = [];
+
+export function MultipleContainersWithPlaceholders({
+  adjustScale = false,
+  itemCount = 3,
+  cancelDrop,
+  columns,
+  handle = false,
+  items: initialItems,
+  containerStyle,
+  coordinateGetter = multipleContainersCoordinateGetter,
+  getItemStyles = () => ({}),
+  wrapperStyle = () => ({}),
+  minimal = false,
+  modifiers,
+  renderItem,
+  strategy = verticalListSortingStrategy,
+  trashable = false,
+  vertical = false,
+  scrollable,
+  placeholder = false,
+  activateCustomDragOverlayHeight,
+  customDragOverlayHeight,
+  trackDragOverlayHeight,
+}: Props) {
+  const [items, setItems] = useState<Items>(
+    () =>
+      initialItems ?? {
+        A: createRange(itemCount, (index) => `A${index + 1}`),
+        B: createRange(itemCount, (index) => `B${index + 1}`),
+        C: createRange(itemCount, (index) => `C${index + 1}`),
+        D: createRange(itemCount, (index) => `D${index + 1}`),
+      }
+  );
+  const [containers, setContainers] = useState(Object.keys(items));
+  const [activeId, setActiveId] = useState<string | null>(null);
+  const lastOverId = useRef<UniqueIdentifier | null>(null);
+  const recentlyMovedToNewContainer = useRef(false);
+  const isSortingContainer = activeId ? containers.includes(activeId) : false;
+  const placeholderId = useUniqueId('Placeholder');
+
+  /**
+   * Custom collision detection strategy optimized for multiple containers
+   *
+   * - First, find any droppable containers intersecting with the pointer.
+   * - If there are none, find intersecting containers with the active draggable.
+   * - If there are no intersecting containers, return the last matched intersection
+   *
+   */
+  const collisionDetectionStrategy: CollisionDetection = useCallback(
+    (args) => {
+      if (activeId && activeId in items) {
+        return closestCenter({
+          ...args,
+          droppableContainers: args.droppableContainers.filter(
+            (container) => container.id in items
+          ),
+        });
+      }
+
+      // Start by finding any intersecting droppable
+      const pointerIntersections = pointerWithin(args);
+      const intersections =
+        pointerIntersections.length > 0
+          ? // If there are droppables intersecting with the pointer, return those
+            pointerIntersections
+          : rectIntersection(args);
+      let overId = getFirstCollision(intersections, 'id');
+
+      if (overId != null) {
+        if (overId === TRASH_ID) {
+          // If the intersecting droppable is the trash, return early
+          // Remove this if you're not using trashable functionality in your app
+          return intersections;
+        }
+
+        if (overId in items) {
+          const containerItems = items[overId];
+
+          // If a container is matched and it contains items (columns 'A', 'B', 'C')
+          if (containerItems.length > 0) {
+            // Return the closest droppable within that container
+            overId = closestCenter({
+              ...args,
+              droppableContainers: args.droppableContainers.filter(
+                (container) =>
+                  container.id !== overId &&
+                  containerItems.includes(container.id)
+              ),
+            })[0]?.id;
+          }
+        }
+
+        lastOverId.current = overId;
+
+        return [{id: overId}];
+      }
+
+      // When a draggable item moves to a new container, the layout may shift
+      // and the `overId` may become `null`. We manually set the cached `lastOverId`
+      // to the id of the draggable item that was moved to the new container, otherwise
+      // the previous `overId` will be returned which can cause items to incorrectly shift positions
+      if (recentlyMovedToNewContainer.current) {
+        lastOverId.current = activeId;
+      }
+
+      // If no droppable is matched, return the last match
+      return lastOverId.current ? [{id: lastOverId.current}] : [];
+    },
+    [activeId, items]
+  );
+  const [clonedItems, setClonedItems] = useState<Items | null>(null);
+  const sensors = useSensors(
+    useSensor(MouseSensor),
+    useSensor(TouchSensor),
+    useSensor(KeyboardSensor, {
+      coordinateGetter,
+    })
+  );
+  const findContainer = (id: string) => {
+    if (id in items) {
+      return id;
+    }
+
+    return Object.keys(items).find((key) => items[key].includes(id));
+  };
+
+  const getIndex = (id: string) => {
+    const container = findContainer(id);
+
+    if (!container) {
+      return -1;
+    }
+
+    const index = items[container].indexOf(id);
+
+    return index;
+  };
+
+  const onDragCancel = () => {
+    if (clonedItems) {
+      // Reset items to their original state in case items have been
+      // Dragged across containers
+      setItems(clonedItems);
+    }
+
+    setActiveId(null);
+    setClonedItems(null);
+  };
+
+  useEffect(() => {
+    requestAnimationFrame(() => {
+      recentlyMovedToNewContainer.current = false;
+    });
+  }, [items]);
+
+  return (
+    <DndContext
+      sensors={sensors}
+      collisionDetection={collisionDetectionStrategy}
+      measuring={{
+        droppable: {
+          strategy: MeasuringStrategy.Always,
+        },
+      }}
+      onDragStart={({active}) => {
+        setActiveId(active.id);
+        setClonedItems(items);
+      }}
+      onDragEnd={({active, over}) => {
+        const overId = over?.id;
+
+        if (!overId || overId === TRASH_ID || active.id in items) {
+          return;
+        }
+
+        const overContainerId: string =
+          over?.data.current?.sortable?.containerId;
+        const overContainer =
+          findContainer(overId) ?? overContainerId.replace('sortable-', '');
+        const activeContainer = findContainer(active.id);
+
+        if (!overContainer || !activeContainer) {
+          return;
+        }
+
+        setItems((items) => {
+          const activeItems = items[activeContainer];
+          const overItems = items[overContainer];
+          const overIndex = overItems.indexOf(overId);
+          const activeIndex = activeItems.indexOf(active.id);
+
+          let newIndex: number;
+
+          if (overId in items) {
+            newIndex = overItems.length + 1;
+          } else {
+            const isBelowOverItem =
+              over &&
+              active.rect.current.translated &&
+              active.rect.current.translated.top >
+                over.rect.top + over.rect.height;
+
+            const modifier = isBelowOverItem ? 1 : 0;
+
+            newIndex =
+              overIndex >= 0 ? overIndex + modifier : overItems.length + 1;
+          }
+
+          recentlyMovedToNewContainer.current = true;
+
+          if (activeContainer !== overContainer) {
+            return {
+              ...items,
+              [activeContainer]: items[activeContainer].filter(
+                (item) => item !== active.id
+              ),
+              [overContainer]: [
+                ...items[overContainer].slice(0, newIndex),
+                items[activeContainer][activeIndex],
+                ...items[overContainer].slice(
+                  newIndex,
+                  items[overContainer].length
+                ),
+              ],
+            };
+          } else {
+            return {
+              ...items,
+              [overContainer]: arrayMove(
+                items[overContainer],
+                activeIndex,
+                newIndex
+              ),
+            };
+          }
+        });
+
+        if (active.id in items && over?.id) {
+          setContainers((containers) => {
+            const activeIndex = containers.indexOf(active.id);
+            const overIndex = containers.indexOf(over.id);
+
+            return arrayMove(containers, activeIndex, overIndex);
+          });
+        }
+
+        if (!activeContainer) {
+          setActiveId(null);
+          return;
+        }
+
+        if (!overId) {
+          setActiveId(null);
+          return;
+        }
+
+        if (overId === TRASH_ID) {
+          setItems((items) => ({
+            ...items,
+            [activeContainer]: items[activeContainer].filter(
+              (id) => id !== activeId
+            ),
+          }));
+          setActiveId(null);
+          return;
+        }
+
+        if (overId === PLACEHOLDER_ID) {
+          const newContainerId = getNextContainerId();
+
+          unstable_batchedUpdates(() => {
+            setContainers((containers) => [...containers, newContainerId]);
+            setItems((items) => ({
+              ...items,
+              [activeContainer]: items[activeContainer].filter(
+                (id) => id !== activeId
+              ),
+              [newContainerId]: [active.id],
+            }));
+            setActiveId(null);
+          });
+          return;
+        }
+
+        setActiveId(null);
+      }}
+      cancelDrop={cancelDrop}
+      onDragCancel={onDragCancel}
+      modifiers={modifiers}
+    >
+      <div
+        style={{
+          display: 'inline-grid',
+          boxSizing: 'border-box',
+          padding: 20,
+          gridAutoFlow: vertical ? 'row' : 'column',
+        }}
+      >
+        <SortableContext
+          items={[...containers]}
+          strategy={
+            vertical
+              ? verticalListSortingStrategy
+              : horizontalListSortingStrategy
+          }
+        >
+          {containers.map((containerId) => {
+            const containerPlaceholderId = `${containerId}-${placeholderId}`;
+            const sortableId = `sortable-${containerId}`;
+
+            return (
+              <DroppableContainer
+                key={containerId}
+                id={containerId}
+                label={minimal ? undefined : `Column ${containerId}`}
+                columns={columns}
+                items={items[containerId]}
+                scrollable={scrollable}
+                style={containerStyle}
+                unstyled={minimal}
+                onRemove={() => handleRemove(containerId)}
+                placeholderId={containerPlaceholderId}
+              >
+                <SortableContext
+                  id={sortableId}
+                  items={items[containerId]}
+                  strategy={strategy}
+                >
+                  {items[containerId].map((value, index) => {
+                    return (
+                      <SortableItem
+                        placeholderId={containerPlaceholderId}
+                        placeholderContainerId={sortableId}
+                        disabled={isSortingContainer}
+                        key={value}
+                        id={value}
+                        index={index}
+                        handle={handle}
+                        style={getItemStyles}
+                        wrapperStyle={wrapperStyle}
+                        renderItem={renderItem}
+                        containerId={containerId}
+                        getIndex={getIndex}
+                      />
+                    );
+                  })}
+                  {placeholder && (
+                    <PlaceholderItem
+                      id={containerPlaceholderId}
+                      placeholderId={containerPlaceholderId}
+                      placeholderContainerId={sortableId}
+                      disabled={isSortingContainer}
+                      key={containerPlaceholderId}
+                      index={items[containerId].length}
+                      handle={handle}
+                      style={getItemStyles}
+                      wrapperStyle={wrapperStyle}
+                      renderItem={renderItem}
+                      containerId={containerId}
+                      getIndex={getIndex}
+                      trackDragOverlayHeight={trackDragOverlayHeight}
+                    />
+                  )}
+                </SortableContext>
+              </DroppableContainer>
+            );
+          })}
+          {minimal ? undefined : (
+            <DroppableContainer
+              id={PLACEHOLDER_ID}
+              disabled={isSortingContainer}
+              items={empty}
+              onClick={handleAddColumn}
+              placeholder
+            >
+              + Add column
+            </DroppableContainer>
+          )}
+        </SortableContext>
+      </div>
+      {createPortal(
+        <DragOverlay adjustScale={adjustScale} dropAnimation={dropAnimation}>
+          {activeId
+            ? containers.includes(activeId)
+              ? renderContainerDragOverlay(activeId)
+              : renderSortableItemDragOverlay(activeId)
+            : null}
+        </DragOverlay>,
+        document.body
+      )}
+      {trashable && activeId && !containers.includes(activeId) ? (
+        <Trash id={TRASH_ID} />
+      ) : null}
+    </DndContext>
+  );
+
+  function renderSortableItemDragOverlay(id: string) {
+    const dragOverlayStyle = {
+      ...getItemStyles({
+        containerId: findContainer(id) as string,
+        overIndex: -1,
+        index: getIndex(id),
+        value: id,
+        isSorting: true,
+        isDragging: true,
+        isDragOverlay: true,
+      }),
+      height: activateCustomDragOverlayHeight
+        ? customDragOverlayHeight
+        : undefined,
+    };
+    return (
+      <Item
+        value={id}
+        handle={handle}
+        style={dragOverlayStyle}
+        color={getColor(id)}
+        wrapperStyle={wrapperStyle({index: 0})}
+        renderItem={renderItem}
+        dragOverlay
+      />
+    );
+  }
+
+  function renderContainerDragOverlay(containerId: string) {
+    return (
+      <Container
+        label={`Column ${containerId}`}
+        columns={columns}
+        style={{
+          height: '100%',
+        }}
+        shadow
+        unstyled={false}
+      >
+        {items[containerId].map((item, index) => (
+          <Item
+            key={item}
+            value={item}
+            handle={handle}
+            style={getItemStyles({
+              containerId,
+              overIndex: -1,
+              index: getIndex(item),
+              value: item,
+              isDragging: false,
+              isSorting: false,
+              isDragOverlay: false,
+            })}
+            color={getColor(item)}
+            wrapperStyle={wrapperStyle({index})}
+            renderItem={renderItem}
+          />
+        ))}
+      </Container>
+    );
+  }
+
+  function handleRemove(containerID: UniqueIdentifier) {
+    setContainers((containers) =>
+      containers.filter((id) => id !== containerID)
+    );
+  }
+
+  function handleAddColumn() {
+    const newContainerId = getNextContainerId();
+
+    unstable_batchedUpdates(() => {
+      setContainers((containers) => [...containers, newContainerId]);
+      setItems((items) => ({
+        ...items,
+        [newContainerId]: [],
+      }));
+    });
+  }
+
+  function getNextContainerId() {
+    const containerIds = Object.keys(items);
+    const lastContainerId = containerIds[containerIds.length - 1];
+
+    return String.fromCharCode(lastContainerId.charCodeAt(0) + 1);
+  }
+}
+
+function getColor(id: string) {
+  switch (id[0]) {
+    case 'A':
+      return '#7193f1';
+    case 'B':
+      return '#ffda6c';
+    case 'C':
+      return '#00bcd4';
+    case 'D':
+      return '#ef769f';
+  }
+
+  return undefined;
+}
+
+function Trash({id}: {id: UniqueIdentifier}) {
+  const {setNodeRef, isOver} = useDroppable({
+    id,
+  });
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        position: 'fixed',
+        left: '50%',
+        marginLeft: -150,
+        bottom: 20,
+        width: 300,
+        height: 60,
+        borderRadius: 5,
+        border: '1px solid',
+        borderColor: isOver ? 'red' : '#DDD',
+      }}
+    >
+      Drop here to delete
+    </div>
+  );
+}
+
+interface SortableItemProps {
+  containerId: string;
+  id: string;
+  index: number;
+  handle: boolean;
+  disabled?: boolean;
+  style(args: any): React.CSSProperties;
+  getIndex(id: string): number;
+  renderItem(): React.ReactElement;
+  wrapperStyle({index}: {index: number}): React.CSSProperties;
+  placeholder?: boolean;
+  placeholderId?: string;
+  placeholderContainerId?: string;
+  trackDragOverlayHeight?: boolean;
+}
+
+function SortableItem({
+  disabled,
+  id,
+  index,
+  handle,
+  renderItem,
+  style,
+  containerId,
+  getIndex,
+  wrapperStyle,
+  placeholder = false,
+  placeholderId,
+  placeholderContainerId,
+}: SortableItemProps) {
+  const {
+    active,
+    setNodeRef,
+    listeners,
+    isDragging,
+    isSorting,
+    over,
+    overIndex,
+    transform,
+    transition,
+  } = useSortable({
+    id,
+    placeholder,
+    placeholderId,
+    placeholderContainerId,
+  });
+  const mounted = useMountStatus();
+  const mountedWhileDragging = isDragging && !mounted;
+  const isSourceSortable =
+    active?.data?.current?.sortable.containerId === placeholderContainerId;
+  const isPlaceholderActive =
+    placeholder &&
+    over?.data.current?.sortable?.containerId === placeholderContainerId;
+  if (
+    (placeholder && isSourceSortable) ||
+    (placeholder && !isPlaceholderActive)
+  ) {
+    return null;
+  }
+
+  return (
+    <Item
+      ref={disabled ? undefined : setNodeRef}
+      value={id}
+      dragging={isDragging}
+      sorting={isSorting}
+      handle={handle}
+      index={index}
+      wrapperStyle={wrapperStyle({index})}
+      style={style({
+        index,
+        value: id,
+        isDragging,
+        isSorting,
+        overIndex: over ? getIndex(over.id) : overIndex,
+        containerId,
+      })}
+      color={getColor(id)}
+      transition={transition}
+      transform={transform}
+      fadeIn={mountedWhileDragging}
+      listeners={listeners}
+      renderItem={renderItem}
+    />
+  );
+}
+
+function PlaceholderItem({
+  style: placeholderStyleProp,
+  trackDragOverlayHeight,
+  ...props
+}: SortableItemProps) {
+  const {dragOverlay} = useDndContext();
+  const dragOverlayHeight = dragOverlay?.rect?.height;
+  const placeholderStyle = useCallback((): CSSProperties => {
+    return {
+      height: trackDragOverlayHeight ? dragOverlayHeight : undefined,
+    };
+  }, [dragOverlayHeight, trackDragOverlayHeight]);
+
+  return <SortableItem placeholder style={placeholderStyle} {...props} />;
+}
+
+function useMountStatus() {
+  const [isMounted, setIsMounted] = useState(false);
+
+  useEffect(() => {
+    const timeout = setTimeout(() => setIsMounted(true), 500);
+
+    return () => clearTimeout(timeout);
+  }, []);
+
+  return isMounted;
+}

--- a/stories/components/Container/Container.tsx
+++ b/stories/components/Container/Container.tsx
@@ -4,6 +4,7 @@ import classNames from 'classnames';
 import {Handle, Remove} from '../Item';
 
 import styles from './Container.module.css';
+import type {UniqueIdentifier} from '@dnd-kit/core';
 
 export interface Props {
   children: React.ReactNode;
@@ -19,6 +20,7 @@ export interface Props {
   unstyled?: boolean;
   onClick?(): void;
   onRemove?(): void;
+  placeholderId?: UniqueIdentifier;
 }
 
 export const Container = forwardRef<HTMLDivElement, Props>(

--- a/stories/components/Droppable/Droppable.tsx
+++ b/stories/components/Droppable/Droppable.tsx
@@ -9,11 +9,13 @@ interface Props {
   children: React.ReactNode;
   dragging: boolean;
   id: UniqueIdentifier;
+  placeholderId?: UniqueIdentifier;
 }
 
-export function Droppable({children, id, dragging}: Props) {
+export function Droppable({children, id, dragging, placeholderId}: Props) {
   const {isOver, setNodeRef} = useDroppable({
     id,
+    placeholderDraggableId: placeholderId,
   });
 
   return (


### PR DESCRIPTION
@clauderic first of all:
Thanks for this fantastic lib!
I've invested so much time to adapt and marry `react-dnd` and `react-beautiful-dnd` before realizing that `dnd-kit` may be able to make my life a LOT easier.

## Motivation
When I first started using `dnd-kit` I didn't even notice that placeholders were not supported that prominently, because in the app I maintain most drop zones only show a full overlay over the dropzone when you drag an element over them that can be dropped.

In a common sortable scenario where you only move an existing entry around placeholders are also not a problem.
But when I tried to implement a dynamic list where entries can be added and sorted in the same step via drag-n-drop I started to realize that this can be very complicated. 

Especially when you use custom appearances for one or more of the elements participating in the operation (e.g. custom drag overlay that represents an abstract type, but becomes a specialized type once you move it onto a droppable). Furthermore I felt a lack of control to independently style and customize certain behaviors.

Another thing that I noticed is that drop animations are limited in terms of animating to a drop target, because a drag mostly seems to be treated as a "move" operation. In case of a "copy" operation the placeholder can also serve as a target to animate the drop to.

## Demo

I've added two Stories that demonstrate the behaviors this PR enables.

These videos give you a glimpse of the functionality - feel free to check out the branch and try it yourself.

### Placeholder for a regular Droppable
https://user-images.githubusercontent.com/16539774/168794615-110769a7-f9ce-4d75-8dff-511f32f713e5.mov

### Dynamic Placeholder for a Sortable
https://user-images.githubusercontent.com/16539774/168794940-8d7a18f2-4c6a-4ac9-993e-b9ffe08d1fcc.mov

### Dynamic Placeholder with a custom height DragOverlay
https://user-images.githubusercontent.com/16539774/168795026-d9ac4a27-89a5-49eb-8498-5870f267fcd6.mov

### Dynamic Placeholder that tracks the custom height of the DragOverlay
https://user-images.githubusercontent.com/16539774/168795104-df702731-ec2b-4256-95b6-eb98bedd5957.mov

## Implementation
This is just my naive first try to implement the behavior I was missing. I'm sure there are edge cases that I might have missed and the API can certainly be improved as well.

I'd rather use this as a starting point for the discussion. There are some dirty hacks included that I didn't put too much effort into yet (e.g. string-replace to parse an id when I didn't have a good idea how to achieve it in a clean fashion).
