### PR TITLE
Introduce `disabled` prop on SortableContext

### DIFF
--- a/.changeset/sortable-disabled-prop.md
+++ b/.changeset/sortable-disabled-prop.md
@@ -1,0 +1,18 @@
+---
+'@dnd-kit/sortable': minor
+---
+
+The `<SortableContext>` component now optionally accepts a `disabled` prop to globally disable `useSortable` hooks rendered within it.
+
+The `disabled` prop accepts either a boolean or an object with the following shape:
+
+```ts
+interface Disabled {
+  draggable?: boolean;
+  droppable?: boolean;
+}
+```
+
+The `useSortable` hook has now been updated to also optionally accept the `disabled` configuration object to conditionally disable the `useDraggable` and/or `useDroppable` hooks used internally.
+
+Like the `strategy` prop, the `disabled` prop defined on the `useSortable` hook takes precedence over the `disabled` prop defined on the parent `<SortableContext>`.

--- a/packages/sortable/src/components/SortableContext.tsx
+++ b/packages/sortable/src/components/SortableContext.tsx
@@ -2,8 +2,8 @@ import React, {useEffect, useMemo, useRef} from 'react';
 import {useDndContext, ClientRect, UniqueIdentifier} from '@dnd-kit/core';
 import {useIsomorphicLayoutEffect, useUniqueId} from '@dnd-kit/utilities';
 
