### PR TITLE
Fix scrollable ancestors bug

### DIFF
--- a/.changeset/fix-container-rect.md
+++ b/.changeset/fix-container-rect.md
@@ -1,0 +1,5 @@
+---
+'@dnd-kit/core': patch
+---
+
+Fixed an issue with the `containerNodeRect` that is exposed to modifiers having stale properties (`top`, `left`, etc.) when its scrollable ancestors were scrolled.

--- a/.changeset/fix-scrollable-ancestors.md
+++ b/.changeset/fix-scrollable-ancestors.md
@@ -1,0 +1,7 @@
+---
+'@dnd-kit/core': patch
+---
+
+Fixed a regression with scrollable ancestors detection.
+
+The scrollable ancestors should be determined by the active node or the over node exclusively. The `draggingNode` variable shouldn't be used to detect scrollable ancestors since it can be the drag overlay node, and the drag overlay node doesn't have any scrollable ancestors because it is a fixed position element.

--- a/packages/core/src/components/DndContext/DndContext.tsx
+++ b/packages/core/src/components/DndContext/DndContext.tsx
@@ -144,10 +144,8 @@ export const DndContext = memo(function DndContext({
 }: Props) {
   const store = useReducer(reducer, undefined, getInitialState);
   const [state, dispatch] = store;
-  const [
-    dispatchMonitorEvent,
-    registerMonitorListener,
-  ] = useDndMonitorProvider();
+  const [dispatchMonitorEvent, registerMonitorListener] =
+    useDndMonitorProvider();
   const [status, setStatus] = useState<Status>(Status.Uninitialized);
   const isInitialized = status === Status.Initialized;
   const {
@@ -181,15 +179,12 @@ export const DndContext = memo(function DndContext({
     [droppableContainers]
   );
   const measuringConfiguration = useMeasuringConfiguration(measuring);
-  const {
-    droppableRects,
-    measureDroppableContainers,
-    measuringScheduled,
-  } = useDroppableMeasuring(enabledDroppableContainers, {
-    dragging: isInitialized,
-    dependencies: [translate.x, translate.y],
-    config: measuringConfiguration.droppable,
-  });
+  const {droppableRects, measureDroppableContainers, measuringScheduled} =
+    useDroppableMeasuring(enabledDroppableContainers, {
+      dragging: isInitialized,
+      dependencies: [translate.x, translate.y],
+      config: measuringConfiguration.droppable,
+    });
   const activeNode = useCachedNode(draggableNodes, activeId);
   const activationCoordinates = useMemo(
     () => (activatorEvent ? getEventCoordinates(activatorEvent) : null),
@@ -257,7 +252,7 @@ export const DndContext = memo(function DndContext({
 
   // Get scrollable ancestors of the dragging node
   const scrollableAncestors = useScrollableAncestors(
-    isInitialized ? overNode ?? draggingNode : null
+    isInitialized ? overNode ?? activeNode : null
   );
   const scrollableAncestorRects = useRects(scrollableAncestors);
 
@@ -395,12 +390,8 @@ export const DndContext = memo(function DndContext({
 
       function createHandler(type: Action.DragEnd | Action.DragCancel) {
         return async function handler() {
-          const {
-            active,
-            collisions,
-            over,
-            scrollAdjustedTranslate,
-          } = sensorContext.current;
+          const {active, collisions, over, scrollAdjustedTranslate} =
+            sensorContext.current;
           let event: DragEndEvent | null = null;
 
           if (active && scrollAdjustedTranslate) {

--- a/packages/core/src/hooks/utilities/useRect.ts
+++ b/packages/core/src/hooks/utilities/useRect.ts
@@ -2,14 +2,18 @@ import {useReducer} from 'react';
 import {useIsomorphicLayoutEffect} from '@dnd-kit/utilities';
 
 import type {ClientRect} from '../../types';
-import {getClientRect} from '../../utilities';
+import {getClientRect, Rect} from '../../utilities';
 
 import {useMutationObserver} from './useMutationObserver';
 import {useResizeObserver} from './useResizeObserver';
 
+function defaultMeasure(element: HTMLElement) {
+  return new Rect(getClientRect(element), element);
+}
+
 export function useRect(
   element: HTMLElement | null,
-  measure: (element: HTMLElement) => ClientRect = getClientRect,
+  measure: (element: HTMLElement) => ClientRect = defaultMeasure,
   fallbackRect?: ClientRect | null
 ) {
   const [rect, measureRect] = useReducer(reducer, null);

--- a/packages/core/src/hooks/utilities/useScrollableAncestors.ts
+++ b/packages/core/src/hooks/utilities/useScrollableAncestors.ts
@@ -16,6 +16,7 @@ export function useScrollableAncestors(node: HTMLElement | null) {
 
       if (
         previousValue &&
+        previousValue !== defaultValue &&
         node &&
         previousNode.current &&
         node.parentNode === previousNode.current.parentNode

--- a/packages/core/src/utilities/scroll/isScrollable.ts
+++ b/packages/core/src/utilities/scroll/isScrollable.ts
@@ -9,11 +9,9 @@ export function isScrollable(
   const overflowRegex = /(auto|scroll|overlay)/;
   const properties = ['overflow', 'overflowX', 'overflowY'];
 
-  return (
-    properties.find((property) => {
-      const value = computedStyle[property as keyof CSSStyleDeclaration];
+  return properties.some((property) => {
+    const value = computedStyle[property as keyof CSSStyleDeclaration];
 
-      return typeof value === 'string' ? overflowRegex.test(value) : false;
-    }) != null
-  );
+    return typeof value === 'string' ? overflowRegex.test(value) : false;
+  });
 }


### PR DESCRIPTION
This PR fixes two issues: an issue with scrollable ancestors detection and an issue with stale `containerNodeRect` properties when its scrollable ancestors were scrolled.