### PR TITLE
Fix race conditions with layout shift scroll compensation

### DIFF
--- a/.changeset/layout-shift-compensation.md
+++ b/.changeset/layout-shift-compensation.md
@@ -13,7 +13,7 @@ interface AutoScrollOptions {
   canScroll?: CanScroll;
   enabled?: boolean;
   interval?: number;
-+ layoutShiftCompensation?: boolean;
++ layoutShiftCompensation?: boolean | {x: boolean, y: boolean};
   order?: TraversalOrder;
   threshold?: {
     x: number;
@@ -22,7 +22,15 @@ interface AutoScrollOptions {
 }
 ```
 
-To disable layout shift scroll compensation, pass in the following autoscroll configuration to `<DndContext>`:
+To enable/disable layout shift scroll compensation for a single scroll axis, pass in the following autoscroll configuration to `<DndContext>`:
+
+```ts
+<DndContext
+  autoScroll={{layoutShiftCompensation: {x: false, y: true}}}
+>
+```
+
+To completely disable layout shift scroll compensation, pass in the following autoscroll configuration to `<DndContext>`:
 
 ```ts
 <DndContext

--- a/packages/core/src/components/DndContext/DndContext.tsx
+++ b/packages/core/src/components/DndContext/DndContext.tsx
@@ -35,14 +35,15 @@ import {
   useCombineActivators,
   useDragOverlayMeasuring,
   useDroppableMeasuring,
-  useScrollableAncestors,
-  useSensorSetup,
-  useRects,
-  useWindowRect,
+  useInitialRect,
   useRect,
   useRectDelta,
+  useRects,
+  useScrollableAncestors,
   useScrollOffsets,
   useScrollOffsetsDelta,
+  useSensorSetup,
+  useWindowRect,
 } from '../../hooks/utilities';
 import type {AutoScrollOptions, SyntheticListener} from '../../hooks/utilities';
 import type {
@@ -192,19 +193,14 @@ export const DndContext = memo(function DndContext({
     [activatorEvent]
   );
   const autoScrollOptions = getAutoScrollerOptions();
-  const layoutShiftCompensationDisabled =
-    activationCoordinates == null ||
-    autoScrollOptions.layoutShiftCompensation === false;
-  const initialActiveNodeRect = useMemo(
-    () =>
-      activeNode ? measuringConfiguration.draggable.measure(activeNode) : null,
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [activeNode, measuringConfiguration.draggable.measure]
+  const initialActiveNodeRect = useInitialRect(
+    activeNode,
+    measuringConfiguration.draggable.measure
   );
 
   useLayoutShiftScrollCompensation({
-    disabled: layoutShiftCompensationDisabled,
-    element: activeNode,
+    activeNode: activeId ? draggableNodes[activeId] : null,
+    config: autoScrollOptions.layoutShiftCompensation,
     initialRect: initialActiveNodeRect,
     measure: measuringConfiguration.draggable.measure,
   });

--- a/packages/core/src/hooks/utilities/index.ts
+++ b/packages/core/src/hooks/utilities/index.ts
@@ -13,6 +13,7 @@ export {
 } from './useDroppableMeasuring';
 export type {DroppableMeasuring} from './useDroppableMeasuring';
 export {useInitialValue} from './useInitialValue';
+export {useInitialRect} from './useInitialRect';
 export {useRect} from './useRect';
 export {useRectDelta} from './useRectDelta';
 export {useResizeObserver} from './useResizeObserver';

--- a/packages/core/src/hooks/utilities/useAutoScroller.ts
+++ b/packages/core/src/hooks/utilities/useAutoScroller.ts
@@ -18,7 +18,12 @@ export interface Options {
   canScroll?: CanScroll;
   enabled?: boolean;
   interval?: number;
-  layoutShiftCompensation?: boolean;
+  layoutShiftCompensation?:
+    | boolean
+    | {
+        x: boolean;
+        y: boolean;
+      };
   order?: TraversalOrder;
   threshold?: {
     x: number;

--- a/packages/core/src/hooks/utilities/useInitialRect.ts
+++ b/packages/core/src/hooks/utilities/useInitialRect.ts
@@ -1,0 +1,9 @@
+import type {ClientRect} from '../../types';
+import {useInitialValue} from './useInitialValue';
+
+export function useInitialRect(
+  node: HTMLElement | null,
+  measure: (node: HTMLElement) => ClientRect
+) {
+  return useInitialValue(node, measure);
+}

--- a/packages/core/src/hooks/utilities/useInitialValue.ts
+++ b/packages/core/src/hooks/utilities/useInitialValue.ts
@@ -1,7 +1,15 @@
 import {useLazyMemo} from '@dnd-kit/utilities';
 
-export function useInitialValue<T>(value: T | null) {
-  return useLazyMemo<T | null>(
+type AnyFunction = (...args: any) => any;
+
+export function useInitialValue<
+  T,
+  U extends AnyFunction | undefined = undefined
+>(
+  value: T | null,
+  computeFn?: U
+): U extends AnyFunction ? ReturnType<U> | null : T | null {
+  return useLazyMemo(
     (previousValue) => {
       if (!value) {
         return null;
@@ -11,8 +19,8 @@ export function useInitialValue<T>(value: T | null) {
         return previousValue;
       }
 
-      return value;
+      return typeof computeFn === 'function' ? computeFn(value) : value;
     },
-    [value]
+    [computeFn, value]
   );
 }


### PR DESCRIPTION
The layout shift scroll compensation effect needs to read the most up to date active node ref to make sure the value isn't stale by the time the effect runs.

This PR also introduces the ability to conditionally enable/disable layout shift scroll compensation for only a single scroll axis by passing a configuration object: `{layoutShiftCompensation: {x: false, y: true}`.