### PR TITLE
Only consider document scrollable if not prevented

### DIFF
--- a/packages/core/src/utilities/scroll/getScrollableAncestors.ts
+++ b/packages/core/src/utilities/scroll/getScrollableAncestors.ts
@@ -6,7 +6,8 @@ import {
 } from '@dnd-kit/utilities';
 
 import {isFixed} from './isFixed';
-import {isScrollable} from './isScrollable';
+import {isScrollingDisabled} from './isScrollingDisabled';
+import {isScrollingEnabled} from './isScrollingEnabled';
 
 export function getScrollableAncestors(
   element: Node | null,
@@ -28,7 +29,13 @@ export function getScrollableAncestors(
       node.scrollingElement != null &&
       !scrollParents.includes(node.scrollingElement)
     ) {
-      scrollParents.push(node.scrollingElement);
+      const computedStyle = getWindow(element).getComputedStyle(
+        node.scrollingElement
+      );
+
+      if (!isScrollingDisabled(node.scrollingElement, computedStyle)) {
+        scrollParents.push(node.scrollingElement);
+      }
 
       return scrollParents;
     }
@@ -44,7 +51,7 @@ export function getScrollableAncestors(
     const computedStyle = getWindow(element).getComputedStyle(node);
 
     if (node !== element) {
-      if (isScrollable(node, computedStyle)) {
+      if (isScrollingEnabled(node, computedStyle)) {
         scrollParents.push(node);
       }
     }

--- a/packages/core/src/utilities/scroll/hasOverflowStyles.ts
+++ b/packages/core/src/utilities/scroll/hasOverflowStyles.ts
@@ -1,12 +1,12 @@
 import {getWindow} from '@dnd-kit/utilities';
 
-export function isScrollable(
-  element: HTMLElement,
+export function hasOverflowStyles(
+  element: Element,
   computedStyle: CSSStyleDeclaration = getWindow(element).getComputedStyle(
     element
-  )
+  ),
+  overflowRegex: RegExp
 ): boolean {
-  const overflowRegex = /(auto|scroll|overlay)/;
   const properties = ['overflow', 'overflowX', 'overflowY'];
 
   return properties.some((property) => {

--- a/packages/core/src/utilities/scroll/index.ts
+++ b/packages/core/src/utilities/scroll/index.ts
@@ -13,5 +13,5 @@ export {
 } from './getScrollOffsets';
 export {getScrollPosition} from './getScrollPosition';
 export {isDocumentScrollingElement} from './documentScrollingElement';
-export {isScrollable} from './isScrollable';
+export {isScrollingEnabled as isScrollable} from './isScrollingEnabled';
 export {scrollIntoViewIfNeeded} from './scrollIntoViewIfNeeded';

--- a/packages/core/src/utilities/scroll/isScrollingDisabled.ts
+++ b/packages/core/src/utilities/scroll/isScrollingDisabled.ts
@@ -1,0 +1,12 @@
+import {getWindow} from '@dnd-kit/utilities';
+
+import {hasOverflowStyles} from './hasOverflowStyles';
+
+export function isScrollingDisabled(
+  element: Element,
+  computedStyle: CSSStyleDeclaration = getWindow(element).getComputedStyle(
+    element
+  )
+): boolean {
+  return hasOverflowStyles(element, computedStyle, /(hide)/);
+}

--- a/packages/core/src/utilities/scroll/isScrollingEnabled.ts
+++ b/packages/core/src/utilities/scroll/isScrollingEnabled.ts
@@ -1,0 +1,11 @@
+import {getWindow} from '@dnd-kit/utilities';
+import {hasOverflowStyles} from './hasOverflowStyles';
+
+export function isScrollingEnabled(
+  element: Element,
+  computedStyle: CSSStyleDeclaration = getWindow(element).getComputedStyle(
+    element
+  )
+): boolean {
+  return hasOverflowStyles(element, computedStyle, /(auto|scroll|overlay)/);
+}


### PR DESCRIPTION
At the moment, the `<html>` element will always be added to the list of scrollable ancestors, even if the element has its scrolling ability deactivated using `overflow: hidden`.

As a result, sensors like `KeyboardSensor` will mistakenly scroll `<html>` when dragging elements, causing unwanted glitches in the visual experience.