### PR TITLE
Deactivate keyboard sensor on blur

### DIFF
--- a/.changeset/silver-games-cough.md
+++ b/.changeset/silver-games-cough.md
@@ -1,0 +1,5 @@
+---
+'@dnd-kit/core': patch
+---
+
+Deactivate keyboard sensor on blur

--- a/packages/core/src/sensors/events.ts
+++ b/packages/core/src/sensors/events.ts
@@ -1,4 +1,5 @@
 export enum EventName {
+  Blur = 'blur',
   Click = 'click',
   DragStart = 'dragstart',
   Keydown = 'keydown',

--- a/packages/core/src/sensors/keyboard/KeyboardSensor.ts
+++ b/packages/core/src/sensors/keyboard/KeyboardSensor.ts
@@ -62,6 +62,7 @@ export class KeyboardSensor implements SensorInstance {
 
     this.windowListeners.add(EventName.Resize, this.handleCancel);
     this.windowListeners.add(EventName.VisibilityChange, this.handleCancel);
+    this.props.event.target?.addEventListener(EventName.Blur, this.handleCancel);
 
     setTimeout(() => this.listeners.add(EventName.Keydown, this.handleKeyDown));
   }
@@ -264,7 +265,9 @@ export class KeyboardSensor implements SensorInstance {
   private handleCancel(event: Event) {
     const {onCancel} = this.props;
 
-    event.preventDefault();
+    if (event.type !== EventName.Blur) {
+      event.preventDefault();
+    }
     this.detach();
     onCancel();
   }
@@ -272,6 +275,7 @@ export class KeyboardSensor implements SensorInstance {
   private detach() {
     this.listeners.removeAll();
     this.windowListeners.removeAll();
+    this.props.event.target?.removeEventListener(EventName.Blur, this.handleCancel);
   }
 
   static activators: Activators<KeyboardSensorOptions> = [


### PR DESCRIPTION
This fixes https://github.com/clauderic/dnd-kit/issues/857.

As stated in that issue, this cannot be fixed by extending the KeyboardSensor, because all methods are private and this also creates other problems —but adding these changes in the main KeyboardSensor class works as expected. Moreover, I think it makes sense to deactivate dragging on blur as a general case in order to keep the UX consistent with the native browser focus —otherwise this leads to an inconsistent experience where a non-focused element keeps being interactive, which hurts usability and accessibility.

This works for losing focus in any way, therefore both by clicking with the mouse somewhere else or by typing Tab, even though in the latter case the (native) focus will stay on the active draggable element and a new Tab is required to navigate to the next focusable element, because of `RestoreFocus`. But since that can be overridden by setting `restoreFocus` to `false` in the `DndContext`, I did not include more changes in this PR in order to keep it minimal.