### PR TITLE
[Experimental branch] Allow the entity to have a new id

### DIFF
--- a/.changeset/rude-worms-kick.md
+++ b/.changeset/rude-worms-kick.md
@@ -1,0 +1,5 @@
+---
+"@dnd-kit/abstract": patch
+---
+
+Allow entities to receive a new id during the lifecycle of the entity

--- a/packages/abstract/src/core/entities/entity/entity.ts
+++ b/packages/abstract/src/core/entities/entity/entity.ts
@@ -38,7 +38,7 @@ export class Entity<
     this.effects = () => [
       () => {
         // Re-run this effect whenever the `id` changes
-        const {id: _, manager} = this;
+        const {id, manager} = this;
 
         if (id === previousId) {
           return;


### PR DESCRIPTION
When the `id` of the entity is updated from a component I noted that the element wasn't draggable anymore, as it if were not being detected. The reason was that the new `id` was not being compared in the `id` effect at `Entity`.

What I did was to change the effect to read the `id` from `this` rather than using the `id` received by the `constructor`. This makes sense because the new `id` is set to the class in the hooks:

```
useOnValueChange(id, () => (droppable.id = id));
```

With this change it should be straightforward to add a "Clone" example to the stories. I can do that too if you're interested.