### PR TITLE
Fix a regression with layout animations

### DIFF
--- a/.changeset/layout-animation-bugfix.md
+++ b/.changeset/layout-animation-bugfix.md
@@ -1,0 +1,5 @@
+---
+'@dnd-kit/sortable': patch
+---
+
+The `wasDragging` property of `animateLayoutChanges` now remains true for longer than a single re-render. Before this change, it was possible for the component where `useSortable` is used to re-render before @dnd-kit is ready to perform the layout animation, causing the animation to be skipped entirely.

--- a/packages/sortable/src/hooks/useSortable.ts
+++ b/packages/sortable/src/hooks/useSortable.ts
@@ -147,6 +147,7 @@ export function useSortable({
     transition,
     wasDragging: previous.current.activeId != null,
   });
+
   const derivedTransform = useDerivedTransform({
     disabled: !shouldAnimateLayoutChanges,
     index,
@@ -166,11 +167,24 @@ export function useSortable({
     if (items !== previous.current.items) {
       previous.current.items = items;
     }
+  }, [isSorting, newIndex, containerId, items]);
 
-    if (activeId !== previous.current.activeId) {
-      previous.current.activeId = activeId;
+  useEffect(() => {
+    if (activeId === previous.current.activeId) {
+      return;
     }
-  }, [activeId, isSorting, newIndex, containerId, items]);
+
+    if (activeId && !previous.current.activeId) {
+      previous.current.activeId = activeId;
+      return;
+    }
+
+    const timeoutId = setTimeout(() => {
+      previous.current.activeId = activeId;
+    }, 50);
+
+    return () => clearTimeout(timeoutId);
+  }, [activeId]);
 
   return {
     active,

--- a/stories/2 - Presets/Sortable/1-Vertical.story.tsx
+++ b/stories/2 - Presets/Sortable/1-Vertical.story.tsx
@@ -149,9 +149,7 @@ export const RerenderBeforeSorting = () => {
 
 export const RemovableItems = () => {
   const animateLayoutChanges: AnimateLayoutChanges = (args) =>
-    args.isSorting || args.wasDragging
-      ? defaultAnimateLayoutChanges(args)
-      : true;
+    defaultAnimateLayoutChanges({...args, wasDragging: true});
 
   return (
     <Sortable

--- a/stories/2 - Presets/Sortable/2-Horizontal.story.tsx
+++ b/stories/2 - Presets/Sortable/2-Horizontal.story.tsx
@@ -115,9 +115,7 @@ export const MarginBetweenItems = () => {
 
 export const RemovableItems = () => {
   const animateLayoutChanges: AnimateLayoutChanges = (args) =>
-    args.isSorting || args.wasDragging
-      ? defaultAnimateLayoutChanges(args)
-      : true;
+    defaultAnimateLayoutChanges({...args, wasDragging: true});
 
   return (
     <Sortable

--- a/stories/2 - Presets/Sortable/3-Grid.story.tsx
+++ b/stories/2 - Presets/Sortable/3-Grid.story.tsx
@@ -138,9 +138,7 @@ export const MinimumDistance = () => (
 
 export const RemovableItems = () => {
   const animateLayoutChanges: AnimateLayoutChanges = (args) =>
-    args.isSorting || args.wasDragging
-      ? defaultAnimateLayoutChanges(args)
-      : true;
+    defaultAnimateLayoutChanges({...args, wasDragging: true});
 
   return (
     <Sortable

--- a/stories/2 - Presets/Sortable/MultipleContainers.tsx
+++ b/stories/2 - Presets/Sortable/MultipleContainers.tsx
@@ -44,7 +44,7 @@ export default {
 };
 
 const animateLayoutChanges: AnimateLayoutChanges = (args) =>
-  args.isSorting || args.wasDragging ? defaultAnimateLayoutChanges(args) : true;
+  defaultAnimateLayoutChanges({...args, wasDragging: true});
 
 function DroppableContainer({
   children,


### PR DESCRIPTION
The `wasDragging` property of `animateLayoutChanges` now remains true for longer than a single re-render. Before this change, it was possible for the component where `useSortable` is used to re-render before @dnd-kit is ready to perform the layout animation, causing the animation to be skipped entirely.
