### PR TITLE
Use fixed position for aria live regions

### DIFF
--- a/.changeset/position-fixed-liveregion.md
+++ b/.changeset/position-fixed-liveregion.md
@@ -1,0 +1,5 @@
+---
+'@dnd-kit/core': patch
+---
+
+The ARIA live region element used for screen reader announcements is now positioned using `position: fixed` instead of `position: absolute`. As of `@dnd-kit/core^6.0.0`, the live region element is no longer portaled by default into the `document.body`. This change was introduced in order to fix issues with portaled live regions. However, this change can introduce visual regressions when using absolutely positioned elements, since the live region element is constrained to the stacking and position context of its closest positioned ancestor. Using fixed position ensures the element does not introduce visual regressions.

--- a/packages/accessibility/src/components/LiveRegion/LiveRegion.tsx
+++ b/packages/accessibility/src/components/LiveRegion/LiveRegion.tsx
@@ -7,7 +7,7 @@ export interface Props {
 
 // Hide element visually but keep it readable by screen readers
 const visuallyHidden: React.CSSProperties = {
-  position: 'absolute',
+  position: 'fixed',
   width: 1,
   height: 1,
   margin: -1,


### PR DESCRIPTION
The ARIA live region element used for screen reader announcements is now positioned using `position: fixed` instead of `position: absolute`. As of `@dnd-kit/core^6.0.0`, the live region element is no longer portaled by default into the `document.body`. This change was introduced in order to fix issues with portaled live regions. However, this change can introduce visual regressions when using absolutely positioned elements, since the live region element is constrained to the stacking and position context of its closest positioned ancestor. Using fixed position ensures the element does not introduce visual regressions.
