### PR TITLE
allow users to pass a more efficient method to compute the item index

### DIFF
--- a/packages/sortable/src/components/SortableContext.tsx
+++ b/packages/sortable/src/components/SortableContext.tsx
@@ -5,6 +5,8 @@ import {useIsomorphicLayoutEffect, useUniqueId} from '@dnd-kit/utilities';
 import type {Disabled, SortingStrategy} from '../types';
 import {getSortedRects, itemsEqual, normalizeDisabled} from '../utilities';
 import {rectSortingStrategy} from '../strategies';
+import type {IndexGetter} from 'packages/sortable/src/hooks/types';
+import {defaultIndexGetter} from 'packages/sortable/src/hooks/defaults';
 
 export interface Props {
   children: React.ReactNode;
@@ -12,6 +14,7 @@ export interface Props {
   strategy?: SortingStrategy;
   id?: string;
   disabled?: boolean | Disabled;
+  getItemIndex?: IndexGetter;
 }
 
 const ID_PREFIX = 'Sortable';
@@ -26,6 +29,7 @@ interface ContextDescriptor {
   useDragOverlay: boolean;
   sortedRects: ClientRect[];
   strategy: SortingStrategy;
+  getItemIndex: IndexGetter;
 }
 
 export const Context = React.createContext<ContextDescriptor>({
@@ -41,6 +45,7 @@ export const Context = React.createContext<ContextDescriptor>({
     draggable: false,
     droppable: false,
   },
+  getItemIndex: defaultIndexGetter,
 });
 
 export function SortableContext({
@@ -49,6 +54,7 @@ export function SortableContext({
   items: userDefinedItems,
   strategy = rectSortingStrategy,
   disabled: disabledProp = false,
+  getItemIndex = defaultIndexGetter,
 }: Props) {
   const {
     active,
@@ -68,8 +74,8 @@ export function SortableContext({
     [userDefinedItems]
   );
   const isDragging = active != null;
-  const activeIndex = active ? items.indexOf(active.id) : -1;
-  const overIndex = over ? items.indexOf(over.id) : -1;
+  const activeIndex = active ? getItemIndex({id: active.id, items}) : -1;
+  const overIndex = over ? getItemIndex({id: over.id, items}) : -1;
   const previousItemsRef = useRef(items);
   const itemsHaveChanged = !itemsEqual(items, previousItemsRef.current);
   const disableTransforms =
@@ -103,6 +109,7 @@ export function SortableContext({
       useDragOverlay,
       sortedRects: getSortedRects(items, droppableRects),
       strategy,
+      getItemIndex,
     }),
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [
@@ -116,6 +123,7 @@ export function SortableContext({
       droppableRects,
       useDragOverlay,
       strategy,
+      getItemIndex,
     ]
   );
 

--- a/packages/sortable/src/hooks/defaults.ts
+++ b/packages/sortable/src/hooks/defaults.ts
@@ -4,6 +4,7 @@ import {arrayMove} from '../utilities';
 
 import type {
   AnimateLayoutChanges,
+  IndexGetter,
   NewIndexGetter,
   SortableTransition,
 } from './types';
@@ -14,6 +15,9 @@ export const defaultNewIndexGetter: NewIndexGetter = ({
   activeIndex,
   overIndex,
 }) => arrayMove(items, activeIndex, overIndex).indexOf(id);
+
+export const defaultIndexGetter: IndexGetter = ({id, items}) =>
+  items.indexOf(id);
 
 export const defaultAnimateLayoutChanges: AnimateLayoutChanges = ({
   containerId,

--- a/packages/sortable/src/hooks/types.ts
+++ b/packages/sortable/src/hooks/types.ts
@@ -26,3 +26,10 @@ export interface NewIndexGetterArguments {
 }
 
 export type NewIndexGetter = (args: NewIndexGetterArguments) => number;
+
+export interface IndexGetterArguments {
+  id: UniqueIdentifier;
+  items: UniqueIdentifier[];
+}
+
+export type IndexGetter = (args: IndexGetterArguments) => number;

--- a/packages/sortable/src/hooks/useSortable.ts
+++ b/packages/sortable/src/hooks/useSortable.ts
@@ -57,19 +57,20 @@ export function useSortable({
     overIndex,
     useDragOverlay,
     strategy: globalStrategy,
+    getItemIndex,
   } = useContext(Context);
   const disabled: Disabled = normalizeLocalDisabled(
     localDisabled,
     globalDisabled
   );
-  const index = items.indexOf(id);
+  const index = getItemIndex({id, items});
   const data = useMemo<SortableData & Data>(
     () => ({sortable: {containerId, index, items}, ...customData}),
     [containerId, customData, index, items]
   );
   const itemsAfterCurrentSortable = useMemo(
-    () => items.slice(items.indexOf(id)),
-    [items, id]
+    () => items.slice(getItemIndex({id, items})),
+    [items, getItemIndex, id]
   );
   const {rect, node, isOver, setNodeRef: setDroppableNodeRef} = useDroppable({
     id,


### PR DESCRIPTION
add a new optional prop to `SortableContext` to let users compute the index of the item themselves. 
This is especially useful if the user can compute the index in O(1) for large lists vs the default O(n).