### PR TITLE
Refactor announcements to receive config object

### DIFF
--- a/.changeset/accessibility-related-props.md
+++ b/.changeset/accessibility-related-props.md
@@ -20,6 +20,33 @@ Accessibility-related props have been regrouped under the `accessibility` prop o
 
 This is a breaking change that will allow easier addition of new accessibility-related features without overloading the props namespace of `<DndContext>`.
 
+#### Arguments object for announcements
+
+The arguments passed to announcement callbacks have changed. They now receive an object that contains the `active` and `over` properties that match the signature of those passed to the DragEvent handlers (`onDragStart`, `onDragMove`, etc.). This change allows consumers to read the `data` property of the `active` and `over` node to customize the announcements based on the data.
+
+Example migration steps:
+
+```diff
+export const announcements: Announcements = {
+-  onDragStart(id) {
++  onDragStart({active}) {
+-    return `Picked up draggable item ${id}.`;
++    return `Picked up draggable item ${active.id}.`;
+  },
+-  onDragOver(id, overId) {
++  onDragOver({active, over}) {
+-    if (overId) {
++    if (over) {
+-      return `Draggable item ${id} was moved over droppable area ${overId}.`;
++      return `Draggable item ${active.id} was moved over droppable area ${over.id}.`;
+    }
+
+-    return `Draggable item ${id} is no longer over a droppable area.`;
++    return `Draggable item ${active.id} is no longer over a droppable area.`;
+  },
+};
+```
+
 #### Accessibility-related DOM nodes are no longer portaled by default
 
 The DOM nodes for the screen reader instructions and announcements are no longer portaled into the `document.body` element by default.

