### PR TITLE
[Accessibility] Introduce activator node refs and automatic focus management

### DIFF
--- a/.changeset/activator-node-ref.md
+++ b/.changeset/activator-node-ref.md
@@ -1,0 +1,51 @@
+---
+'@dnd-kit/core': minor
+'@dnd-kit/sortable': minor
+---
+
+#### Introducing activator node refs
+
+Introducing the concept of activator node refs for `useDraggable` and `useSortable`. This allows @dnd-kit to handle common use-cases such as restoring focus on the activator node after dragging via the keyboard or only allowing the activator node to instantiate the keyboard sensor.
+
+Consumers of `useDraggable` and `useSortable` may now optionally set the activator node ref on the element that receives listeners:
+
+```diff
+import {useDraggable} from '@dnd-kit/core';
+
+function Draggable(props) {
+  const {
+    listeners,
+    setNodeRef,
++   setActivatorNodeRef,
+  } = useDraggable({id: props.id});
+
+  return (
+    <div ref={setNodeRef}>
+      Draggable element
+      <button
+        {...listeners}
++       ref={setActivatorNodeRef}
+      >
+        :: Drag Handle
+      </button>
+    </div>
+  )
+}
+```
+
+It's common for the activator element (the element that receives the sensor listeners) to differ from the draggable node. When this happens, @dnd-kit has no reliable way to get a reference to the activator node after dragging ends, as the original `event.target` that instantiated the sensor may no longer be mounted in the DOM or associated with the draggable node that was previously active.
+
+#### Automatically restoring focus
+
+Focus management is now automatically handled by @dnd-kit. When the activator event is a Keyboard event, @dnd-kit will now attempt to automatically restore focus back to the first focusable node of the activator node or draggable node.
+
+If no activator node is specified via the `setActivatorNodeRef` setter function of `useDraggble` and `useSortable`, @dnd-kit will automatically restore focus on the first focusable node of the draggable node set via the `setNodeRef` setter function of `useDraggable` and `useSortable`.
+
+If you were previously managing focus manually and would like to opt-out of automatic focus management, use the newly introduced `restoreFocus` property of the `accessibility` prop of `<DndContext>`:
+
+```diff
+<DndContext
+  accessibility={{
++   restoreFocus: false
+  }}
+```

--- a/.changeset/first-focusable-node.md
+++ b/.changeset/first-focusable-node.md
@@ -1,0 +1,5 @@
+---
+'@dnd-kit/utilities': minor
+---
+
+Introduced the `findFirstFocusableNode` utility function that returns the first focusable node within a given HTMLElement, or the element itself if it is focusable.

--- a/packages/core/src/components/Accessibility/Accessibility.tsx
+++ b/packages/core/src/components/Accessibility/Accessibility.tsx
@@ -3,13 +3,14 @@ import {createPortal} from 'react-dom';
 import {useUniqueId} from '@dnd-kit/utilities';
 import {HiddenText, LiveRegion, useAnnouncement} from '@dnd-kit/accessibility';
 
-import type {Announcements, ScreenReaderInstructions} from './types';
+import {DndMonitorArguments, useDndMonitor} from '../../hooks/monitor';
 import type {UniqueIdentifier} from '../../types';
+
+import type {Announcements, ScreenReaderInstructions} from './types';
 import {
   defaultAnnouncements,
   defaultScreenReaderInstructions,
 } from './defaults';
