### PR TITLE
Disabled scroll intent should reset speed/direction for that axis

### DIFF
--- a/packages/core/src/hooks/utilities/useAutoScroller.ts
+++ b/packages/core/src/hooks/utilities/useAutoScroller.ts
@@ -133,10 +133,14 @@ export function useAutoScroller({
           threshold
         );
 
-        if (
-          (speed.x > 0 && scrollIntent.x[direction.x as Direction]) ||
-          (speed.y > 0 && scrollIntent.y[direction.y as Direction])
-        ) {
+        for (const axis of ['x', 'y'] as const) {
+          if (!scrollIntent[axis][direction[axis] as Direction]) {
+            speed[axis] = 0;
+            direction[axis] = 0;
+          }
+        }
+
+        if (speed.x > 0 || speed.y > 0) {
           clearAutoScrollInterval();
 
           scrollContainerRef.current = scrollContainer;


### PR DESCRIPTION
Fix an oversight in the scroll intent tracking logic that did not reset the speed and direction for the given axis that had disabled scroll intent.