### PR TITLE
Faster Paint with delayed flush of Effects

### DIFF
--- a/.changeset/sixty-buses-call.md
+++ b/.changeset/sixty-buses-call.md
@@ -1,0 +1,5 @@
+---
+'@dnd-kit/core': patch
+---
+
+Faster Paint with delayed flush of Effects

--- a/packages/core/src/hooks/useDroppable.ts
+++ b/packages/core/src/hooks/useDroppable.ts
@@ -1,10 +1,5 @@
 import {useCallback, useContext, useEffect, useRef} from 'react';
-import {
-  useIsomorphicLayoutEffect,
-  useLatestValue,
-  useNodeRef,
-  useUniqueId,
-} from '@dnd-kit/utilities';
+import {useLatestValue, useNodeRef, useUniqueId} from '@dnd-kit/utilities';
 
 import {InternalContext, Action, Data} from '../store';
 import type {ClientRect, UniqueIdentifier} from '../types';
@@ -43,9 +38,8 @@ export function useDroppable({
   resizeObserverConfig,
 }: UseDroppableArguments) {
   const key = useUniqueId(ID_PREFIX);
-  const {active, dispatch, over, measureDroppableContainers} = useContext(
-    InternalContext
-  );
+  const {active, dispatch, over, measureDroppableContainers} =
+    useContext(InternalContext);
   const previous = useRef({disabled});
   const resizeObserverConnected = useRef(false);
   const rect = useRef<ClientRect | null>(null);

--- a/packages/core/src/hooks/useDroppable.ts
+++ b/packages/core/src/hooks/useDroppable.ts
@@ -116,7 +116,7 @@ export function useDroppable({
     resizeObserver.observe(nodeRef.current);
   }, [nodeRef, resizeObserver]);
 
-  useIsomorphicLayoutEffect(
+  useEffect(
     () => {
       dispatch({
         type: Action.RegisterDroppable,

--- a/packages/core/src/hooks/utilities/useRect.ts
+++ b/packages/core/src/hooks/utilities/useRect.ts
@@ -1,4 +1,4 @@
-import {useReducer} from 'react';
+import {useState} from 'react';
 import {useIsomorphicLayoutEffect} from '@dnd-kit/utilities';
 
 import type {ClientRect} from '../../types';
@@ -16,10 +16,10 @@ export function useRect(
   measure: (element: HTMLElement) => ClientRect = defaultMeasure,
   fallbackRect?: ClientRect | null
 ) {
-  const [rect, setRect] = useState(null);
+  const [rect, setRect] = useState<ClientRect | null>(null);
 
   function measureRect() {
-    setRect((currentRect: ClientRect | null) => {
+    setRect((currentRect): ClientRect | null => {
       if (!element) {
         return null;
       }

--- a/packages/core/src/hooks/utilities/useRect.ts
+++ b/packages/core/src/hooks/utilities/useRect.ts
@@ -16,8 +16,30 @@ export function useRect(
   measure: (element: HTMLElement) => ClientRect = defaultMeasure,
   fallbackRect?: ClientRect | null
 ) {
-  const [rect, measureRect] = useReducer(reducer, null);
+  const [rect, setRect] = useState(null);
 
+  function measureRect() {
+    setRect((currentRect: ClientRect | null) => {
+      if (!element) {
+        return null;
+      }
+  
+      if (element.isConnected === false) {
+        // Fall back to last rect we measured if the element is
+        // no longer connected to the DOM.
+        return currentRect ?? fallbackRect ?? null;
+      }
+  
+      const newRect = measure(element);
+  
+      if (JSON.stringify(currentRect) === JSON.stringify(newRect)) {
+        return currentRect;
+      }
+  
+      return newRect;
+    });
+  }
+  
   const mutationObserver = useMutationObserver({
     callback(records) {
       if (!element) {
@@ -56,24 +78,4 @@ export function useRect(
   }, [element]);
 
   return rect;
-
-  function reducer(currentRect: ClientRect | null) {
-    if (!element) {
-      return null;
-    }
-
-    if (element.isConnected === false) {
-      // Fall back to last rect we measured if the element is
-      // no longer connected to the DOM.
-      return currentRect ?? fallbackRect ?? null;
-    }
-
-    const newRect = measure(element);
-
-    if (JSON.stringify(currentRect) === JSON.stringify(newRect)) {
-      return currentRect;
-    }
-
-    return newRect;
-  }
 }

--- a/packages/core/src/hooks/utilities/useRects.ts
+++ b/packages/core/src/hooks/utilities/useRects.ts
@@ -1,3 +1,4 @@
+import {useState} from 'react';
 import {getWindow, useIsomorphicLayoutEffect} from '@dnd-kit/utilities';
 
 import type {ClientRect} from '../../types';
@@ -17,7 +18,7 @@ export function useRects(
   const windowRect = useWindowRect(
     firstElement ? getWindow(firstElement) : null
   );
-  const [rects, setRects] = useState(defaultValue);
+  const [rects, setRects] = useState<ClientRect[]>(defaultValue);
 
   function measureRects() {
     setRects(() => {

--- a/packages/core/src/hooks/utilities/useRects.ts
+++ b/packages/core/src/hooks/utilities/useRects.ts
@@ -1,4 +1,3 @@
-import {useReducer} from 'react';
 import {getWindow, useIsomorphicLayoutEffect} from '@dnd-kit/utilities';
 
 import type {ClientRect} from '../../types';
@@ -18,7 +17,22 @@ export function useRects(
   const windowRect = useWindowRect(
     firstElement ? getWindow(firstElement) : null
   );
-  const [rects, measureRects] = useReducer(reducer, defaultValue);
+  const [rects, setRects] = useState(defaultValue);
+
+  function measureRects() {
+    setRects(() => {
+      if (!elements.length) {
+        return defaultValue;
+      }
+  
+      return elements.map((element) =>
+        isDocumentScrollingElement(element)
+          ? (windowRect as ClientRect)
+          : new Rect(measure(element), element)
+      );
+    });
+  }
+  
   const resizeObserver = useResizeObserver({callback: measureRects});
 
   if (elements.length > 0 && rects === defaultValue) {
@@ -35,16 +49,4 @@ export function useRects(
   }, [elements]);
 
   return rects;
-
-  function reducer() {
-    if (!elements.length) {
-      return defaultValue;
-    }
-
-    return elements.map((element) =>
-      isDocumentScrollingElement(element)
-        ? (windowRect as ClientRect)
-        : new Rect(measure(element), element)
-    );
-  }
 }


### PR DESCRIPTION
This pull request enables faster paint of chat switch the changes to DND kit with the following changes:

**Change 1: Changing `useIsoMorphicLayoutEffect` to `useEffect`**
**Reason:** Changing state in a layout effect can delay browser paint.

**Details:** The DND kit mutates state in a layout effect, but only for registering elements as draggable. This hurts performance as changing state in a layout effect can delay browser paint. In this case, there is no need to change state in a layout effect because this state change is only registering draggable elements which can wait until browser paint.

**Example:** A [CodeSandbox](https://codesandbox.io/p/sandbox/keen-mountain-scpydy-forked-tsk9sq)  example demonstrates how setting state in a layout effect delays browser paint.

**Case 1:** Changing state in a layout effect.
![image](https://github.com/clauderic/dnd-kit/assets/30507092/493ec874-8c4e-4767-a16b-5b6a7c4ad121)
Screenshot showing Paint after flush.

**Case 2:** Changing state in an effect.
![image](https://github.com/clauderic/dnd-kit/assets/30507092/256392b4-6ea5-4ef5-8839-01f34c1721fc)
Screenshot showing Paint before flush.

**Change 2: Updating `useRect `and `useRects`**
**Reason:** Removed the reducer implementation in favor of state.

**Details:** Similar to the first point, the state was changing in a layout effect when a user clicks and drag a DND node. Initially, we considered replacing useIsoMorphicLayoutEffect with useEffect. However, to avoid visual discrepancies, we replaced the useReducer with useState. This change ensures that even though the state updates within a layout effect, the paint is delayed only when there is a meaningful state change. This is because useReducer doesn't [bail out of meaningless state updates](https://github.com/facebook/react/pull/22445), whereas useState can.

Automated Tests:
We also ran Cypress and Unit Test on github repo to gain confidence on proposed changes. Here are the results 
![image](https://github.com/clauderic/dnd-kit/assets/30507092/8fa6875f-0a21-43cb-b05f-57e9b671acf4)

![image](https://github.com/clauderic/dnd-kit/assets/30507092/7b8749d7-64ac-42dd-b088-7fe2293e4565)