-import type {SortingStrategy} from '../types';
-import {getSortedRects} from '../utilities';
+import type {Disabled, SortingStrategy} from '../types';
+import {getSortedRects, itemsEqual, normalizeDisabled} from '../utilities';
 import {rectSortingStrategy} from '../strategies';
 
 export interface Props {
@@ -11,6 +11,7 @@ export interface Props {
   items: (UniqueIdentifier | {id: UniqueIdentifier})[];
   strategy?: SortingStrategy;
   id?: string;
+  disabled?: boolean | Disabled;
 }
 
 const ID_PREFIX = 'Sortable';
@@ -18,6 +19,7 @@ const ID_PREFIX = 'Sortable';
 interface ContextDescriptor {
   activeIndex: number;
   containerId: string;
+  disabled: Disabled;
   disableTransforms: boolean;
   items: UniqueIdentifier[];
   overIndex: number;
@@ -35,6 +37,10 @@ export const Context = React.createContext<ContextDescriptor>({
   useDragOverlay: false,
   sortedRects: [],
   strategy: rectSortingStrategy,
+  disabled: {
+    draggable: false,
+    droppable: false,
+  },
 });
 
 export function SortableContext({
@@ -42,6 +48,7 @@ export function SortableContext({
   id,
   items: userDefinedItems,
   strategy = rectSortingStrategy,
+  disabled: disabledProp = false,
 }: Props) {
   const {
     active,
@@ -60,18 +67,26 @@ export function SortableContext({
       ),
     [userDefinedItems]
   );
+  const isDragging = active != null;
   const activeIndex = active ? items.indexOf(active.id) : -1;
   const overIndex = over ? items.indexOf(over.id) : -1;
   const previousItemsRef = useRef(items);
-  const itemsHaveChanged = !isEqual(items, previousItemsRef.current);
+  const itemsHaveChanged = !itemsEqual(items, previousItemsRef.current);
   const disableTransforms =
     (overIndex !== -1 && activeIndex === -1) || itemsHaveChanged;
+  const disabled = normalizeDisabled(disabledProp);
 
   useIsomorphicLayoutEffect(() => {
-    if (itemsHaveChanged && !measuringScheduled) {
+    if (itemsHaveChanged && isDragging && !measuringScheduled) {
       measureDroppableContainers(items);
     }
-  }, [itemsHaveChanged, items, measureDroppableContainers, measuringScheduled]);
+  }, [
+    itemsHaveChanged,
+    items,
+    isDragging,
+    measureDroppableContainers,
+    measuringScheduled,
+  ]);
 
   useEffect(() => {
     previousItemsRef.current = items;
@@ -81,6 +96,7 @@ export function SortableContext({
     (): ContextDescriptor => ({
       activeIndex,
       containerId,
+      disabled,
       disableTransforms,
       items,
       overIndex,
@@ -88,9 +104,12 @@ export function SortableContext({
       sortedRects: getSortedRects(items, droppableRects),
       strategy,
     }),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [
       activeIndex,
       containerId,
+      disabled.draggable,
+      disabled.droppable,
       disableTransforms,
       items,
       overIndex,
@@ -101,15 +120,4 @@ export function SortableContext({
   );
 
   return <Context.Provider value={contextValue}>{children}</Context.Provider>;
-}
-
-function isEqual(arr1: string[], arr2: string[]) {
-  if (arr1 === arr2) return true;
-  if (arr1.length !== arr2.length) return false;
-  for (let i = 0; i < arr1.length; i++) {
-    if (arr1[i] !== arr2[i]) {
-      return false;
-    }
-  }
-  return true;
 }

--- a/packages/sortable/src/types/disabled.ts
+++ b/packages/sortable/src/types/disabled.ts
@@ -1,0 +1,4 @@
+export interface Disabled {
+  draggable?: boolean;
+  droppable?: boolean;
+}

--- a/packages/sortable/src/types/index.ts
+++ b/packages/sortable/src/types/index.ts
@@ -1,3 +1,4 @@
+export type {Disabled} from './disabled';
 export type {SortableData} from './data';
 export type {SortingStrategy} from './strategies';
 export {hasSortableData} from './type-guard';

--- a/packages/sortable/src/utilities/index.ts
+++ b/packages/sortable/src/utilities/index.ts
@@ -2,3 +2,5 @@ export {arrayMove} from './arrayMove';
 export {arraySwap} from './arraySwap';
 export {getSortedRects} from './getSortedRects';
 export {isValidIndex} from './isValidIndex';
+export {itemsEqual} from './itemsEqual';
+export {normalizeDisabled} from './normalizeDisabled';

--- a/packages/sortable/src/utilities/itemsEqual.ts
+++ b/packages/sortable/src/utilities/itemsEqual.ts
@@ -1,0 +1,19 @@
+import type {UniqueIdentifier} from '@dnd-kit/core';
+
+export function itemsEqual(a: UniqueIdentifier[], b: UniqueIdentifier[]) {
+  if (a === b) {
+    return true;
+  }
+
+  if (a.length !== b.length) {
+    return false;
+  }
+
+  for (let i = 0; i < a.length; i++) {
+    if (a[i] !== b[i]) {
+      return false;
+    }
+  }
+
+  return true;
+}

--- a/packages/sortable/src/utilities/normalizeDisabled.ts
+++ b/packages/sortable/src/utilities/normalizeDisabled.ts
@@ -1,0 +1,12 @@
+import type {Disabled} from '../types';
+
+export function normalizeDisabled(disabled: boolean | Disabled): Disabled {
+  if (typeof disabled === 'boolean') {
+    return {
+      draggable: disabled,
+      droppable: disabled,
+    };
+  }
+
+  return disabled;
+}


### PR DESCRIPTION
The `<SortableContext>` component now optionally accepts a `disabled` prop to globally disable `useSortable` hooks rendered within it.

The `disabled` prop accepts either a boolean or an object with the following shape:

```ts
interface Disabled {
  draggable?: boolean;
  droppable?: boolean;
}
```

The `useSortable` hook has now been updated to also optionally accept the `disabled` configuration object to conditionally disable the `useDraggable` and/or `useDroppable` hooks used internally.

```ts
useSortable({
  disabled: {
    draggable: true,
    droppable: false,
  }
});
```

Like the `strategy` prop, the `disabled` prop defined on the `useSortable` hook takes precedence over the `disabled` prop defined on the parent `<SortableContext>`.
