### PR TITLE
Add `initial` and `delta` to `pointerCoordinates` in `collisionDetection`

### DIFF
--- a/.changeset/poor-coats-compete.md
+++ b/.changeset/poor-coats-compete.md
@@ -1,0 +1,11 @@
+---
+'@dnd-kit/core': minor
+---
+
+Add `initial` and `delta` to `pointerCoordinates` in `collisionDetection`
+
+This allows custom `collisionDetection` algorithms to consider where the event
+started or by how much it moved, allowing, for instance, for different
+collisions when dragging left than when dragging right.
+
+No change in usage required.

--- a/packages/core/src/components/DndContext/DndContext.tsx
+++ b/packages/core/src/components/DndContext/DndContext.tsx
@@ -277,7 +277,11 @@ export const DndContext = memo(function DndContext({
   });
 
   const pointerCoordinates = activationCoordinates
-    ? add(activationCoordinates, translate)
+    ? {
+        ...add(activationCoordinates, translate),
+        initial: activationCoordinates,
+        delta: translate,
+      }
     : null;
 
   const scrollOffsets = useScrollOffsets(scrollableAncestors);

--- a/packages/core/src/types/coordinates.ts
+++ b/packages/core/src/types/coordinates.ts
@@ -15,3 +15,8 @@ export interface ScrollCoordinates {
   current: Coordinates;
   delta: Coordinates;
 }
+
+export interface DragCoordinates extends Coordinates {
+  initial: Coordinates;
+  delta: Coordinates;
+};

--- a/packages/core/src/utilities/algorithms/types.ts
+++ b/packages/core/src/utilities/algorithms/types.ts
@@ -1,5 +1,5 @@
 import type {Active, Data, DroppableContainer, RectMap} from '../../store';
-import type {Coordinates, ClientRect, UniqueIdentifier} from '../../types';
+import type {DragCoordinates, ClientRect, UniqueIdentifier} from '../../types';
 
 export interface Collision {
   id: UniqueIdentifier;
@@ -19,5 +19,5 @@ export type CollisionDetection = (args: {
   collisionRect: ClientRect;
   droppableRects: RectMap;
   droppableContainers: DroppableContainer[];
-  pointerCoordinates: Coordinates | null;
+  pointerCoordinates: DragCoordinates | null;
 }) => Collision[];


### PR DESCRIPTION
This was done this way to avoid breaking existing usages, but

```
export interface DragCoordinates {
  initial: Coordinates;
  current: Coordinates;
  delta: Coordinates;
};
```

would perhaps be preferable.

My motivating usage is to allow considering the center of the `active` rather than the `pointerCoordinates`