-import {DndMonitorArguments, useDndMonitor} from '../../hooks/monitor';
 
 interface Props {
   announcements?: Announcements;

--- a/packages/core/src/components/Accessibility/components/index.ts
+++ b/packages/core/src/components/Accessibility/components/index.ts
@@ -1,0 +1,1 @@
+export {RestoreFocus} from './RestoreFocus';

--- a/packages/core/src/components/Accessibility/hooks/index.ts
+++ b/packages/core/src/components/Accessibility/hooks/index.ts
@@ -1,1 +1,0 @@
-export {useRestoreFocus} from './useRestoreFocus';

--- a/packages/core/src/components/Accessibility/hooks/index.ts
+++ b/packages/core/src/components/Accessibility/hooks/index.ts
@@ -1,0 +1,1 @@
+export {useRestoreFocus} from './useRestoreFocus';

--- a/packages/core/src/components/Accessibility/hooks/useRestoreFocus.tsx
+++ b/packages/core/src/components/Accessibility/hooks/useRestoreFocus.tsx
@@ -1,0 +1,71 @@
+import {useEffect} from 'react';
+import {
+  findFirstFocusableNode,
+  isKeyboardEvent,
+  usePrevious,
+} from '@dnd-kit/utilities';
+
+import type {DraggableNodes} from '../../../store';
+import type {UniqueIdentifier} from '../../../types';
+
+interface Arguments {
+  activeId: UniqueIdentifier | null;
+  activatorEvent: Event | null;
+  disabled: boolean;
+  draggableNodes: DraggableNodes;
+}
+
+export function useRestoreFocus({
+  activeId,
+  activatorEvent,
+  disabled,
+  draggableNodes,
+}: Arguments) {
+  const previousActivatorEvent = usePrevious(activatorEvent);
+  const previousActiveId = usePrevious(activeId);
+
+  // Restore keyboard focus on the activator node
+  useEffect(() => {
+    if (disabled) {
+      return;
+    }
+
+    if (!activatorEvent && previousActivatorEvent && previousActiveId != null) {
+      if (!isKeyboardEvent(previousActivatorEvent)) {
+        return;
+      }
+
+      if (document.activeElement === previousActivatorEvent.target) {
+        // No need to restore focus
+        return;
+      }
+
+      const draggableNode = draggableNodes[previousActiveId];
+
+      if (!draggableNode) {
+        return;
+      }
+
+      const {node, activatorNode} = draggableNode;
+
+      for (const element of [node.current, activatorNode.current]) {
+        if (!element) {
+          continue;
+        }
+
+        const focusableNode = findFirstFocusableNode(element);
+
+        if (focusableNode) {
+          focusableNode.focus();
+          break;
+        }
+      }
+    }
+  }, [
+    activatorEvent,
+    disabled,
+    draggableNodes,
+    previousActiveId,
+    previousActivatorEvent,
+  ]);
+}

--- a/packages/core/src/components/Accessibility/index.ts
+++ b/packages/core/src/components/Accessibility/index.ts
@@ -1,7 +1,7 @@
 export {Accessibility} from './Accessibility';
+export {RestoreFocus} from './components';
 export {
   defaultAnnouncements,
   defaultScreenReaderInstructions,
 } from './defaults';
 export type {Announcements, ScreenReaderInstructions} from './types';
-export {useRestoreFocus} from './hooks';

--- a/packages/core/src/components/Accessibility/index.ts
+++ b/packages/core/src/components/Accessibility/index.ts
@@ -4,3 +4,4 @@ export {
   defaultScreenReaderInstructions,
 } from './defaults';
 export type {Announcements, ScreenReaderInstructions} from './types';
+export {useRestoreFocus} from './hooks';

--- a/packages/core/src/components/DndContext/DndContext.tsx
+++ b/packages/core/src/components/DndContext/DndContext.tsx
@@ -74,7 +74,7 @@ import type {
 import {
   Accessibility,
   Announcements,
-  useRestoreFocus,
+  RestoreFocus,
   ScreenReaderInstructions,
 } from '../Accessibility';
 
@@ -617,13 +617,6 @@ export const DndContext = memo(function DndContext({
     scrollableAncestorRects,
   });
 
-  useRestoreFocus({
-    activeId,
-    activatorEvent,
-    disabled: accessibility?.restoreFocus === false,
-    draggableNodes,
-  });
-
   const publicContext = useMemo(() => {
     const context: PublicContextDescriptor = {
       active,
@@ -702,6 +695,7 @@ export const DndContext = memo(function DndContext({
             {children}
           </ActiveDraggableContext.Provider>
         </PublicContext.Provider>
+        <RestoreFocus disabled={accessibility?.restoreFocus === false} />
       </InternalContext.Provider>
       <Accessibility
         {...accessibility}

--- a/packages/core/src/components/DndContext/DndContext.tsx
+++ b/packages/core/src/components/DndContext/DndContext.tsx
@@ -74,6 +74,7 @@ import type {
 import {
   Accessibility,
   Announcements,
+  useRestoreFocus,
   ScreenReaderInstructions,
 } from '../Accessibility';
 
@@ -89,6 +90,7 @@ export interface Props {
   accessibility?: {
     announcements?: Announcements;
     container?: Element;
+    restoreFocus?: boolean;
     screenReaderInstructions?: ScreenReaderInstructions;
   };
   autoScroll?: boolean | AutoScrollOptions;
@@ -613,6 +615,13 @@ export const DndContext = memo(function DndContext({
     pointerCoordinates,
     scrollableAncestors,
     scrollableAncestorRects,
+  });
+
+  useRestoreFocus({
+    activeId,
+    activatorEvent,
+    disabled: accessibility?.restoreFocus === false,
+    draggableNodes,
   });
 
   const publicContext = useMemo(() => {

--- a/packages/core/src/components/DndContext/hooks/index.ts
+++ b/packages/core/src/components/DndContext/hooks/index.ts
@@ -1,0 +1,2 @@
+export {useMeasuringConfiguration} from './useMeasuringConfiguration';
+export {useLayoutShiftScrollCompensation} from './useLayoutShiftScrollCompensation';

--- a/packages/core/src/components/DndContext/hooks/useLayoutShiftScrollCompensation.ts
+++ b/packages/core/src/components/DndContext/hooks/useLayoutShiftScrollCompensation.ts
@@ -1,36 +1,11 @@
-import {useMemo, useRef} from 'react';
+import {useRef} from 'react';
 import {useIsomorphicLayoutEffect} from '@dnd-kit/utilities';
-import type {DeepRequired} from '@dnd-kit/utilities';
 
-import {getRectDelta} from '../../utilities/rect';
-import {getFirstScrollableAncestor} from '../../utilities/scroll';
-import type {ClientRect} from '../../types';
-import {defaultMeasuringConfiguration} from './defaults';
-import type {MeasuringFunction, MeasuringConfiguration} from './types';
-import type {DraggableNode} from '../../store';
-
-export function useMeasuringConfiguration(
-  config: MeasuringConfiguration | undefined
-): DeepRequired<MeasuringConfiguration> {
-  return useMemo(
-    () => ({
-      draggable: {
-        ...defaultMeasuringConfiguration.draggable,
-        ...config?.draggable,
-      },
-      droppable: {
-        ...defaultMeasuringConfiguration.droppable,
-        ...config?.droppable,
-      },
-      dragOverlay: {
-        ...defaultMeasuringConfiguration.dragOverlay,
-        ...config?.dragOverlay,
-      },
-    }),
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [config?.draggable, config?.droppable, config?.dragOverlay]
-  );
-}
+import {getRectDelta} from '../../../utilities/rect';
+import {getFirstScrollableAncestor} from '../../../utilities/scroll';
+import type {ClientRect} from '../../../types';
+import type {DraggableNode} from '../../../store';
+import type {MeasuringFunction} from '../types';
 
 interface Options {
   activeNode: DraggableNode | null | undefined;

--- a/packages/core/src/components/DndContext/hooks/useMeasuringConfiguration.ts
+++ b/packages/core/src/components/DndContext/hooks/useMeasuringConfiguration.ts
@@ -1,0 +1,28 @@
+import {useMemo} from 'react';
+import type {DeepRequired} from '@dnd-kit/utilities';
+
+import {defaultMeasuringConfiguration} from '../defaults';
+import type {MeasuringConfiguration} from '../types';
+
+export function useMeasuringConfiguration(
+  config: MeasuringConfiguration | undefined
+): DeepRequired<MeasuringConfiguration> {
+  return useMemo(
+    () => ({
+      draggable: {
+        ...defaultMeasuringConfiguration.draggable,
+        ...config?.draggable,
+      },
+      droppable: {
+        ...defaultMeasuringConfiguration.droppable,
+        ...config?.droppable,
+      },
+      dragOverlay: {
+        ...defaultMeasuringConfiguration.dragOverlay,
+        ...config?.dragOverlay,
+      },
+    }),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [config?.draggable, config?.droppable, config?.dragOverlay]
+  );
+}

--- a/packages/core/src/hooks/useDraggable.ts
+++ b/packages/core/src/hooks/useDraggable.ts
@@ -61,12 +61,13 @@ export function useDraggable({
     isDragging ? ActiveDraggableContext : NullContext
   );
   const [node, setNodeRef] = useNodeRef();
+  const [activatorNode, setActivatorNodeRef] = useNodeRef();
   const listeners = useSyntheticListeners(activators, id);
   const dataRef = useLatestValue(data);
 
   useIsomorphicLayoutEffect(
     () => {
-      draggableNodes[id] = {id, key, node, data: dataRef};
+      draggableNodes[id] = {id, key, node, activatorNode, data: dataRef};
 
       return () => {
         const node = draggableNodes[id];
@@ -101,6 +102,7 @@ export function useDraggable({
     node,
     over,
     setNodeRef,
+    setActivatorNodeRef,
     transform,
   };
 }

--- a/packages/core/src/hooks/utilities/useCombineActivators.ts
+++ b/packages/core/src/hooks/utilities/useCombineActivators.ts
@@ -1,6 +1,6 @@
 import {useMemo} from 'react';
 
-import type {SensorDescriptor, SensorHandler} from '../../sensors';
+import type {SensorActivatorFunction, SensorDescriptor} from '../../sensors';
 import type {
   SyntheticListener,
   SyntheticListeners,
@@ -9,7 +9,7 @@ import type {
 export function useCombineActivators(
   sensors: SensorDescriptor<any>[],
   getSyntheticHandler: (
-    handler: SensorHandler,
+    handler: SensorActivatorFunction<any>,
     sensor: SensorDescriptor<any>
   ) => SyntheticListener['handler']
 ): SyntheticListeners {

--- a/packages/core/src/sensors/index.ts
+++ b/packages/core/src/sensors/index.ts
@@ -32,6 +32,7 @@ export type {
   Response as SensorResponse,
   Sensor,
   Sensors,
+  SensorActivatorFunction,
   SensorDescriptor,
   SensorContext,
   SensorHandler,

--- a/packages/core/src/sensors/keyboard/KeyboardSensor.ts
+++ b/packages/core/src/sensors/keyboard/KeyboardSensor.ts
@@ -15,7 +15,12 @@ import {
 import {scrollIntoViewIfNeeded} from '../../utilities/scroll';
 import {EventName} from '../events';
 import {Listeners} from '../utilities';
-import type {SensorInstance, SensorProps, SensorOptions} from '../types';
+import type {
+  Activators,
+  SensorInstance,
+  SensorProps,
+  SensorOptions,
+} from '../types';
 
 import {KeyboardCoordinateGetter, KeyboardCode, KeyboardCodes} from './types';
 import {
@@ -263,19 +268,23 @@ export class KeyboardSensor implements SensorInstance {
     this.windowListeners.removeAll();
   }
 
-  static activators = [
+  static activators: Activators<KeyboardSensorOptions> = [
     {
       eventName: 'onKeyDown' as const,
       handler: (
         event: React.KeyboardEvent,
-        {
-          keyboardCodes = defaultKeyboardCodes,
-          onActivation,
-        }: KeyboardSensorOptions
+        {keyboardCodes = defaultKeyboardCodes, onActivation},
+        {active}
       ) => {
         const {code} = event.nativeEvent;
 
         if (keyboardCodes.start.includes(code)) {
+          const activator = active.activatorNode.current;
+
+          if (activator && event.target !== activator) {
+            return false;
+          }
+
           event.preventDefault();
 
           onActivation?.({event: event.nativeEvent});

--- a/packages/core/src/sensors/types.ts
+++ b/packages/core/src/sensors/types.ts
@@ -55,9 +55,17 @@ export type SensorInstance = {
   autoScrollEnabled: boolean;
 };
 
+export type SensorActivatorFunction<T> = (
+  event: any,
+  options: T,
+  context: {
+    active: DraggableNode;
+  }
+) => boolean | undefined;
+
 export type Activator<T> = {
   eventName: SyntheticEventName;
-  handler(event: React.SyntheticEvent, options: T): boolean | undefined;
+  handler: SensorActivatorFunction<T>;
 };
 
 export type Activators<T> = Activator<T>[];

--- a/packages/core/src/store/types.ts
+++ b/packages/core/src/store/types.ts
@@ -50,6 +50,7 @@ export type DraggableNode = {
   id: UniqueIdentifier;
   key: UniqueIdentifier;
   node: MutableRefObject<HTMLElement | null>;
+  activatorNode: MutableRefObject<HTMLElement | null>;
   data: DataRef;
 };
 

--- a/packages/sortable/src/hooks/useSortable.ts
+++ b/packages/sortable/src/hooks/useSortable.ts
@@ -81,6 +81,7 @@ export function useSortable({
     listeners,
     isDragging,
     over,
+    setActivatorNodeRef,
     transform,
   } = useDraggable({
     id,
@@ -179,6 +180,7 @@ export function useSortable({
     overIndex,
     over,
     setNodeRef,
+    setActivatorNodeRef,
     setDroppableNodeRef,
     setDraggableNodeRef,
     transform: derivedTransform ?? finalTransform,

--- a/packages/utilities/src/focus/findFirstFocusableNode.ts
+++ b/packages/utilities/src/focus/findFirstFocusableNode.ts
@@ -1,0 +1,12 @@
+const SELECTOR =
+  'a,frame,iframe,input:not([type=hidden]):not(:disabled),select:not(:disabled),textarea:not(:disabled),button:not(:disabled),*[tabindex]';
+
+export function findFirstFocusableNode(
+  element: HTMLElement
+): HTMLElement | null {
+  if (element.matches(SELECTOR)) {
+    return element;
+  }
+
+  return element.querySelector(SELECTOR);
+}

--- a/packages/utilities/src/focus/index.ts
+++ b/packages/utilities/src/focus/index.ts
@@ -1,0 +1,1 @@
+export {findFirstFocusableNode} from './findFirstFocusableNode';

--- a/packages/utilities/src/index.ts
+++ b/packages/utilities/src/index.ts
@@ -21,6 +21,7 @@ export {
   isTouchEvent,
 } from './event';
 export {canUseDOM, getOwnerDocument, getWindow} from './execution-context';
+export {findFirstFocusableNode} from './focus';
 export {
   isDocument,
   isHTMLElement,

--- a/stories/2 - Presets/Sortable/4-MultipleContainers.story.tsx
+++ b/stories/2 - Presets/Sortable/4-MultipleContainers.story.tsx
@@ -12,6 +12,8 @@ export default {
 
 export const BasicSetup = () => <MultipleContainers />;
 
+export const DragHandle = () => <MultipleContainers handle />;
+
 export const ManyItems = () => (
   <MultipleContainers
     containerStyle={{

--- a/stories/2 - Presets/Sortable/MultipleContainers.tsx
+++ b/stories/2 - Presets/Sortable/MultipleContainers.tsx
@@ -670,6 +670,7 @@ function SortableItem({
 }: SortableItemProps) {
   const {
     setNodeRef,
+    setActivatorNodeRef,
     listeners,
     isDragging,
     isSorting,
@@ -690,6 +691,7 @@ function SortableItem({
       dragging={isDragging}
       sorting={isSorting}
       handle={handle}
+      handleProps={handle ? {ref: setActivatorNodeRef} : undefined}
       index={index}
       wrapperStyle={wrapperStyle({index})}
       style={style({

--- a/stories/2 - Presets/Sortable/Sortable.tsx
+++ b/stories/2 - Presets/Sortable/Sortable.tsx
@@ -308,6 +308,7 @@ export function SortableItem({
     listeners,
     overIndex,
     setNodeRef,
+    setActivatorNodeRef,
     transform,
     transition,
   } = useSortable({
@@ -325,6 +326,13 @@ export function SortableItem({
       dragging={isDragging}
       sorting={isSorting}
       handle={handle}
+      handleProps={
+        handle
+          ? {
+              ref: setActivatorNodeRef,
+            }
+          : undefined
+      }
       renderItem={renderItem}
       index={index}
       style={style({

--- a/stories/components/Item/Item.tsx
+++ b/stories/components/Item/Item.tsx
@@ -13,6 +13,7 @@ export interface Props {
   disabled?: boolean;
   dragging?: boolean;
   handle?: boolean;
+  handleProps?: any;
   height?: number;
   index?: number;
   fadeIn?: boolean;
@@ -49,6 +50,7 @@ export const Item = React.memo(
         disabled,
         fadeIn,
         handle,
+        handleProps,
         height,
         index,
         listeners,
@@ -142,7 +144,7 @@ export const Item = React.memo(
               {onRemove ? (
                 <Remove className={styles.Remove} onClick={onRemove} />
               ) : null}
-              {handle ? <Handle {...listeners} /> : null}
+              {handle ? <Handle {...handleProps} {...listeners} /> : null}
             </span>
           </div>
         </li>

--- a/stories/components/Item/components/Action/Action.tsx
+++ b/stories/components/Item/components/Action/Action.tsx
@@ -1,4 +1,4 @@
-import React, {CSSProperties} from 'react';
+import React, {forwardRef, CSSProperties} from 'react';
 import classNames from 'classnames';
 
 import styles from './Action.module.css';
@@ -11,20 +11,23 @@ export interface Props extends React.HTMLAttributes<HTMLButtonElement> {
   cursor?: CSSProperties['cursor'];
 }
 
-export function Action({active, className, cursor, style, ...props}: Props) {
-  return (
-    <button
-      {...props}
-      className={classNames(styles.Action, className)}
-      tabIndex={0}
-      style={
-        {
-          ...style,
-          cursor,
-          '--fill': active?.fill,
-          '--background': active?.background,
-        } as CSSProperties
-      }
-    />
-  );
-}
+export const Action = forwardRef<HTMLButtonElement, Props>(
+  ({active, className, cursor, style, ...props}, ref) => {
+    return (
+      <button
+        ref={ref}
+        {...props}
+        className={classNames(styles.Action, className)}
+        tabIndex={0}
+        style={
+          {
+            ...style,
+            cursor,
+            '--fill': active?.fill,
+            '--background': active?.background,
+          } as CSSProperties
+        }
+      />
+    );
+  }
+);

--- a/stories/components/Item/components/Handle/Handle.tsx
+++ b/stories/components/Item/components/Handle/Handle.tsx
@@ -1,13 +1,20 @@
-import React from 'react';
+import React, {forwardRef} from 'react';
 
 import {Action, ActionProps} from '../Action';
 
-export function Handle(props: ActionProps) {
-  return (
-    <Action cursor="grab" data-cypress="draggable-handle" {...props}>
-      <svg viewBox="0 0 20 20" width="12">
-        <path d="M7 2a2 2 0 1 0 .001 4.001A2 2 0 0 0 7 2zm0 6a2 2 0 1 0 .001 4.001A2 2 0 0 0 7 8zm0 6a2 2 0 1 0 .001 4.001A2 2 0 0 0 7 14zm6-8a2 2 0 1 0-.001-4.001A2 2 0 0 0 13 6zm0 2a2 2 0 1 0 .001 4.001A2 2 0 0 0 13 8zm0 6a2 2 0 1 0 .001 4.001A2 2 0 0 0 13 14z"></path>
-      </svg>
-    </Action>
-  );
-}
+export const Handle = forwardRef<HTMLButtonElement, ActionProps>(
+  (props, ref) => {
+    return (
+      <Action
+        ref={ref}
+        cursor="grab"
+        data-cypress="draggable-handle"
+        {...props}
+      >
+        <svg viewBox="0 0 20 20" width="12">
+          <path d="M7 2a2 2 0 1 0 .001 4.001A2 2 0 0 0 7 2zm0 6a2 2 0 1 0 .001 4.001A2 2 0 0 0 7 8zm0 6a2 2 0 1 0 .001 4.001A2 2 0 0 0 7 14zm6-8a2 2 0 1 0-.001-4.001A2 2 0 0 0 13 6zm0 2a2 2 0 1 0 .001 4.001A2 2 0 0 0 13 8zm0 6a2 2 0 1 0 .001 4.001A2 2 0 0 0 13 14z"></path>
+        </svg>
+      </Action>
+    );
+  }
+);


### PR DESCRIPTION
### Introducing activator node refs

Introducing the concept of activator node refs for `useDraggable` and `useSortable`. This allows @dnd-kit to handle common use-cases such as restoring focus on the activator node after dragging via the keyboard or only allowing the activator node to instantiate the keyboard sensor.

Consumers of `useDraggable` and `useSortable` may now optionally set the activator node ref on the element that receives listeners:

```diff
import {useDraggable} from '@dnd-kit/core';

function Draggable(props) {
  const {
    listeners,
    setNodeRef,
+   setActivatorNodeRef,
  } = useDraggable({id: props.id});

  return (
    <div ref={setNodeRef}>
      Draggable element
      <button
        {...listeners}
+       ref={setActivatorNodeRef}
      >
        :: Drag Handle
      </button>
    </div>
  )
}
```

It's common for the activator element (the element that receives the sensor listeners) to differ from the draggable node. When this happens, @dnd-kit has no reliable way to get a reference to the activator node after dragging ends, as the original `event.target` that instantiated the sensor may no longer be mounted in the DOM or associated with the draggable node that was previously active.

### Automatically restoring focus

Focus management is now automatically handled by @dnd-kit. When the activator event is a Keyboard event, @dnd-kit will now attempt to automatically restore focus back to the first focusable node of the activator node or draggable node.

If no activator node is specified via the `setActivatorNodeRef` setter function of `useDraggble` and `useSortable`, @dnd-kit will automatically restore focus on the first focusable node of the draggable node set via the `setNodeRef` setter function of `useDraggable` and `useSortable`.

If you were previously managing focus manually and would like to opt-out of automatic focus management, use the newly introduced `restoreFocus` property of the `accessibility` prop of `<DndContext>`:

```diff
<DndContext
  accessibility={{
+   restoreFocus: false
  }}
```

#### Before

https://user-images.githubusercontent.com/1416436/169355420-98d6eef9-865f-49cd-b03e-e784321b3c77.mov

#### After

https://user-images.githubusercontent.com/1416436/169354483-c2e44583-a1e7-46d9-8899-1f9eac00afc1.mov
