### PR TITLE
Add missing peer dependency to @dnd-kit/modifiers

### DIFF
--- a/.changeset/missing-peer-deps.md
+++ b/.changeset/missing-peer-deps.md
@@ -1,0 +1,5 @@
+---
+"@dnd-kit/modifiers": patch
+---
+
+Add missing peer dependency to @dnd-kit/modifiers

--- a/packages/modifiers/package.json
+++ b/packages/modifiers/package.json
@@ -30,7 +30,8 @@
     "tslib": "^2.0.0"
   },
   "peerDependencies": {
-    "@dnd-kit/core": "^6.0.0"
+    "@dnd-kit/core": "^6.0.0",
+    "react": ">=16.8.0"
   },
   "devDependencies": {
     "@dnd-kit/core": "^6.0.0"


### PR DESCRIPTION
This was missing as surfaced by Yarn PnP.