### PR TITLE
Fix: getOwnerDocument should get correct document for SVG Elements

### DIFF
--- a/.changeset/owner-doc-for-svg-elements.md
+++ b/.changeset/owner-doc-for-svg-elements.md
@@ -1,0 +1,5 @@
+---
+"@dnd-kit/utilities": patch
+---
+
+Fix: getOwnerDocument should get correct document for SVG Elements

--- a/packages/utilities/src/execution-context/getOwnerDocument.ts
+++ b/packages/utilities/src/execution-context/getOwnerDocument.ts
@@ -1,4 +1,10 @@
-import {isWindow, isHTMLElement, isDocument, isNode} from '../type-guards';
+import {
+  isWindow,
+  isHTMLElement,
+  isDocument,
+  isNode,
+  isSVGElement,
+} from '../type-guards';
 
 export function getOwnerDocument(target: Event['target']): Document {
   if (!target) {
@@ -17,7 +23,7 @@ export function getOwnerDocument(target: Event['target']): Document {
     return target;
   }
 
-  if (isHTMLElement(target)) {
+  if (isHTMLElement(target) || isSVGElement(target)) {
     return target.ownerDocument;
   }
 


### PR DESCRIPTION
This PR fixes `getOwnerDocument`: Currently the function checks only for HTMLElement but it should also get ownerDocument for SVGElement, which both inherit from Element but SVG and HTML elements belong to different branches.

