### PR TITLE
Pass DND Context to sorting `strategy`

### DIFF
--- a/.changeset/twelve-windows-act.md
+++ b/.changeset/twelve-windows-act.md
@@ -1,0 +1,10 @@
+---
+'@dnd-kit/sortable': minor
+---
+
+Pass DND context to sorting `strategy`
+
+This allows the sorting strategy to make it's decisions based on the collisions or the items,
+allowing accessing the associated data, without having to keep track of it externally.
+
+No change in usage required.

--- a/packages/sortable/src/hooks/useSortable.ts
+++ b/packages/sortable/src/hooks/useSortable.ts
@@ -1,5 +1,6 @@
 import {useContext, useEffect, useMemo, useRef} from 'react';
 import {
+  useDndContext,
   useDraggable,
   useDroppable,
   UseDraggableArguments,
@@ -47,6 +48,7 @@ export function useSortable({
   resizeObserverConfig,
   transition = defaultTransition,
 }: Arguments) {
+  const dndContext = useDndContext();
   const {
     items,
     containerId,
@@ -118,13 +120,16 @@ export function useSortable({
   const strategy = localStrategy ?? globalStrategy;
   const finalTransform = displaceItem
     ? dragSourceDisplacement ??
-      strategy({
-        rects: sortedRects,
-        activeNodeRect,
-        activeIndex,
-        overIndex,
-        index,
-      })
+      strategy(
+        {
+          rects: sortedRects,
+          activeNodeRect,
+          activeIndex,
+          overIndex,
+          index,
+        },
+        dndContext
+      )
     : null;
   const newIndex =
     isValidIndex(activeIndex) && isValidIndex(overIndex)

--- a/packages/sortable/src/types/strategies.ts
+++ b/packages/sortable/src/types/strategies.ts
@@ -1,10 +1,13 @@
-import type {ClientRect} from '@dnd-kit/core';
+import type {ClientRect, PublicContextDescriptor} from '@dnd-kit/core';
 import type {Transform} from '@dnd-kit/utilities';
 
-export type SortingStrategy = (args: {
-  activeNodeRect: ClientRect | null;
-  activeIndex: number;
-  index: number;
-  rects: ClientRect[];
-  overIndex: number;
-}) => Transform | null;
+export type SortingStrategy = (
+  args: {
+    activeNodeRect: ClientRect | null;
+    activeIndex: number;
+    index: number;
+    rects: ClientRect[];
+    overIndex: number;
+  },
+  context: PublicContextDescriptor
+) => Transform | null;


### PR DESCRIPTION
This allows the sorting strategy to receive data returned in custom collision detection algorithms