### PR TITLE
useDraggable - render only dragging item

### DIFF
--- a/cypress/integration/draggable_spec.ts
+++ b/cypress/integration/draggable_spec.ts
@@ -416,4 +416,17 @@ describe('Draggable', () => {
         });
     });
   });
+
+  describe('Multiple Draggables', () => {
+    it('should render only dragging element', () => {
+      cy.visitStory('core-draggable-multi-draggable--basic-setup')
+        .findFirstDraggableItem()
+
+        .mouseMoveBy(0, 100);
+
+      cy.get('[data-testid="1"]').should('have.text', 'updated');
+      cy.get('[data-testid="2"]').should('have.text', 'mounted');
+      cy.get('[data-testid="3"]').should('have.text', 'mounted');
+    });
+  });
 });

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -27,7 +27,7 @@ function getDocumentScroll() {
 }
 
 Cypress.Commands.add('findFirstDraggableItem', () => {
-  return cy.get(`[data-cypress="draggable-item"`);
+  return cy.get(`[data-cypress="draggable-item"]`).first();
 });
 
 Cypress.Commands.add(

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "@types/classnames": "^2.2.11",
     "@types/react": "^16.9.43",
     "@types/react-dom": "^16.9.8",
+    "@types/use-sync-external-store": "^0.0.3",
     "babel-jest": "^27.0.2",
     "babel-loader": "^8.2.1",
     "chromatic": "^5.4.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -30,9 +30,10 @@
     "react-dom": ">=16.8.0"
   },
   "dependencies": {
-    "tslib": "^2.0.0",
     "@dnd-kit/accessibility": "^3.0.0",
-    "@dnd-kit/utilities": "^3.2.1"
+    "@dnd-kit/utilities": "^3.2.1",
+    "tslib": "^2.0.0",
+    "use-sync-external-store": "^1.2.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/core/src/components/Accessibility/components/RestoreFocus.tsx
+++ b/packages/core/src/components/Accessibility/components/RestoreFocus.tsx
@@ -12,7 +12,11 @@ interface Props {
 }
 
 export function RestoreFocus({disabled}: Props) {
-  const {active, activatorEvent, draggableNodes} = useContext(InternalContext);
+  const {useGloablActive, useGlobalActivatorEvent, draggableNodes} =
+    useContext(InternalContext);
+  const active = useGloablActive();
+  const activatorEvent = useGlobalActivatorEvent();
+
   const previousActivatorEvent = usePrevious(activatorEvent);
   const previousActiveId = usePrevious(active?.id);
 

--- a/packages/core/src/components/DndContext/DndContext.tsx
+++ b/packages/core/src/components/DndContext/DndContext.tsx
@@ -83,7 +83,7 @@ import {
 } from './hooks';
 import type {MeasuringConfiguration} from './types';
 import {createActiveAPI} from './activeAPI';
-import {useActiveRects} from './useActiveRects';
+import {useActiveNodeDomValues} from './useActiveNodeDomValues';
 
 export interface Props {
   id?: string;
@@ -180,14 +180,15 @@ export const DndContext = memo(function DndContext({
       config: measuringConfiguration.droppable,
     });
 
-  const activeNodeStuff = useActiveRects(
+  const activeNodeDomValues = useActiveNodeDomValues(
     draggableNodes,
     measuringConfiguration,
     active?.id || null
   );
-  const activeNode = activeNodeStuff?.activeNode || null;
-  const initialActiveNodeRect = activeNodeStuff?.initialActiveNodeRect || null;
-  const activeNodeRect = activeNodeStuff?.activeNodeRect || null;
+  const activeNode = activeNodeDomValues?.activeNode || null;
+  const initialActiveNodeRect =
+    activeNodeDomValues?.initialActiveNodeRect || null;
+  const activeNodeRect = activeNodeDomValues?.activeNodeRect || null;
   const containerNodeRect = useRect(
     activeNode ? activeNode.parentElement : null
   );
@@ -667,12 +668,12 @@ export const DndContext = memo(function DndContext({
       useMyActivatorEvent: activeAPI.useMyActivatorEvent,
       useGlobalActivatorEvent: activeAPI.useActivatorEvent,
       useMyActiveNodeRect: (id: UniqueIdentifier) => {
-        const stuff = useActiveRects(
+        const domValues = useActiveNodeDomValues(
           draggableNodes,
           measuringConfiguration,
           id
         );
-        return stuff?.activeNodeRect || null;
+        return domValues?.activeNodeRect || null;
       },
       activators,
       ariaDescribedById: {

--- a/packages/core/src/components/DndContext/DndContext.tsx
+++ b/packages/core/src/components/DndContext/DndContext.tsx
@@ -362,9 +362,8 @@ export const DndContext = memo(function DndContext({
             setStatus(Status.Initializing);
             activeAPI.setActive(id);
             dispatch({
-              type: Action.DragStart,
+              type: Action.SetInitiailCoordinates,
               initialCoordinates,
-              active: id,
             });
             dispatchMonitorEvent({type: 'onDragStart', event});
           });
@@ -375,8 +374,8 @@ export const DndContext = memo(function DndContext({
             coordinates,
           });
         },
-        onEnd: createHandler(Action.DragEnd),
-        onCancel: createHandler(Action.DragCancel),
+        onEnd: createHandler('DragEnd'),
+        onCancel: createHandler('DragCancel'),
       });
 
       unstable_batchedUpdates(() => {
@@ -384,7 +383,7 @@ export const DndContext = memo(function DndContext({
         activeAPI.setActivatorEvent(event.nativeEvent);
       });
 
-      function createHandler(type: Action.DragEnd | Action.DragCancel) {
+      function createHandler(type: 'DragEnd' | 'DragCancel') {
         return async function handler() {
           const {active, collisions, over, scrollAdjustedTranslate} =
             sensorContext.current;
@@ -401,11 +400,11 @@ export const DndContext = memo(function DndContext({
               over,
             };
 
-            if (type === Action.DragEnd && typeof cancelDrop === 'function') {
+            if (type === 'DragEnd' && typeof cancelDrop === 'function') {
               const shouldCancel = await Promise.resolve(cancelDrop(event));
 
               if (shouldCancel) {
-                type = Action.DragCancel;
+                type = 'DragCancel';
               }
             }
           }
@@ -414,14 +413,13 @@ export const DndContext = memo(function DndContext({
 
           unstable_batchedUpdates(() => {
             activeAPI.setActive(null);
-            dispatch({type});
+            dispatch({type: Action.ClearCoordinates});
             setStatus(Status.Uninitialized);
             setOver(null);
             setActiveSensor(null);
             activeAPI.setActivatorEvent(null);
 
-            const eventName =
-              type === Action.DragEnd ? 'onDragEnd' : 'onDragCancel';
+            const eventName = type === 'DragEnd' ? 'onDragEnd' : 'onDragCancel';
 
             if (event) {
               const handler = latestProps.current[eventName];

--- a/packages/core/src/components/DndContext/activeAPI.ts
+++ b/packages/core/src/components/DndContext/activeAPI.ts
@@ -1,0 +1,80 @@
+import type {MutableRefObject} from 'react';
+import {useSyncExternalStore} from 'use-sync-external-store/shim';
+import type {Active} from '../../store';
+
+import type {UniqueIdentifier, ClientRect} from '../../types';
+import {defaultData} from './defaults';
+
+type Rects = MutableRefObject<{
+  initial: ClientRect | null;
+  translated: ClientRect | null;
+}>;
+
+export function createActiveAPI(rect: Rects) {
+  let activeId: UniqueIdentifier | null = null;
+  let active: Active | null = null;
+
+  let activatorEvent: Event | null = null;
+  const draggableNodes = new Map<UniqueIdentifier, any>();
+  const activeRects = rect;
+
+  const registry: (() => void)[] = [];
+
+  function subscribe(listener: () => void) {
+    registry.push(listener);
+    return () => {
+      registry.splice(registry.indexOf(listener), 1);
+    };
+  }
+
+  function getActiveInfo() {
+    if (!activeId) return null;
+    const node = draggableNodes.get(activeId);
+    return {
+      id: activeId,
+      rect: activeRects,
+      data: node ? node.data : defaultData,
+    };
+  }
+
+  return {
+    draggableNodes,
+    setActive: function (id: UniqueIdentifier | null) {
+      if (activeId === id) return;
+      activeId = id;
+      active = getActiveInfo();
+      registry.forEach((li) => li());
+    },
+
+    setActivatorEvent: function (event: Event | null) {
+      activatorEvent = event;
+      registry.forEach((li) => li());
+    },
+
+    useIsDragging: function (id: UniqueIdentifier) {
+      return useSyncExternalStore(subscribe, () => activeId === id);
+    },
+
+    useHasActive: function () {
+      return useSyncExternalStore(subscribe, () => activeId !== null);
+    },
+    useActive: function () {
+      return useSyncExternalStore(subscribe, () => active);
+    },
+
+    useMyActive: function (id: UniqueIdentifier) {
+      return useSyncExternalStore(subscribe, () =>
+        activeId === id ? active : null
+      );
+    },
+
+    useActivatorEvent: function () {
+      return useSyncExternalStore(subscribe, () => activatorEvent);
+    },
+    useMyActivatorEvent: function (id: UniqueIdentifier) {
+      return useSyncExternalStore(subscribe, () =>
+        activeId === id ? activatorEvent : null
+      );
+    },
+  };
+}

--- a/packages/core/src/components/DndContext/useActiveNodeDomValues.tsx
+++ b/packages/core/src/components/DndContext/useActiveNodeDomValues.tsx
@@ -5,7 +5,7 @@ import type {DraggableNodes} from '../../store';
 import type {UniqueIdentifier} from '../../types';
 import type {MeasuringConfiguration} from './types';
 
-export function useActiveRects(
+export function useActiveNodeDomValues(
   draggableNodes: DraggableNodes,
   measuringConfiguration: DeepRequired<MeasuringConfiguration>,
   activeId: UniqueIdentifier | null

--- a/packages/core/src/components/DndContext/useActiveRects.tsx
+++ b/packages/core/src/components/DndContext/useActiveRects.tsx
@@ -1,0 +1,37 @@
+import type {DeepRequired} from '@dnd-kit/utilities';
+import {useMemo} from 'react';
+import {useCachedNode, useInitialRect, useRect} from '../../hooks/utilities';
+import type {DraggableNodes} from '../../store';
+import type {UniqueIdentifier} from '../../types';
+import type {MeasuringConfiguration} from './types';
+
+export function useActiveRects(
+  draggableNodes: DraggableNodes,
+  measuringConfiguration: DeepRequired<MeasuringConfiguration>,
+  activeId: UniqueIdentifier | null
+) {
+  const activeNode = useCachedNode(draggableNodes, activeId);
+
+  const initialActiveNodeRect = useInitialRect(
+    activeNode,
+    measuringConfiguration.draggable.measure
+  );
+
+  const activeNodeRect = useRect(
+    activeNode,
+    measuringConfiguration.draggable.measure,
+    initialActiveNodeRect
+  );
+
+  const value = useMemo(() => {
+    return activeNode
+      ? {
+          activeNode,
+          activeNodeRect,
+          initialActiveNodeRect,
+        }
+      : null;
+  }, [activeNode, activeNodeRect, initialActiveNodeRect]);
+
+  return value;
+}

--- a/packages/core/src/components/my/stateMachine.ts
+++ b/packages/core/src/components/my/stateMachine.ts
@@ -1,0 +1,88 @@
+import type {MutableRefObject} from 'react';
+import type {DraggableNodes, Over} from '../../store';
+import type {
+  Coordinates,
+  DragStartEvent,
+  UniqueIdentifier,
+  ClientRect,
+  Translate,
+  DragEndEvent,
+} from '../../types';
+import type {Collision} from '../../utilities';
+import {defaultData} from '../DndContext/defaults';
+
+enum Status {
+  Uninitialized,
+  Initializing,
+  Initialized,
+}
+
+export class Api {
+  state = {};
+  draggableNodes: DraggableNodes = new Map();
+  status: Status = Status.Uninitialized;
+  active: UniqueIdentifier | null = null;
+  initialCoordinates: Coordinates = {x: 0, y: 0};
+
+  startDrag(
+    id: UniqueIdentifier | null,
+    activeRects: MutableRefObject<{
+      initial: ClientRect | null;
+      translated: ClientRect | null;
+    }>,
+    initialCoordinates: Coordinates,
+    onDragStart?: (event: DragStartEvent) => void
+  ) {
+    if (id == null) {
+      return;
+    }
+    const draggableNode = this.draggableNodes.get(id);
+
+    if (!draggableNode) {
+      return;
+    }
+    const event: DragStartEvent = {
+      active: {id, data: draggableNode.data, rect: activeRects},
+    };
+
+    onDragStart?.(event);
+    this.status = Status.Initializing;
+    this.active = id;
+    this.initialCoordinates = initialCoordinates;
+  }
+
+  endDrag(
+    activeRects: MutableRefObject<{
+      initial: ClientRect | null;
+      translated: ClientRect | null;
+    }>,
+    type: 'onDragEnd' | 'onDragCancel',
+    sensorState: {
+      over: Over | null;
+      collisions: Collision[] | null;
+      activatorEvent: Event | null;
+      delta: Translate | null;
+    },
+    onDragEnd?: (event: DragEndEvent) => void
+  ) {
+    const event = this.active
+      ? {
+          ...sensorState,
+          active: {
+            id: this.active,
+            data: this.draggableNodes.get(this.active)?.data ?? defaultData,
+            rect: activeRects,
+          },
+        }
+      : null;
+    const shouldFireEvent = this.active && sensorState.delta;
+
+    this.active = null;
+    this.initialCoordinates = {x: 0, y: 0};
+    this.status = Status.Uninitialized;
+
+    if (shouldFireEvent) {
+      onDragEnd?.(event as DragEndEvent);
+    }
+  }
+}

--- a/packages/core/src/hooks/useDraggable.ts
+++ b/packages/core/src/hooks/useDraggable.ts
@@ -49,8 +49,8 @@ export function useDraggable({
   const key = useUniqueId(ID_PREFIX);
   const {
     activators,
-    activatorEvent,
-    active,
+    useMyActivatorEvent,
+    useMyActive,
     activeNodeRect,
     ariaDescribedById,
     draggableNodes,
@@ -61,7 +61,9 @@ export function useDraggable({
     roleDescription = 'draggable',
     tabIndex = 0,
   } = attributes ?? {};
-  const isDragging = active?.id === id;
+  const active = useMyActive(id);
+  const isDragging = active !== null;
+  const activatorEvent = useMyActivatorEvent(id);
   const transform: Transform | null = useContext(
     isDragging ? ActiveDraggableContext : NullContext
   );
@@ -106,6 +108,7 @@ export function useDraggable({
   );
 
   return {
+    //active and activatorEvent will by null if this isn't the active node
     active,
     activatorEvent,
     activeNodeRect,

--- a/packages/core/src/hooks/useDraggable.ts
+++ b/packages/core/src/hooks/useDraggable.ts
@@ -51,7 +51,7 @@ export function useDraggable({
     activators,
     useMyActivatorEvent,
     useMyActive,
-    activeNodeRect,
+    useMyActiveNodeRect,
     ariaDescribedById,
     draggableNodes,
     over,
@@ -64,6 +64,7 @@ export function useDraggable({
   const active = useMyActive(id);
   const isDragging = active !== null;
   const activatorEvent = useMyActivatorEvent(id);
+  const activeNodeRect = useMyActiveNodeRect(id);
   const transform: Transform | null = useContext(
     isDragging ? ActiveDraggableContext : NullContext
   );

--- a/packages/core/src/hooks/useDroppable.ts
+++ b/packages/core/src/hooks/useDroppable.ts
@@ -43,9 +43,9 @@ export function useDroppable({
   resizeObserverConfig,
 }: UseDroppableArguments) {
   const key = useUniqueId(ID_PREFIX);
-  const {active, dispatch, over, measureDroppableContainers} = useContext(
-    InternalContext
-  );
+  const {useHasActive, dispatch, over, measureDroppableContainers} =
+    useContext(InternalContext);
+  const hasActive = useHasActive();
   const previous = useRef({disabled});
   const resizeObserverConnected = useRef(false);
   const rect = useRef<ClientRect | null>(null);
@@ -84,7 +84,7 @@ export function useDroppable({
   );
   const resizeObserver = useResizeObserver({
     callback: handleResize,
-    disabled: resizeObserverDisabled || !active,
+    disabled: resizeObserverDisabled || !hasActive,
   });
   const handleNodeChange = useCallback(
     (newElement: HTMLElement | null, previousElement: HTMLElement | null) => {
@@ -155,7 +155,7 @@ export function useDroppable({
   }, [id, key, disabled, dispatch]);
 
   return {
-    active,
+    //I removed the active from here, it forces all droppable to re-render when active changes.
     rect,
     isOver: over?.id === id,
     node: nodeRef,

--- a/packages/core/src/store/actions.ts
+++ b/packages/core/src/store/actions.ts
@@ -2,10 +2,9 @@ import type {Coordinates, UniqueIdentifier} from '../types';
 import type {DroppableContainer} from './types';
 
 export enum Action {
-  DragStart = 'dragStart',
+  SetInitiailCoordinates = 'setInitialCoordinates',
   DragMove = 'dragMove',
-  DragEnd = 'dragEnd',
-  DragCancel = 'dragCancel',
+  ClearCoordinates = 'clearCoordinates',
   DragOver = 'dragOver',
   RegisterDroppable = 'registerDroppable',
   SetDroppableDisabled = 'setDroppableDisabled',
@@ -14,13 +13,11 @@ export enum Action {
 
 export type Actions =
   | {
-      type: Action.DragStart;
-      active: UniqueIdentifier;
+      type: Action.SetInitiailCoordinates;
       initialCoordinates: Coordinates;
     }
   | {type: Action.DragMove; coordinates: Coordinates}
-  | {type: Action.DragEnd}
-  | {type: Action.DragCancel}
+  | {type: Action.ClearCoordinates}
   | {
       type: Action.RegisterDroppable;
       element: DroppableContainer;

--- a/packages/core/src/store/context.ts
+++ b/packages/core/src/store/context.ts
@@ -3,7 +3,12 @@ import {createContext} from 'react';
 import {noop} from '../utilities/other';
 import {defaultMeasuringConfiguration} from '../components/DndContext/defaults';
 import {DroppableContainersMap} from './constructors';
-import type {InternalContextDescriptor, PublicContextDescriptor} from './types';
+import type {
+  Active,
+  InternalContextDescriptor,
+  PublicContextDescriptor,
+} from './types';
+import type {ClientRect} from '../types';
 
 export const defaultPublicContext: PublicContextDescriptor = {
   activatorEvent: null,
@@ -32,10 +37,7 @@ export const defaultPublicContext: PublicContextDescriptor = {
 };
 
 export const defaultInternalContext: InternalContextDescriptor = {
-  activatorEvent: null,
   activators: [],
-  active: null,
-  activeNodeRect: null,
   ariaDescribedById: {
     draggable: '',
   },
@@ -43,12 +45,29 @@ export const defaultInternalContext: InternalContextDescriptor = {
   draggableNodes: new Map(),
   over: null,
   measureDroppableContainers: noop,
+  useMyActive: function (): Active | null {
+    throw new Error('Function not implemented.');
+  },
+  useGloablActive: function (): Active | null {
+    throw new Error('Function not implemented.');
+  },
+  useHasActive: function (): boolean {
+    throw new Error('Function not implemented.');
+  },
+  useMyActivatorEvent: function (): Event | null {
+    throw new Error('Function not implemented.');
+  },
+  useGlobalActivatorEvent: function (): Event | null {
+    throw new Error('Function not implemented.');
+  },
+  useMyActiveNodeRect: function (): ClientRect | null {
+    throw new Error('Function not implemented.');
+  },
 };
 
 export const InternalContext = createContext<InternalContextDescriptor>(
   defaultInternalContext
 );
 
-export const PublicContext = createContext<PublicContextDescriptor>(
-  defaultPublicContext
-);
+export const PublicContext =
+  createContext<PublicContextDescriptor>(defaultPublicContext);

--- a/packages/core/src/store/reducer.ts
+++ b/packages/core/src/store/reducer.ts
@@ -5,7 +5,7 @@ import type {State} from './types';
 export function getInitialState(): State {
   return {
     draggable: {
-      initialCoordinates: {x: 0, y: 0},
+      initialCoordinates: null,
       translate: {x: 0, y: 0},
     },
     droppable: {
@@ -16,7 +16,7 @@ export function getInitialState(): State {
 
 export function reducer(state: State, action: Actions): State {
   switch (action.type) {
-    case Action.DragStart:
+    case Action.SetInitiailCoordinates:
       return {
         ...state,
         draggable: {
@@ -25,9 +25,9 @@ export function reducer(state: State, action: Actions): State {
         },
       };
     case Action.DragMove:
-      // if (!state.draggable.active) {
-      //   return state;
-      // }
+      if (!state.draggable.initialCoordinates) {
+        return state;
+      }
 
       return {
         ...state,
@@ -39,8 +39,7 @@ export function reducer(state: State, action: Actions): State {
           },
         },
       };
-    case Action.DragEnd:
-    case Action.DragCancel:
+    case Action.ClearCoordinates:
       return {
         ...state,
         draggable: {

--- a/packages/core/src/store/reducer.ts
+++ b/packages/core/src/store/reducer.ts
@@ -5,9 +5,7 @@ import type {State} from './types';
 export function getInitialState(): State {
   return {
     draggable: {
-      active: null,
       initialCoordinates: {x: 0, y: 0},
-      nodes: new Map(),
       translate: {x: 0, y: 0},
     },
     droppable: {
@@ -24,13 +22,12 @@ export function reducer(state: State, action: Actions): State {
         draggable: {
           ...state.draggable,
           initialCoordinates: action.initialCoordinates,
-          active: action.active,
         },
       };
     case Action.DragMove:
-      if (!state.draggable.active) {
-        return state;
-      }
+      // if (!state.draggable.active) {
+      //   return state;
+      // }
 
       return {
         ...state,
@@ -48,7 +45,6 @@ export function reducer(state: State, action: Actions): State {
         ...state,
         draggable: {
           ...state.draggable,
-          active: null,
           initialCoordinates: {x: 0, y: 0},
           translate: {x: 0, y: 0},
         },

--- a/packages/core/src/store/types.ts
+++ b/packages/core/src/store/types.ts
@@ -97,11 +97,13 @@ export interface PublicContextDescriptor {
 }
 
 export interface InternalContextDescriptor {
-  useMyActivatorEvent: (id: UniqueIdentifier) => Event | null;
   activators: SyntheticListeners;
   useMyActive: (id: UniqueIdentifier) => Active | null;
+  useGloablActive: () => Active | null;
   useHasActive: () => boolean;
-  activeNodeRect: ClientRect | null;
+  useMyActivatorEvent: (id: UniqueIdentifier) => Event | null;
+  useGlobalActivatorEvent: () => Event | null;
+  useMyActiveNodeRect: (id: UniqueIdentifier) => ClientRect | null;
   ariaDescribedById: {
     draggable: string;
   };

--- a/packages/core/src/store/types.ts
+++ b/packages/core/src/store/types.ts
@@ -67,9 +67,7 @@ export interface State {
     containers: DroppableContainers;
   };
   draggable: {
-    active: UniqueIdentifier | null;
     initialCoordinates: Coordinates;
-    nodes: DraggableNodes;
     translate: Coordinates;
   };
 }
@@ -99,9 +97,10 @@ export interface PublicContextDescriptor {
 }
 
 export interface InternalContextDescriptor {
-  activatorEvent: Event | null;
+  useMyActivatorEvent: (id: UniqueIdentifier) => Event | null;
   activators: SyntheticListeners;
-  active: Active | null;
+  useMyActive: (id: UniqueIdentifier) => Active | null;
+  useHasActive: () => boolean;
   activeNodeRect: ClientRect | null;
   ariaDescribedById: {
     draggable: string;

--- a/packages/core/src/store/types.ts
+++ b/packages/core/src/store/types.ts
@@ -67,7 +67,7 @@ export interface State {
     containers: DroppableContainers;
   };
   draggable: {
-    initialCoordinates: Coordinates;
+    initialCoordinates: Coordinates | null;
     translate: Coordinates;
   };
 }

--- a/stories/1 - Core/Draggable/1-Draggable.story.tsx
+++ b/stories/1 - Core/Draggable/1-Draggable.story.tsx
@@ -112,15 +112,10 @@ function DraggableItem({
   handle,
   buttonStyle,
 }: DraggableItemProps) {
-  const {
-    attributes,
-    isDragging,
-    listeners,
-    setNodeRef,
-    transform,
-  } = useDraggable({
-    id: 'draggable',
-  });
+  const {attributes, isDragging, listeners, setNodeRef, transform} =
+    useDraggable({
+      id: 'draggable',
+    });
 
   return (
     <Draggable

--- a/stories/1 - Core/Draggable/3-MultipleDraggable.story.tsx
+++ b/stories/1 - Core/Draggable/3-MultipleDraggable.story.tsx
@@ -1,0 +1,162 @@
+import React, {useState} from 'react';
+import {
+  DndContext,
+  useDraggable,
+  useSensor,
+  MouseSensor,
+  TouchSensor,
+  KeyboardSensor,
+  PointerActivationConstraint,
+  Modifiers,
+  useSensors,
+} from '@dnd-kit/core';
+
+import type {Coordinates} from '@dnd-kit/utilities';
+
+import {Axis, Draggable, Wrapper} from '../../components';
+
+export default {
+  title: 'Core/Draggable/Multi/draggable',
+};
+
+const defaultCoordinates = {
+  x: 0,
+  y: 0,
+};
+
+interface Props {
+  activationConstraint?: PointerActivationConstraint;
+  axis?: Axis;
+  handle?: boolean;
+  modifiers?: Modifiers;
+  buttonStyle?: React.CSSProperties;
+  style?: React.CSSProperties;
+  label?: string;
+}
+
+function DraggableStory({
+  activationConstraint,
+  axis,
+  handle,
+  label = 'Go ahead, drag me.',
+  modifiers,
+  style,
+  buttonStyle,
+}: Props) {
+  const [coordinated, setCoordinates] = useState<{[id: string]: Coordinates}>({
+    '1': defaultCoordinates,
+    '2': defaultCoordinates,
+    '3': defaultCoordinates,
+  });
+  //   const [{x, y}, setCoordinates] = useState<Coordinates>(defaultCoordinates);
+  const mouseSensor = useSensor(MouseSensor, {
+    activationConstraint,
+  });
+  const touchSensor = useSensor(TouchSensor, {
+    activationConstraint,
+  });
+  const keyboardSensor = useSensor(KeyboardSensor, {});
+  const sensors = useSensors(mouseSensor, touchSensor, keyboardSensor);
+
+  return (
+    <DndContext
+      sensors={sensors}
+      onDragEnd={({delta, active}) => {
+        setCoordinates((state) => {
+          return {
+            ...state,
+            [active.id]: {
+              x: state[active.id].x + delta.x,
+              y: state[active.id].y + delta.y,
+            },
+          };
+        });
+      }}
+      modifiers={modifiers}
+    >
+      <Wrapper>
+        <MemoDraggableItem
+          key="1"
+          id="1"
+          axis={axis}
+          label={label}
+          handle={handle}
+          top={coordinated['1'].y}
+          left={coordinated['1'].x}
+          style={style}
+          buttonStyle={buttonStyle}
+        />
+        <MemoDraggableItem
+          key="2"
+          id="2"
+          axis={axis}
+          label={label}
+          handle={handle}
+          top={coordinated['2'].y}
+          left={coordinated['2'].x}
+          style={style}
+          buttonStyle={buttonStyle}
+        />
+        <MemoDraggableItem
+          key="3"
+          id="3"
+          axis={axis}
+          label={label}
+          handle={handle}
+          top={coordinated['3'].y}
+          left={coordinated['3'].x}
+          style={style}
+          buttonStyle={buttonStyle}
+        />
+      </Wrapper>
+    </DndContext>
+  );
+}
+
+interface DraggableItemProps {
+  label: string;
+  handle?: boolean;
+  style?: React.CSSProperties;
+  buttonStyle?: React.CSSProperties;
+  axis?: Axis;
+  top?: number;
+  left?: number;
+  id: string;
+}
+
+function DraggableItem({
+  id,
+  axis,
+  label,
+  style,
+  top,
+  left,
+  handle,
+  buttonStyle,
+}: DraggableItemProps) {
+  const {attributes, isDragging, listeners, setNodeRef, transform} =
+    useDraggable({
+      id: id,
+    });
+
+  console.log('render draggable', id);
+
+  return (
+    <Draggable
+      ref={setNodeRef}
+      dragging={isDragging}
+      handle={handle}
+      label={label}
+      listeners={listeners}
+      style={{...style, top, left}}
+      buttonStyle={buttonStyle}
+      transform={transform}
+      axis={axis}
+      {...attributes}
+    />
+  );
+}
+
+const MemoDraggableItem = React.memo(DraggableItem);
+
+export const BasicSetup = () => <DraggableStory />;

--- a/stories/1 - Core/Draggable/3-MultipleDraggable.story.tsx
+++ b/stories/1 - Core/Draggable/3-MultipleDraggable.story.tsx
@@ -1,4 +1,4 @@
-import React, {useState} from 'react';
+import React, {useMemo, useState} from 'react';
 import {
   DndContext,
   useDraggable,
@@ -49,13 +49,15 @@ function DraggableStory({
     '3': defaultCoordinates,
   });
   //   const [{x, y}, setCoordinates] = useState<Coordinates>(defaultCoordinates);
-  const mouseSensor = useSensor(MouseSensor, {
-    activationConstraint,
-  });
-  const touchSensor = useSensor(TouchSensor, {
-    activationConstraint,
-  });
-  const keyboardSensor = useSensor(KeyboardSensor, {});
+  const sensorOptions = useMemo(
+    () => ({
+      activationConstraint,
+    }),
+    [activationConstraint]
+  );
+  const mouseSensor = useSensor(MouseSensor, sensorOptions);
+  const touchSensor = useSensor(TouchSensor, sensorOptions);
+  const keyboardSensor = useSensor(KeyboardSensor);
   const sensors = useSensors(mouseSensor, touchSensor, keyboardSensor);
 
   return (

--- a/stories/1 - Core/Draggable/3-MultipleDraggable.story.tsx
+++ b/stories/1 - Core/Draggable/3-MultipleDraggable.story.tsx
@@ -1,4 +1,4 @@
-import React, {useMemo, useState} from 'react';
+import React, {Profiler, useMemo, useRef, useState} from 'react';
 import {
   DndContext,
   useDraggable,
@@ -139,22 +139,35 @@ function DraggableItem({
     useDraggable({
       id: id,
     });
-
-  console.log('render draggable', id);
+  const span = useRef<HTMLSpanElement>(null);
 
   return (
-    <Draggable
-      ref={setNodeRef}
-      dragging={isDragging}
-      handle={handle}
-      label={label}
-      listeners={listeners}
-      style={{...style, top, left}}
-      buttonStyle={buttonStyle}
-      transform={transform}
-      axis={axis}
-      {...attributes}
-    />
+    <Profiler
+      id="App"
+      onRender={(id, phase) => {
+        if (phase === 'update' && span.current) {
+          span.current.innerHTML = 'updated';
+        }
+      }}
+    >
+      <div>
+        <span data-testid={id} ref={span}>
+          mounted
+        </span>
+        <Draggable
+          ref={setNodeRef}
+          dragging={isDragging}
+          handle={handle}
+          label={label}
+          listeners={listeners}
+          style={{...style, top, left}}
+          buttonStyle={buttonStyle}
+          transform={transform}
+          axis={axis}
+          {...attributes}
+        />
+      </div>
+    </Profiler>
   );
 }
 

--- a/stories/1 - Core/Draggable/3-MultipleDraggable.story.tsx
+++ b/stories/1 - Core/Draggable/3-MultipleDraggable.story.tsx
@@ -48,7 +48,6 @@ function DraggableStory({
     '2': defaultCoordinates,
     '3': defaultCoordinates,
   });
-  //   const [{x, y}, setCoordinates] = useState<Coordinates>(defaultCoordinates);
   const sensorOptions = useMemo(
     () => ({
       activationConstraint,
@@ -159,6 +158,9 @@ function DraggableItem({
   );
 }
 
+//we are memoizing the draggable item to prevent it all items from re-rendering when one of them changes coordinates.
+//so it will be easier to test
+//changes in the context are ignored by the memoization
 const MemoDraggableItem = React.memo(DraggableItem);
 
 export const BasicSetup = () => <DraggableStory />;

--- a/yarn.lock
+++ b/yarn.lock
@@ -4318,6 +4318,11 @@
   resolved "https://registry.npmjs.org/@types/unist/-/unist-2.0.6.tgz"
   integrity sha512-PBjIUxZHOuj0R15/xuwJYjFi+KZdNFrehocChv4g5hu6aFroHue8m0lBP0POdK2nKzbw0cgV1mws8+V/JAcEkQ==
 
+"@types/use-sync-external-store@^0.0.3":
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/@types/use-sync-external-store/-/use-sync-external-store-0.0.3.tgz#b6725d5f4af24ace33b36fafd295136e75509f43"
+  integrity sha512-EwmlvuaxPNej9+T4v5AuBPJa2x2UOJVdjCtDHgcDqitUeOtjnJKJ+apYjVcAoBEMjKW1VVFGZLUb5+qqa09XFA==
+
 "@types/webpack-env@^1.16.0":
   version "1.16.0"
   resolved "https://registry.npmjs.org/@types/webpack-env/-/webpack-env-1.16.0.tgz"
@@ -16560,6 +16565,11 @@ use-sidecar@^1.0.1:
   dependencies:
     detect-node-es "^1.0.0"
     tslib "^1.9.3"
+
+use-sync-external-store@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz#7dbefd6ef3fe4e767a0cf5d7287aacfb5846928a"
+  integrity sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==
 
 use@^3.1.0:
   version "3.1.1"


### PR DESCRIPTION
in this PR we solve only the re-rendering for `useDraggable` hooks (and the components using it) when active element changes.

did not try to solve similar issues (yet) when `over` changes or for `useSortable` which exposes `activeIndex` and `overIndex` - to solve the issue there we will need to find a different API.
Maybe something like over: 'item-before' | 'me' | 'item-after' | 'other' so that the whole list won't re-render while dragging.

I tried to make as little changes as possible, but there are still some pretty significant changes, including changes in the API:
- `useDraggable` not returns `null` for `active`, `activatorEvent`, `activeNodeRect` if item isn't dragging
- `useDroppable` does not expose `active`.

please review and if you like the direction give some feedback. 
if you like the direction I'll see if this PR needs some fine-tuning and start thinking about the same issue in other areas.