### PR TITLE
Fix issue with over being null in onDragEnd

### DIFF
--- a/.changeset/soft-mails-check.md
+++ b/.changeset/soft-mails-check.md
@@ -1,0 +1,5 @@
+---
+'@dnd-kit/core': patch
+---
+
+Fix issue with over being null in onDragEnd

--- a/packages/core/src/components/DndContext/DndContext.tsx
+++ b/packages/core/src/components/DndContext/DndContext.tsx
@@ -567,6 +567,7 @@ export const DndContext = memo(function DndContext({
       };
 
       unstable_batchedUpdates(() => {
+        sensorContext.current.over = over;
         setOver(over);
         onDragOver?.(event);
         dispatchMonitorEvent({type: 'onDragOver', event});


### PR DESCRIPTION
I am currently implementing drag and drop behavior within our application and I've noticed that sometimes the `over` property is set to null. Found a issue for this one as well: https://github.com/clauderic/dnd-kit/issues/391

After some investigation, I was able to reproduce this on storybook in the `MultipleContainers` example as well, as I first thought I made a mistake in the implementation. Its very hard to reliably reproduce it so pardon me for not providing a codesandbox. I tried writing a test for this but it turns out this is not very easy to achieve.

Ways on how to reproduce (takes quite some time):
1. Do a very fast click (mouse down, mouse up) on a `Draggable`.
2. The `over` property you get through `onDragEnd` is sometimes `null`.

It really feels like a timing issue, since the `sensorContext.over` is set through this `useIsomorphicLayoutEffect`:
https://github.com/clauderic/dnd-kit/blob/5c58f0fe5d19b5aaa5cf93572f3435f4a0a6e54f/packages/core/src/components/DndContext/DndContext.tsx#L579-L613

By setting `over` directly in the `sensorContext` instead of relying on the `useIsomorphicLayoutEffect` to fire before the `onDragEnd` callback is called.
