### PR TITLE
Add `aria-disabled` attribute

### DIFF
--- a/.changeset/aria-disabled-attribute.md
+++ b/.changeset/aria-disabled-attribute.md
@@ -1,0 +1,5 @@
+---
+'@dnd-kit/core': minor
+---
+
+Added the `aria-disabled` attribute to the `attribtues` object returned by `useDraggable` and `useSortable`. The value of the `aria-disabled` attribute is populated based on whether or not the `disabled` argument is passed to `useDraggble` or `useSortable`.

--- a/packages/core/src/hooks/useDraggable.ts
+++ b/packages/core/src/hooks/useDraggable.ts
@@ -25,6 +25,7 @@ export interface UseDraggableArguments {
 export interface DraggableAttributes {
   role: string;
   tabIndex: number;
+  'aria-disabled': boolean;
   'aria-pressed': boolean | undefined;
   'aria-roledescription': string;
   'aria-describedby': string;
@@ -85,11 +86,19 @@ export function useDraggable({
     () => ({
       role,
       tabIndex,
+      'aria-disabled': disabled,
       'aria-pressed': isDragging && role === defaultRole ? true : undefined,
       'aria-roledescription': roleDescription,
       'aria-describedby': ariaDescribedById.draggable,
     }),
-    [role, tabIndex, isDragging, roleDescription, ariaDescribedById.draggable]
+    [
+      disabled,
+      role,
+      tabIndex,
+      isDragging,
+      roleDescription,
+      ariaDescribedById.draggable,
+    ]
   );
 
   return {


### PR DESCRIPTION
Added the `aria-disabled` attribute to the `attribtues` object returned by `useDraggable` and `useSortable`. The value of the `aria-disabled` attribute is populated based on whether or not the `disabled` argument is passed to `useDraggble` or `useSortable`.
