### PR TITLE
Add `fill: forwards` to default drop animation

### DIFF
--- a/.changeset/drop-animation-fill.md
+++ b/.changeset/drop-animation-fill.md
@@ -1,0 +1,5 @@
+---
+'@dnd-kit/core': patch
+---
+
+Fixed a regression with the default drop animation of `<DragOverlay>` for consumers using React 18.

--- a/packages/core/src/components/DragOverlay/hooks/useDropAnimation.ts
+++ b/packages/core/src/components/DragOverlay/hooks/useDropAnimation.ts
@@ -276,8 +276,9 @@ function createDefaultDropAnimation(
 
     const cleanup = sideEffects?.({active, dragOverlay, ...rest});
     const animation = dragOverlay.node.animate(animationKeyframes, {
-      easing,
       duration,
+      easing,
+      fill: 'forwards',
     });
 
     return new Promise((resolve) => {

--- a/stories/components/Draggable/DraggableOverlay.tsx
+++ b/stories/components/Draggable/DraggableOverlay.tsx
@@ -39,6 +39,7 @@ const dropAnimationConfig: DropAnimation = {
         {
           duration: 250,
           easing: 'ease',
+          fill: 'forwards',
         }
       );
     }


### PR DESCRIPTION
Fixes #758 

This fixes an issue with React 18 where the drag overlay component returns to its initial position once the animation completes before it has time to unmount.