### PR TITLE
Fix errors in firefox extension when destructuring the window

### DIFF
--- a/.changeset/firefox-getcomputedstyle-fix.md
+++ b/.changeset/firefox-getcomputedstyle-fix.md
@@ -1,0 +1,5 @@
+---
+"@dnd-kit/core": patch
+---
+
+Fix errors with calls to `getComputedStyle` in Firefox when destructuring from the window object

--- a/packages/core/src/utilities/rect/getRect.ts
+++ b/packages/core/src/utilities/rect/getRect.ts
@@ -19,8 +19,8 @@ export function getClientRect(
   let rect: ClientRect = element.getBoundingClientRect();
 
   if (options.ignoreTransform) {
-    const {getComputedStyle} = getWindow(element);
-    const {transform, transformOrigin} = getComputedStyle(element);
+    const {transform, transformOrigin} =
+      getWindow(element).getComputedStyle(element);
 
     if (transform) {
       rect = inverseTransform(rect, transform, transformOrigin);

--- a/packages/core/src/utilities/scroll/getScrollableAncestors.ts
+++ b/packages/core/src/utilities/scroll/getScrollableAncestors.ts
@@ -41,8 +41,7 @@ export function getScrollableAncestors(
       return scrollParents;
     }
 
-    const {getComputedStyle} = getWindow(node);
-    const computedStyle = getComputedStyle(node);
+    const computedStyle = getWindow(element).getComputedStyle(node);
 
     if (node !== element) {
       if (isScrollable(node, computedStyle)) {


### PR DESCRIPTION
This has to go down as one of the weirder bugs I've come across. We use dnd-kit with our web app and within our Chrome and Firefox extensions. We came across some errors when dragging elements within our Firefox extension.

For some reason, destructuring the window object (returned from the `getWindow` function) causes the `getComputedStyle` function to throw an error: `'getComputedStyle' called on an object that does not implement interface Window.`

<img width="640" alt="Screenshot 2023-02-18 at 2 41 37 PM" src="https://user-images.githubusercontent.com/1872029/219902644-ff475111-1ff3-42aa-ae5e-5174f8480b81.png">

When stepping through using the debugger, the window object is defined, and the elements that the code is getting the computed styles of are defined. When the window object isn't deconstructed and called directly (similar to [how it's done](https://github.com/clauderic/dnd-kit/blob/2448b7ab3aed77de52f2374d601a6d02ae467178/packages/core/src/utilities/scroll/isFixed.ts#L5) in [other places](https://github.com/clauderic/dnd-kit/blob/919f21af9382b88141b6305769836960d5844fa5/packages/core/src/utilities/scroll/isScrollable.ts#L5) in the app) the error disappears. 

The cause of this bug is unknown, and could be a bug within Firefox. However this small syntax change makes dnd-kit work perfectly in our Firefox extension. Unfortunately this error does make our Firefox extension unusable, so we'd appreciate it you considered merging this PR in.


----

Some insights if you're interested:

* We considered that maybe the extension was running in a different context to the page, maybe the window object was different. However this wasn't the case. The window object returned from `getWindow` was the same if calling `window` directly. 
* This was also the case if we changed the code to this: `const { getComputedStyle } = window`. It caused the same error, which ruled out the `getWindow` function.
* The element that was being dragged was defined and within the document.
* We considered that the Firefox extension blocked certain calls to the window, but that was disproved pretty quickly. 
* We considered that maybe the `getComputedStyle` was conflicting with the global `getComputedStyle`. It's hard to prove this though, and this could be a bug with how Firefox deals with extensions.