### PR TITLE
Shallow copying the entire object to copy owned as well as prototype properties

### DIFF
--- a/packages/sortable/src/hooks/useSortable.ts
+++ b/packages/sortable/src/hooks/useSortable.ts
@@ -64,7 +64,11 @@ export function useSortable({
   );
   const index = items.indexOf(id);
   const data = useMemo<SortableData & Data>(
-    () => ({sortable: {containerId, index, items}, ...customData}),
+    () => ({sortable: {containerId, index, items}, 
+      ...Object.create(
+      Object.getPrototypeOf(customData),
+      Object.getOwnPropertyDescriptors(customData),
+    )}),
     [containerId, customData, index, items]
   );
   const itemsAfterCurrentSortable = useMemo(


### PR DESCRIPTION
Spread paramters will only copy enumerable and own properties from a source object to a target object, 

you are able to use this method and [Object.create()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/create) for a [shallow copy](https://developer.mozilla.org/en-US/docs/Glossary/Shallow_copy) between two unknown objects.