### PR TITLE
Fallback to initial rect when active node un-mounts during initialization

### DIFF
--- a/.changeset/active-rect-fallback.md
+++ b/.changeset/active-rect-fallback.md
@@ -1,0 +1,5 @@
+---
+'@dnd-kit/core': patch
+---
+
+Fallback to initial rect measured for the active draggable node if it unmounts during initialization (after `onDragStart` is dispatched).

--- a/packages/core/src/hooks/utilities/index.ts
+++ b/packages/core/src/hooks/utilities/index.ts
@@ -14,6 +14,7 @@ export {
 export type {DroppableMeasuring} from './useDroppableMeasuring';
 export {useInitialValue} from './useInitialValue';
 export {useRect} from './useRect';
+export {useRectDelta} from './useRectDelta';
 export {useResizeObserver} from './useResizeObserver';
 export {useScrollableAncestors} from './useScrollableAncestors';
 export {useScrollIntoViewIfNeeded} from './useScrollIntoViewIfNeeded';

--- a/packages/core/src/hooks/utilities/useRect.ts
+++ b/packages/core/src/hooks/utilities/useRect.ts
@@ -9,9 +9,11 @@ import {useResizeObserver} from './useResizeObserver';
 
 export function useRect(
   element: HTMLElement | null,
-  measure: (element: HTMLElement) => ClientRect = getClientRect
+  measure: (element: HTMLElement) => ClientRect = getClientRect,
+  fallbackRect?: ClientRect | null
 ) {
   const [rect, measureRect] = useReducer(reducer, null);
+
   const mutationObserver = useMutationObserver({
     callback(records) {
       if (!element) {
@@ -54,6 +56,12 @@ export function useRect(
   function reducer(currentRect: ClientRect | null) {
     if (!element) {
       return null;
+    }
+
+    if (element.isConnected === false) {
+      // Fall back to last rect we measured if the element is
+      // no longer connected to the DOM.
+      return currentRect ?? fallbackRect ?? null;
     }
 
     const newRect = measure(element);

--- a/packages/core/src/hooks/utilities/useRectDelta.ts
+++ b/packages/core/src/hooks/utilities/useRectDelta.ts
@@ -1,0 +1,10 @@
+import type {ClientRect} from '../../types';
+import {getRectDelta} from '../../utilities';
+
+import {useInitialValue} from './useInitialValue';
+
+export function useRectDelta(rect: ClientRect | null) {
+  const initialRect = useInitialValue(rect);
+
+  return getRectDelta(rect, initialRect);
+}


### PR DESCRIPTION
The `<DragOverlay>` [refactor PR](https://github.com/clauderic/dnd-kit/pull/733) introduced a regression for some consumers that are unmounting the active draggable node `onDragStart`. 

This PR ensures that we fall back to the initial measurement of the active draggable node that was measured right before propagating the `onDragStart` event if the active draggable node unmounts subsequently and is disconnected from the DOM.