### PR TITLE
Introduce auto-scroll intent tracking

### DIFF
--- a/.changeset/autoscroll-intent-tracking.md
+++ b/.changeset/autoscroll-intent-tracking.md
@@ -1,0 +1,5 @@
+---
+'@dnd-kit/core': minor
+---
+
+The auto scroller now keeps track of the drag direction to infer scroll intent. By default, auto-scrolling will now be disabled for a given direction if dragging in that direction hasn't occurred yet. This prevents accidental auto-scrolling when picking up a draggable item that is near the scroll boundary threshold.

--- a/packages/core/src/components/DndContext/DndContext.tsx
+++ b/packages/core/src/components/DndContext/DndContext.tsx
@@ -598,6 +598,7 @@ export const DndContext = memo(function DndContext({
 
   useAutoScroller({
     ...autoScrollOptions,
+    delta: translate,
     draggingRect: collisionRect,
     pointerCoordinates,
     scrollableAncestors,


### PR DESCRIPTION
Fixes https://github.com/clauderic/dnd-kit/issues/362

The auto scroller now keeps track of the drag direction to infer scroll intent. By default, auto-scrolling will now be disabled for a given direction if dragging in that direction hasn't occurred yet. This prevents accidental auto-scrolling when picking up a draggable item that is near the scroll boundary threshold.

#### Before

https://user-images.githubusercontent.com/1416436/168849280-8df2eb81-bf40-4766-998f-bf5725680de5.mov


#### After

https://user-images.githubusercontent.com/1416436/168849317-268fe2f6-2d2a-46b8-8761-57d9fe3e6024.mov