--- a/packages/core/src/components/Accessibility/Accessibility.tsx
+++ b/packages/core/src/components/Accessibility/Accessibility.tsx
@@ -37,21 +37,21 @@ export function Accessibility({
     useMemo<DndMonitorListener>(
       () => ({
         onDragStart({active}) {
-          announce(announcements.onDragStart(active.id));
+          announce(announcements.onDragStart({active}));
         },
         onDragMove({active, over}) {
           if (announcements.onDragMove) {
-            announce(announcements.onDragMove(active.id, over?.id));
+            announce(announcements.onDragMove({active, over}));
           }
         },
         onDragOver({active, over}) {
-          announce(announcements.onDragOver(active.id, over?.id));
+          announce(announcements.onDragOver({active, over}));
         },
         onDragEnd({active, over}) {
-          announce(announcements.onDragEnd(active.id, over?.id));
+          announce(announcements.onDragEnd({active, over}));
         },
-        onDragCancel({active}) {
-          announce(announcements.onDragCancel(active.id));
+        onDragCancel({active, over}) {
+          announce(announcements.onDragCancel({active, over}));
         },
       }),
       [announce, announcements]

--- a/packages/core/src/components/Accessibility/defaults.ts
+++ b/packages/core/src/components/Accessibility/defaults.ts
@@ -9,24 +9,24 @@ export const defaultScreenReaderInstructions: ScreenReaderInstructions = {
 };
 
 export const defaultAnnouncements: Announcements = {
-  onDragStart(id) {
-    return `Picked up draggable item ${id}.`;
+  onDragStart({active}) {
+    return `Picked up draggable item ${active.id}.`;
   },
-  onDragOver(id, overId) {
-    if (overId) {
-      return `Draggable item ${id} was moved over droppable area ${overId}.`;
+  onDragOver({active, over}) {
+    if (over) {
+      return `Draggable item ${active.id} was moved over droppable area ${over.id}.`;
     }
 
-    return `Draggable item ${id} is no longer over a droppable area.`;
+    return `Draggable item ${active.id} is no longer over a droppable area.`;
   },
-  onDragEnd(id, overId) {
-    if (overId) {
-      return `Draggable item ${id} was dropped over droppable area ${overId}`;
+  onDragEnd({active, over}) {
+    if (over) {
+      return `Draggable item ${active.id} was dropped over droppable area ${over.id}`;
     }
 
-    return `Draggable item ${id} was dropped.`;
+    return `Draggable item ${active.id} was dropped.`;
   },
-  onDragCancel(id) {
-    return `Dragging was cancelled. Draggable item ${id} was dropped.`;
+  onDragCancel({active}) {
+    return `Dragging was cancelled. Draggable item ${active.id} was dropped.`;
   },
 };

--- a/packages/core/src/components/Accessibility/types.ts
+++ b/packages/core/src/components/Accessibility/types.ts
@@ -1,20 +1,16 @@
-import type {UniqueIdentifier} from '../../types';
+import type {Active, Over} from '../../store';
+
+export interface Arguments {
+  active: Active;
+  over: Over | null;
+}
 
 export interface Announcements {
-  onDragStart(id: UniqueIdentifier): string | undefined;
-  onDragMove?(
-    id: UniqueIdentifier,
-    overId: UniqueIdentifier | undefined
-  ): string | undefined;
-  onDragOver(
-    id: UniqueIdentifier,
-    overId: UniqueIdentifier | undefined
-  ): string | undefined;
-  onDragEnd(
-    id: UniqueIdentifier,
-    overId: UniqueIdentifier | undefined
-  ): string | undefined;
-  onDragCancel(id: UniqueIdentifier): string | undefined;
+  onDragStart({active}: Pick<Arguments, 'active'>): string | undefined;
+  onDragMove?({active, over}: Arguments): string | undefined;
+  onDragOver({active, over}: Arguments): string | undefined;
+  onDragEnd({active, over}: Arguments): string | undefined;
+  onDragCancel({active, over}: Arguments): string | undefined;
 }
 
 export interface ScreenReaderInstructions {

--- a/stories/2 - Presets/Sortable/Sortable.tsx
+++ b/stories/2 - Presets/Sortable/Sortable.tsx
@@ -142,12 +142,12 @@ export function Sortable({
     ? (id: string) => setItems((items) => items.filter((item) => item !== id))
     : undefined;
   const announcements: Announcements = {
-    onDragStart(id) {
+    onDragStart({active: {id}}) {
       return `Picked up sortable item ${id}. Sortable item ${id} is in position ${getPosition(
         id
       )} of ${items.length}`;
     },
-    onDragOver(id, overId) {
+    onDragOver({active, over}) {
       // In this specific use-case, the picked up item's `id` is always the same as the first `over` id.
       // The first `onDragOver` event therefore doesn't need to be announced, because it is called
       // immediately after the `onDragStart` announcement and is redundant.
@@ -156,24 +156,24 @@ export function Sortable({
         return;
       }
 
-      if (overId) {
-        return `Sortable item ${id} was moved into position ${getPosition(
-          overId
-        )} of ${items.length}`;
+      if (over) {
+        return `Sortable item ${
+          active.id
+        } was moved into position ${getPosition(over.id)} of ${items.length}`;
       }
 
       return;
     },
-    onDragEnd(id, overId) {
-      if (overId) {
-        return `Sortable item ${id} was dropped at position ${getPosition(
-          overId
-        )} of ${items.length}`;
+    onDragEnd({active, over}) {
+      if (over) {
+        return `Sortable item ${
+          active.id
+        } was dropped at position ${getPosition(over.id)} of ${items.length}`;
       }
 
       return;
     },
-    onDragCancel(id) {
+    onDragCancel({active: {id}}) {
       return `Sorting was cancelled. Sortable item ${id} was dropped and returned to position ${getPosition(
         id
       )} of ${items.length}.`;

--- a/stories/3 - Examples/Tree/SortableTree.tsx
+++ b/stories/3 - Examples/Tree/SortableTree.tsx
@@ -170,20 +170,20 @@ export function SortableTree({
   }, [flattenedItems, offsetLeft]);
 
   const announcements: Announcements = {
-    onDragStart(id) {
-      return `Picked up ${id}.`;
+    onDragStart({active}) {
+      return `Picked up ${active.id}.`;
     },
-    onDragMove(id, overId) {
-      return getMovementAnnouncement('onDragMove', id, overId);
+    onDragMove({active, over}) {
+      return getMovementAnnouncement('onDragMove', active.id, over?.id);
     },
-    onDragOver(id, overId) {
-      return getMovementAnnouncement('onDragOver', id, overId);
+    onDragOver({active, over}) {
+      return getMovementAnnouncement('onDragOver', active.id, over?.id);
     },
-    onDragEnd(id, overId) {
-      return getMovementAnnouncement('onDragEnd', id, overId);
+    onDragEnd({active, over}) {
+      return getMovementAnnouncement('onDragEnd', active.id, over?.id);
     },
-    onDragCancel(id) {
-      return `Moving was cancelled. ${id} was dropped in its original position.`;
+    onDragCancel({active}) {
+      return `Moving was cancelled. ${active.id} was dropped in its original position.`;
     },
   };
 


### PR DESCRIPTION
The arguments passed to announcement callbacks have changed. They now receive an object that contains the `active` and `over` properties that match the signature of those passed to the DragEvent handlers (`onDragStart`, `onDragMove`, etc.). This change allows consumers to read the `data` property of the `active` and `over` node to customize the announcements based on the data.