### PR TITLE
Always set proxy

### DIFF
--- a/.changeset/always-set-proxy.md
+++ b/.changeset/always-set-proxy.md
@@ -1,0 +1,5 @@
+---
+'@dnd-kit/dom': patch
+---
+
+Fix a bug that prevented all unique droppables that share an element from each receiving the cloned proxy.

--- a/packages/dom/src/core/plugins/accessibility/Accessibility.ts
+++ b/packages/dom/src/core/plugins/accessibility/Accessibility.ts
@@ -1,6 +1,6 @@
 import {effects} from '@dnd-kit/state';
 import {Plugin} from '@dnd-kit/abstract';
-import {getWindow, isSafari} from '@dnd-kit/dom/utilities';
+import {getWindow, isSafari, generateUniqueId} from '@dnd-kit/dom/utilities';
 
 import type {DragDropManager} from '../../manager/index.ts';
 import {
@@ -11,7 +11,7 @@ import {
   defaultScreenReaderInstructions,
 } from './defaults.ts';
 import type {Announcements, ScreenReaderInstructions} from './types.ts';
-import {generateUniqueId, isFocusable} from './utilities.ts';
+import {isFocusable} from './utilities.ts';
 import {createHiddenText} from './HiddenText.ts';
 import {createLiveRegion} from './LiveRegion.ts';
 

--- a/packages/dom/src/core/plugins/accessibility/utilities.ts
+++ b/packages/dom/src/core/plugins/accessibility/utilities.ts
@@ -12,12 +12,3 @@ export function isFocusable(element: Element) {
     element instanceof window.HTMLAreaElement
   );
 }
-
-const ids: Record<string, number> = {};
-
-export function generateUniqueId(prefix: string) {
-  const id = ids[prefix] == null ? 0 : ids[prefix] + 1;
-  ids[prefix] = id;
-
-  return `${prefix}-${id}`;
-}

--- a/packages/dom/src/utilities/index.ts
+++ b/packages/dom/src/utilities/index.ts
@@ -47,3 +47,5 @@ export {
   parseTranslate,
 } from './transform/index.ts';
 export type {Transform} from './transform/index.ts';
+
+export {generateUniqueId} from './misc/generateUniqueId.ts';

--- a/packages/dom/src/utilities/misc/generateUniqueId.ts
+++ b/packages/dom/src/utilities/misc/generateUniqueId.ts
@@ -1,0 +1,8 @@
+const ids: Record<string, number> = {};
+
+export function generateUniqueId(prefix: string) {
+  const id = ids[prefix] == null ? 0 : ids[prefix] + 1;
+  ids[prefix] = id;
+
+  return `${prefix}-${id}`;
+}


### PR DESCRIPTION
Fix a bug in the `experimental` branch that prevented all unique droppables that share an element from each receiving the cloned proxy.

This is because the underlying IDENTIFIER_ATTRIBUTE was getting overwritten for each droppable, and so only the last droppable item would have the correct identifier attribute and hence proxy.

Instead, generate a unique data attribute for each droppable using `generateUniqueId` (now moved out of the accessibility plugin) and store it in a map. Note, we can't reuse the element's ID, since this may contain illegal characters.