### PR TITLE
fix: workaround LiveRegion layout issues

### DIFF
--- a/.changeset/tidy-cobras-hang.md
+++ b/.changeset/tidy-cobras-hang.md
@@ -1,0 +1,9 @@
+---
+'@dnd-kit/accessibility': patch
+---
+
+Workaround `<LiveRegion>` layout bug by adding explicit `top` and `left`
+attributes. Under sufficiently complex CSS conditions, the element would
+overflow containers that it's not supposed to. See [this
+post](https://blog.duvallj.pw/posts/2024-11-19-chrome-heisenbug-uncovered.html)
+for a complete explanation.

--- a/packages/accessibility/src/components/LiveRegion/LiveRegion.tsx
+++ b/packages/accessibility/src/components/LiveRegion/LiveRegion.tsx
@@ -10,6 +10,8 @@ export function LiveRegion({id, announcement, ariaLiveType = "assertive"}: Props
   // Hide element visually but keep it readable by screen readers
   const visuallyHidden: React.CSSProperties = {
     position: 'fixed',
+    top: 0,
+    left: 0,
     width: 1,
     height: 1,
     margin: -1,


### PR DESCRIPTION
It turns out, under some sufficiently complex CSS conditions, the visually hidden `<LiveRegion>` component can cause layout issues. See <https://static.duvallj.pw/2024-11-19/scrollHeightBug/index.html> for a minimal reproduction (Chrome and Firefox; behavior is correct in Safari), and <https://blog.duvallj.pw/posts/2024-11-19-chrome-heisenbug-uncovered.html> for an explanation of what's wrong about this example.

TL;DR sometimes this `position: fixed;` element will overflow container divs in a strange + unexpected + buggy way. Setting explicit `top`/`left` properties causes the layout to be calculated correctly again.