### PR TITLE
Expose collision via notifier, and add data param

### DIFF
--- a/.changeset/add-data-param-to-collision.md
+++ b/.changeset/add-data-param-to-collision.md
@@ -1,0 +1,5 @@
+---
+'@dnd-kit/abstract': patch
+---
+
+Enable collision algorithms to define an optional `data` parameter on collisions.

--- a/.changeset/expose-collision-via-notifier.md
+++ b/.changeset/expose-collision-via-notifier.md
@@ -1,0 +1,5 @@
+---
+'@dnd-kit/abstract': patch
+---
+
+Expose `collision` via notifier for parsing collision data in drag callbacks.

--- a/packages/abstract/src/core/collision/notifier.ts
+++ b/packages/abstract/src/core/collision/notifier.ts
@@ -54,6 +54,8 @@ export class CollisionNotifier extends CorePlugin {
           if (firstCollision?.id !== manager.dragOperation.target?.id) {
             collisionObserver.disable();
 
+            manager.actions.setCollision(firstCollision);
+
             manager.actions.setDropTarget(firstCollision?.id).then(() => {
               collisionObserver.enable();
             });

--- a/packages/abstract/src/core/collision/types.ts
+++ b/packages/abstract/src/core/collision/types.ts
@@ -4,6 +4,7 @@ import type {
   Droppable,
   UniqueIdentifier,
 } from '../entities/index.ts';
+import {Serializable} from '../manager/dragOperation.ts';
 
 export enum CollisionPriority {
   Lowest,
@@ -24,6 +25,7 @@ export interface Collision {
   priority: CollisionPriority | number;
   type: CollisionType;
   value: number;
+  data?: Serializable;
 }
 
 export type Collisions = Collision[];

--- a/packages/abstract/src/core/manager/dragOperation.ts
+++ b/packages/abstract/src/core/manager/dragOperation.ts
@@ -12,6 +12,7 @@ import {descriptor} from '../plugins/index.ts';
 
 import type {DragDropManager} from './manager.ts';
 import {defaultPreventable} from './events.ts';
+import {Collision} from '../collision/types.ts';
 
 export enum Status {
   Idle = 'idle',
@@ -30,6 +31,7 @@ export interface DragOperation<
 > {
   activatorEvent: Event | null;
   canceled: boolean;
+  collision: Collision | null;
   position: Position;
   transform: Coordinates;
   status: {
@@ -74,6 +76,7 @@ export function DragOperationManager<
   const canceled = signal<boolean>(false);
   const position = new Position({x: 0, y: 0});
   const activatorEvent = signal<Event | null>(null);
+  const collision = signal<Collision | null>(null);
   const sourceIdentifier = signal<UniqueIdentifier | null>(null);
   const targetIdentifier = signal<UniqueIdentifier | null>(null);
   const dragging = computed(() => status.value === Status.Dragging);
@@ -129,6 +132,7 @@ export function DragOperationManager<
       canceled: canceled.peek(),
       source: source.peek(),
       target: target.peek(),
+      collision: collision.peek(),
       status: {
         current: status.peek(),
         idle: idle.peek(),
@@ -158,6 +162,9 @@ export function DragOperationManager<
     },
     get canceled() {
       return canceled.value;
+    },
+    get collision() {
+      return collision.value;
     },
     get source() {
       return source.value;
@@ -216,6 +223,7 @@ export function DragOperationManager<
   const reset = () => {
     batch(() => {
       status.value = Status.Idle;
+      collision.value = null;
       sourceIdentifier.value = null;
       targetIdentifier.value = null;
       shape.current.value = null;
@@ -228,6 +236,9 @@ export function DragOperationManager<
   return {
     operation,
     actions: {
+      setCollision(currentCollision: Collision) {
+        collision.value = currentCollision;
+      },
       setDragSource(identifier: UniqueIdentifier) {
         sourceIdentifier.value = identifier;
       },


### PR DESCRIPTION
Make two changes to support advanced collision detection algorithms in the `experimental` branch:

1. Add the optional `data` parameter to the Collision type, to allow collision detector algorithms to provide metadata about the collision
2. Expose the `collision` via the notifier (on DataOperation), so the user can access the collision (including the new `data` parameter) in their drag callbacks

My use-case is a a sophisticated collision detection algorithm for Puck in #598 that provides [`position: "before" | "after"` data](https://github.com/measuredco/puck/pull/598/files#r1795882946) based on the intersection of the two items.

