### PR TITLE
fix a grammer typo

### DIFF
--- a/docs/pages/api-documentation/draggable/index.mdx
+++ b/docs/pages/api-documentation/draggable/index.mdx
@@ -4,7 +4,7 @@ import {Callout} from '../../../components';
 
 ![](/draggable-large.svg)
 
-Use the `useDraggable` hook turn DOM nodes into draggable sources that can be picked up, moved and dropped over [droppable](../droppable/) containers.
+Use the `useDraggable` hook to turn DOM nodes into draggable sources that can be picked up, moved and dropped over [droppable](../droppable/) containers.
 
 ## Usage
 


### PR DESCRIPTION
There is a very small typo on the docs page on [this](https://docs.dndkit.com/api-documentation/draggable) link. 
A "to" is missing.

**Original line is:**
Use the useDraggable hook turn DOM nodes into draggable sources that can be picked up, moved and dropped over [droppable](https://docs.dndkit.com/api-documentation/droppable) containers.


**It should be:**
Use the useDraggable hook **to** turn DOM nodes into draggable sources that can be picked up, moved and dropped over [droppable](https://docs.dndkit.com/api-documentation/droppable) containers.