### PR TITLE
Fix Disabled Example

### DIFF
--- a/stories/2 - Presets/Sortable/1-Vertical.story.tsx
+++ b/stories/2 - Presets/Sortable/1-Vertical.story.tsx
@@ -103,7 +103,7 @@ export const VariableHeights = () => {
 };
 
 export const DisabledItems = () => {
-  const disabledItems: UniqueIdentifier[] = ['1', '5', '8', '13', '20'];
+  const disabledItems: UniqueIdentifier[] = [1, 5, 8, 13, 20];
   return (
     <Sortable
       {...props}


### PR DESCRIPTION
Fixed the Disabled Items example story found [here](https://master--5fc05e08a4a65d0021ae0bf2.chromatic.com/?path=/docs/presets-sortable-vertical--disabled-items)

Currently in this example, you can drag any item in the list with no restrictions. This is because the `createRange` utility creates an array of numbers, that are then compared to the strings inside of `disabledItems`.