### PR TITLE
Allow delay and distance constraints to be combined

### DIFF
--- a/.changeset/delay-or-distance.md
+++ b/.changeset/delay-or-distance.md
@@ -1,0 +1,5 @@
+---
+'@dnd-kit/core': minor
+---
+
+Allow `delay` and `distance` activation constraints to be used concurrently for `MouseSensor`, `TouchSensor` and `PointerSensor`.

--- a/stories/1 - Core/Draggable/1-Draggable.story.tsx
+++ b/stories/1 - Core/Draggable/1-Draggable.story.tsx
@@ -112,15 +112,10 @@ function DraggableItem({
   handle,
   buttonStyle,
 }: DraggableItemProps) {
-  const {
-    attributes,
-    isDragging,
-    listeners,
-    setNodeRef,
-    transform,
-  } = useDraggable({
-    id: 'draggable',
-  });
+  const {attributes, isDragging, listeners, setNodeRef, transform} =
+    useDraggable({
+      id: 'draggable',
+    });
 
   return (
     <Draggable
@@ -153,6 +148,21 @@ export const PressDelay = () => (
     }}
   />
 );
+
+PressDelay.storyName = 'Press delay';
+
+export const PressDelayOrDistance = () => (
+  <DraggableStory
+    label="Activated dragging 3px or holding 250ms"
+    activationConstraint={{
+      delay: 250,
+      distance: 3,
+      tolerance: 10,
+    }}
+  />
+);
+
+PressDelayOrDistance.storyName = 'Press delay or minimum distance';
 
 export const MinimumDistance = () => (
   <DraggableStory


### PR DESCRIPTION
This PR allows the `delay` and `distance` constraints to be used concurrently for the `MouseSensor`, `TouchSensor` and `PointerSensor`. This is useful in situations where you want either constraint to allow dragging rather than being mutually exclusive.

This allows for more intuitive drag and drop activation constraints in situations where you need to reserve click listeners for an action other than drag and drop and do not want to resort to using a drag handle.