### PR TITLE
fix: ensure delta correct for transforms and size changes

### DIFF
--- a/packages/dom/src/core/plugins/feedback/Feedback.ts
+++ b/packages/dom/src/core/plugins/feedback/Feedback.ts
@@ -153,20 +153,23 @@ export class Feedback extends Plugin<DragDropManager, FeedbackOptions> {
         x: initialCoordinates.x - relativeLeft,
         y: initialCoordinates.y - relativeTop,
       };
+
       const sizeDelta = {
         width:
-          (initialSize.width / initialFrameTransform.scaleX -
-            width / frameTransform.scaleX) *
+          (initialSize.width * initialFrameTransform.scaleX -
+            width * frameTransform.scaleX) *
           transformOrigin.x,
         height:
-          (initialSize.height / initialFrameTransform.scaleY -
-            height / frameTransform.scaleY) *
+          (initialSize.height * initialFrameTransform.scaleY -
+            height * frameTransform.scaleY) *
           transformOrigin.y,
       };
+
       const delta = {
-        x: coordinatesDelta.x / frameTransform.scaleX - sizeDelta.width,
-        y: coordinatesDelta.y / frameTransform.scaleY - sizeDelta.height,
+        x: coordinatesDelta.x / frameTransform.scaleX + sizeDelta.width,
+        y: coordinatesDelta.y / frameTransform.scaleY + sizeDelta.height,
       };
+
       const projected = {
         left: left + delta.x,
         top: top + delta.y,


### PR DESCRIPTION
Attempt at fixing an issue introduced in https://github.com/clauderic/dnd-kit/commit/682db33dfce65abcd99fdc82edf078a6e4a356a1, which broke the sizeDelta calculation for cases where the droppable changes size.

This change is the culprit

```
     const sizeDelta = {
        width:
          (initialSize.width / initialFrameTransform.scaleX -
            width / frameTransform.scaleX) *
          transformOrigin.x,
        height:
          (initialSize.height / initialFrameTransform.scaleY -
            height / frameTransform.scaleY) *
          transformOrigin.y,
      };
```

Which be reverted by inverting the arithmetic

```
     const sizeDelta = {
        width:
          (width / frameTransform.scaleX - initialSize.width / initialFrameTransform.scaleX) *
          transformOrigin.x,
        height:
          (height / frameTransform.scaleY - initialSize.height / initialFrameTransform.scaleY) *
          transformOrigin.y,
      };
```

This PR initially seemed to address the issue, but upon further inspection, I noticed it does not behave consistently, noticeable on smaller transform sizes (`0.5`) or when using keyboard sensor. This is a bad smell and indicates to me that I haven't understood the underlying logic.

I've been slowly stepping through the Feedback sensor and making adjustments locally to get my head around how the transforms are being applied, but it's taking me a while as I'm struggling to understand how the transformed are being reasoned about.

Sharing this PR for progress, but marking as draft.