### PR TITLE
Fix rects measuring on elements change

### DIFF
--- a/packages/core/src/hooks/utilities/useRects.ts
+++ b/packages/core/src/hooks/utilities/useRects.ts
@@ -30,8 +30,8 @@ export function useRects(
       elements.forEach((element) => resizeObserver?.observe(element));
     } else {
       resizeObserver?.disconnect();
-      measureRects();
     }
+    measureRects();
   }, [elements]);
 
   return rects;


### PR DESCRIPTION
A fix for #1092, I am not sure if there are any other implications with this change so any input is appreciated. 

#### What was happening?
When using multiple containers `scrollableAncestors` would get updated, but their rects would not. 
So, let's imagine dragging from one container to another, first we have something like:
```
scrollableAncestors = [parent, grandparent]
scrollableAncestorsRects = [parentRect, grandparentRect]
```
Then ancestors get updated to just one element in between switching containers, but rects **do not**.
```
scrollableAncestors = [grandparent]
scrollableAncestorsRects = [parentRect, grandparentRect]
```
Then, this code brings chaos:
https://github.com/clauderic/dnd-kit/blob/5c58f0fe5d19b5aaa5cf93572f3435f4a0a6e54f/packages/core/src/hooks/utilities/useAutoScroller.ts#L121-L122

Because for grandparent `scrollContainer` it would use index 0 to access rects, leading to `scrollContainerRect` being `parentRect` for grandparent container - causing seemingly random jumps as can be seen in the video from the issue referenced on top. 
