### PR TITLE
Add `Active` and `Over` in `hasSortableData` type guard

### DIFF
--- a/.changeset/sortable-type-guard.md
+++ b/.changeset/sortable-type-guard.md
@@ -1,0 +1,5 @@
+---
+'@dnd-kit/sortable': patch
+---
+
+The `hasSortableData` type-guard that is exported by @dnd-kit/sortable has been updated to also accept the `Active` and `Over` interfaces so it can be used in events such as `onDragStart`, `onDragOver`, and `onDragEnd`.

--- a/packages/sortable/src/types/type-guard.ts
+++ b/packages/sortable/src/types/type-guard.ts
@@ -1,8 +1,16 @@
-import type {Data, DroppableContainer, DraggableNode} from '@dnd-kit/core';
+import type {
+  Active,
+  Data,
+  DroppableContainer,
+  DraggableNode,
+  Over,
+} from '@dnd-kit/core';
 
 import type {SortableData} from './data';
 
-export function hasSortableData<T extends DraggableNode | DroppableContainer>(
+export function hasSortableData<
+  T extends Active | Over | DraggableNode | DroppableContainer
+>(
   entry: T | null | undefined
 ): entry is T & {data: {current: Data<SortableData>}} {
   if (!entry) {


### PR DESCRIPTION
The `hasSortableData` type-guard that is exported by @dnd-kit/sortable has been updated to also accept the `Active` and `Over` interfaces so it can be used in events such as `onDragStart`, `onDragOver`, and `onDragEnd`.