### PR TITLE
Export `defaultKeyboardCoordinateGetter`

### DIFF
--- a/.changeset/few-panthers-punch.md
+++ b/.changeset/few-panthers-punch.md
@@ -1,0 +1,5 @@
+---
+'@dnd-kit/core': patch
+---
+
+Export `defaultKeyboardCoordinateGetter`

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -52,6 +52,7 @@ export {
   MouseSensor,
   PointerSensor,
   TouchSensor,
+  defaultKeyboardCoordinateGetter,
   useSensors,
   useSensor,
 } from './sensors';

--- a/packages/core/src/sensors/index.ts
+++ b/packages/core/src/sensors/index.ts
@@ -18,7 +18,11 @@ export type {MouseSensorOptions, MouseSensorProps} from './mouse';
 export {TouchSensor} from './touch';
 export type {TouchSensorOptions, TouchSensorProps} from './touch';
 
-export {KeyboardSensor, KeyboardCode} from './keyboard';
+export {
+  KeyboardSensor,
+  KeyboardCode,
+  defaultKeyboardCoordinateGetter,
+} from './keyboard';
 export type {
   KeyboardCoordinateGetter,
   KeyboardSensorOptions,

--- a/packages/core/src/sensors/keyboard/index.ts
+++ b/packages/core/src/sensors/keyboard/index.ts
@@ -5,3 +5,4 @@ export type {
 } from './KeyboardSensor';
 export type {KeyboardCoordinateGetter, KeyboardCodes} from './types';
 export {KeyboardCode} from './types';
+export {defaultKeyboardCoordinateGetter} from './defaults';


### PR DESCRIPTION
Adds `defaultKeyboardCoordinateGetter` to the exports for `@dnd-kit/core`.

My use case for this is to compose the default coordinate getter with a custom coordinate getter that handles keystrokes other than arrow keys.