### PR TITLE
Fix a regression with the KeyboardSensor's scrolling logic

### DIFF
--- a/.changeset/keyboard-sensor-scrolling.md
+++ b/.changeset/keyboard-sensor-scrolling.md
@@ -1,0 +1,5 @@
+---
+'@dnd-kit/core': patch
+---
+
+Fixed a regression in the `KeyboardSensor` scrolling logic.

--- a/stories/2 - Presets/Sortable/multipleContainersKeyboardCoordinates.ts
+++ b/stories/2 - Presets/Sortable/multipleContainersKeyboardCoordinates.ts
@@ -88,10 +88,17 @@ export const coordinateGetter: KeyboardCoordinateGetter = (
       const newRect = newDroppable?.rect.current;
 
       if (newNode && newRect) {
-        if (newDroppable.data.current?.type === 'container') {
+        if (newDroppable.id === 'placeholder') {
           return {
             x: newRect.left + (newRect.width - collisionRect.width) / 2,
             y: newRect.top + (newRect.height - collisionRect.height) / 2,
+          };
+        }
+
+        if (newDroppable.data.current?.type === 'container') {
+          return {
+            x: newRect.left + 20,
+            y: newRect.top + 74,
           };
         }
 


### PR DESCRIPTION
There was a regression introduced in https://github.com/clauderic/dnd-kit/commit/750d72655922363b2218d7b41e028f9dceaef013 with the `KeyboardSensor`'s scrolling logic.

When the KeyboardSensor can scroll to the new coordinates but there is a delta on the opposite axis (for example, if we can scroll on the `y` axis but there is a delta on the `x` axis) the `KeyboardSensor` would scroll to the `maxScroll` or `minScroll` coordinates instead of the new scroll coordinates.