### PR TITLE
Use `aria-live="polite"` for announcements

### DIFF
--- a/.changeset/configure-aria-live.md
+++ b/.changeset/configure-aria-live.md
@@ -1,0 +1,5 @@
+---
+"@dnd-kit/accessibility": minor
+---
+
+Introduce `ariaLiveType` prop on `<LiveRegion>` to allow consumers to configure the `aria-live` attribute to other values for announcements, such as `aria-live="polite"`.

--- a/packages/accessibility/src/components/LiveRegion/LiveRegion.tsx
+++ b/packages/accessibility/src/components/LiveRegion/LiveRegion.tsx
@@ -3,10 +3,10 @@ import React from 'react';
 export interface Props {
   id: string;
   announcement: string;
-  ariaLiveType: "polite" | "assertive" | "off";
+  ariaLiveType?: "polite" | "assertive" | "off";
 }
 
-export function LiveRegion({id, announcement, ariaLiveType = "polite"}: Props) {
+export function LiveRegion({id, announcement, ariaLiveType = "assertive"}: Props) {
   // Hide element visually but keep it readable by screen readers
   const visuallyHidden: React.CSSProperties = {
     position: 'fixed',

--- a/packages/accessibility/src/components/LiveRegion/LiveRegion.tsx
+++ b/packages/accessibility/src/components/LiveRegion/LiveRegion.tsx
@@ -3,29 +3,30 @@ import React from 'react';
 export interface Props {
   id: string;
   announcement: string;
+  ariaLiveType: "polite" | "assertive" | "off";
 }
 
-// Hide element visually but keep it readable by screen readers
-const visuallyHidden: React.CSSProperties = {
-  position: 'fixed',
-  width: 1,
-  height: 1,
-  margin: -1,
-  border: 0,
-  padding: 0,
-  overflow: 'hidden',
-  clip: 'rect(0 0 0 0)',
-  clipPath: 'inset(100%)',
-  whiteSpace: 'nowrap',
-};
-
-export function LiveRegion({id, announcement}: Props) {
+export function LiveRegion({id, announcement, ariaLiveType = "polite"}: Props) {
+  // Hide element visually but keep it readable by screen readers
+  const visuallyHidden: React.CSSProperties = {
+    position: 'fixed',
+    width: 1,
+    height: 1,
+    margin: -1,
+    border: 0,
+    padding: 0,
+    overflow: 'hidden',
+    clip: 'rect(0 0 0 0)',
+    clipPath: 'inset(100%)',
+    whiteSpace: 'nowrap',
+  };
+  
   return (
     <div
       id={id}
       style={visuallyHidden}
       role="status"
-      aria-live="assertive"
+      aria-live={ariaLiveType}
       aria-atomic
     >
       {announcement}


### PR DESCRIPTION
When playing around with dnd-kit, I noticed that the `aria-live` property is set to "assertive" by default. I believe that "assertive" should only be used for time-sensitive/critical notifications that absolutely require the user's immediate attention (from: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Live_Regions#live_regions). 

Also, changing it to "polite" makes it such that the announcement is made when the user is idle. I think that really helps with screen-reader not announcing each time a user moves the item (gets a little annoying when say I want to drag it 5 rows below, it keeps announcing for each row but doesn't complete the announcement as each time I press down, it announces the new position without the last one completing) and instead, announces it when the user is a little sure of where the item should be (i.e be idle). 

Also moved the `visuallyHidden` directly within the component and not as a global constant as this reduces the number of declared constants and limits the scope of visuallyHidden (since it is only used within `LiveRegion` anyways)