### PR TITLE
Upgrade to TS 4.8

### DIFF
--- a/.changeset/dependencies-update-typescript.md
+++ b/.changeset/dependencies-update-typescript.md
@@ -1,0 +1,6 @@
+---
+"@dnd-kit/core": patch
+"@dnd-kit/utilities": patch
+---
+
+Upgrade to TypeScript to 4.8

--- a/package.json
+++ b/package.json
@@ -52,13 +52,13 @@
     "react-tiny-virtual-list": "^2.2.0",
     "style-loader": "^2.0.0",
     "tsdx": "^0.14.1",
-    "typescript": "^4.6.4"
+    "typescript": "^4.8.4"
   },
   "resolutions": {
     "prettier": "^2.2.0",
     "**/@typescript-eslint/eslint-plugin": "^4.8.2",
     "**/@typescript-eslint/parser": "^4.8.2",
-    "**/typescript": "^4.6.4",
+    "**/typescript": "^4.8.4",
     "jest": "^27.0.5",
     "ts-jest": "^27.0.3"
   }

--- a/packages/core/src/sensors/types.ts
+++ b/packages/core/src/sensors/types.ts
@@ -81,7 +81,7 @@ export interface Sensor<T extends Object> {
 
 export type Sensors = Sensor<any>[];
 
-export type SensorDescriptor<T> = {
+export type SensorDescriptor<T extends Object> = {
   sensor: Sensor<T>;
   options: T;
 };

--- a/packages/utilities/src/hooks/useLatestValue.ts
+++ b/packages/utilities/src/hooks/useLatestValue.ts
@@ -1,10 +1,11 @@
 import {useRef} from 'react';
+import type {DependencyList} from 'react';
 
 import {useIsomorphicLayoutEffect} from './useIsomorphicLayoutEffect';
 
 export function useLatestValue<T extends any>(
   value: T,
-  dependencies = [value]
+  dependencies: DependencyList = [value]
 ) {
   const valueRef = useRef<T>(value);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -16287,10 +16287,10 @@ typedarray@^0.0.6:
   resolved "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@^3.7.3, typescript@^4.6.4:
-  version "4.7.2"
-  resolved "https://registry.npmjs.org/typescript/-/typescript-4.7.2.tgz"
-  integrity sha512-Mamb1iX2FDUpcTRzltPxgWMKy3fhg0TN378ylbktPGPK/99KbDtMQ4W1hwgsbPAsG3a0xKa1vmw4VKZQbkvz5A==
+typescript@^3.7.3, typescript@^4.8.4:
+  version "4.8.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.8.4.tgz#c464abca159669597be5f96b8943500b238e60e6"
+  integrity sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==
 
 ua-parser-js@^0.7.18:
   version "0.7.28"


### PR DESCRIPTION
Fixes https://github.com/clauderic/dnd-kit/issues/877

- Upgrade from TS 4.6 to TS 4.8 (I could have upgraded to TS 4.9 but the rest of the ecosystem like typescript-eslint isn't ready yet for it, and also the major breaking change is from the 4.7 to the 4.8, so we should have just 1 release for the 4.8 update to smooth the upgrade)
- Fix 2 type issues:
  - one regarding the generic in `SensorDescription` (it now extends `Object`)
  - another one regarding the previously untyped dependencies array in `useLatestValue`


## Test

Those are only type changes, so it cannot break the runtime of the libraries.

Also I ran `yarn tsc -p . --noEmit`, before and after the updates, and
- before I had 9 errors were reported in 6 files,
- after the update (without the 2 fixes), I had 11 errors,
- and after the update and the fixes, I'm back again at 9 errors
  (as those are already here on `master`, I didn't fix them in this PR)

![image](https://user-images.githubusercontent.com/22725671/203252545-b732c45b-b54a-4a40-a11a-e2967099a157.png)

## Release

As this is just a minor patch, this could either be a patch release.