### PR TITLE
fix playground parcel error

### DIFF
--- a/playground/.gitignore
+++ b/playground/.gitignore
@@ -1,3 +1,3 @@
 node_modules
-.cache
+.parcel-cache/*
 dist

--- a/playground/index.html
+++ b/playground/index.html
@@ -14,6 +14,6 @@
   </style>
   <body>
     <div id="root"></div>
-    <script src="./index.tsx"></script>
+    <script type="module" src="./index.tsx"></script>
   </body>
 </html>

--- a/playground/package.json
+++ b/playground/package.json
@@ -23,7 +23,7 @@
   "devDependencies": {
     "@types/react": "^16.9.11",
     "@types/react-dom": "^16.8.4",
-    "parcel": "^1.12.3",
+    "parcel": "^2.6.0",
     "typescript": "^3.4.5"
   }
 }


### PR DESCRIPTION
the parcel version on the playground is outdated.

 changes:
1. it  upgrades the parcel version 
2. adds the new cache folder in `.gitignore` (`.parcel-cache`)
3. set the  `type:module` on the script tag in index.html 