### PR TITLE
Avoid re-rendering children on click event

### DIFF
--- a/.changeset/brave-kids-explain.md
+++ b/.changeset/brave-kids-explain.md
@@ -1,0 +1,5 @@
+---
+'@dnd-kit/core': patch
+---
+
+Improves performance by eliminating wasteful re-renders on every child item on click

--- a/packages/core/src/components/DndContext/DndContext.tsx
+++ b/packages/core/src/components/DndContext/DndContext.tsx
@@ -320,7 +320,6 @@ export const DndContext = memo(function DndContext({
   );
 
   const activeSensorRef = useRef<SensorInstance | null>(null);
-  const activatorEventRef = useRef<Event | null>(null);
   const instantiateSensor = useCallback(
     (
       event: React.SyntheticEvent,
@@ -374,7 +373,7 @@ export const DndContext = memo(function DndContext({
             });
             dispatchMonitorEvent({type: 'onDragStart', event});
             setActiveSensor(activeSensorRef.current);
-            setActivatorEvent(activatorEventRef.current);
+            setActivatorEvent(activatorEvent);
           });
         },
         onMove(coordinates) {
@@ -388,7 +387,6 @@ export const DndContext = memo(function DndContext({
       });
 
       activeSensorRef.current = sensorInstance;
-      activatorEventRef.current = event.nativeEvent;
 
       function createHandler(type: Action.DragEnd | Action.DragCancel) {
         return async function handler() {
@@ -425,7 +423,6 @@ export const DndContext = memo(function DndContext({
             setActiveSensor(null);
             setActivatorEvent(null);
             activeSensorRef.current = null;
-            activatorEventRef.current = null;
 
             const eventName =
               type === Action.DragEnd ? 'onDragEnd' : 'onDragCancel';

--- a/packages/core/src/components/DndContext/DndContext.tsx
+++ b/packages/core/src/components/DndContext/DndContext.tsx
@@ -319,6 +319,8 @@ export const DndContext = memo(function DndContext({
     activeNodeRect
   );
 
+  const activeSensorRef = useRef<SensorInstance | null>(null);
+  const activatorEventRef = useRef<Event | null>(null);
   const instantiateSensor = useCallback(
     (
       event: React.SyntheticEvent,
@@ -371,6 +373,8 @@ export const DndContext = memo(function DndContext({
               active: id,
             });
             dispatchMonitorEvent({type: 'onDragStart', event});
+            setActiveSensor(activeSensorRef.current);
+            setActivatorEvent(activatorEventRef.current);
           });
         },
         onMove(coordinates) {
@@ -383,10 +387,8 @@ export const DndContext = memo(function DndContext({
         onCancel: createHandler(Action.DragCancel),
       });
 
-      unstable_batchedUpdates(() => {
-        setActiveSensor(sensorInstance);
-        setActivatorEvent(event.nativeEvent);
-      });
+      activeSensorRef.current = sensorInstance;
+      activatorEventRef.current = event.nativeEvent;
 
       function createHandler(type: Action.DragEnd | Action.DragCancel) {
         return async function handler() {
@@ -422,6 +424,8 @@ export const DndContext = memo(function DndContext({
             setOver(null);
             setActiveSensor(null);
             setActivatorEvent(null);
+            activeSensorRef.current = null;
+            activatorEventRef.current = null;
 
             const eventName =
               type === Action.DragEnd ? 'onDragEnd' : 'onDragCancel';


### PR DESCRIPTION
I noticed that clicking on a DnD child node can be costly because it triggers all child nodes to rerender twice. This issue has been reported before. See #1379 

This happens when `DndContext` updates the `activeSensor` and `activatorEvent` states on a mouse down event. These state changes cause rerenders in all consumers of `DndContext`.  Consumers of `useSortable` re-render too because `SortableContext` depends on `DndContext`.

If the user is just clicking or if activation constraints aren’t met, DndContext resets these states to null, causing another render cycle.

Here’s what it looks like in React Profiler for a click event, where you'll see back-to-back commit cycles causing unnecessary rerenders for every child:
![image](https://github.com/user-attachments/assets/97ef0115-2ce6-43d1-b170-3a5ea5e57824)

I don't see why we need to update state unless the user is actually dragging. This PR proposes delaying the` activeSensor` and `activatorEvent` state updates until the drag event starts and constraints are met. This reduces unnecessary re-renders, saving two render cycles for every child.

Here’s what the React Profiler looks like with this change:

![image](https://github.com/user-attachments/assets/3de7adc0-7150-48f1-b110-06d4a3d6deb7)

From Perf trace, you'll notice that mouse down and mouse up events aren't doing much work
Before:
![image](https://github.com/user-attachments/assets/788c65d5-0bda-4802-9835-d3264b3c77ed)

After: 

![image](https://github.com/user-attachments/assets/e46dd49f-9c5e-4d9b-a7d3-57e3a44f4b6e)


Cypress tests are passing -

![image](https://github.com/user-attachments/assets/ea45e072-e674-4f42-bc77-5ab8cbcacfc6)


