### PR TITLE
Make it easier to implement visual cues when using activation constraints.

### DIFF
--- a/.changeset/metal-mice-develop.md
+++ b/.changeset/metal-mice-develop.md
@@ -1,0 +1,58 @@
+---
+'@dnd-kit/core': patch
+---
+
+Make it possible to add visual cues when using activation constraints.
+
+### Context
+
+Activation constraints are used when we want to prevent accidental dragging or when
+pointer press can mean more than "start dragging".
+
+A typical use case is a button that needs to respond to both "click" and "drag" gestures.
+Clicks can be distinguished from drags based on how long the pointer was
+held pressed.
+
+### The problem
+
+A control that responds differently to a pointer press based on duration or distance can
+be confusing to use -- the user has to guess how long to keep holding or how far to keep
+dragging until their intent is acknowledged.
+
+Implementing such cues is currently possible by attaching extra event listeners so that
+we know when a drag is pending. Furthermore, the listener needs to have access to
+the same constraints that were applied to the sensor initiating the drag. This can be
+made to work in simple cases, but it becomes error-prone and difficult to maintain in
+complex scenarios.
+
+### Solution
+
+This changeset proposes the addition of two new events: `onDragPending` and `onDragAbort`.
+
+#### `onDragPending`
+
+A drag is considered to be pending when the pointer has been pressed and there are
+activation constraints that need to be satisfied before a drag can start.
+
+This event is initially fired on pointer press. At this time `offset` (see below) will be
+`undefined`.
+
+It will subsequently be fired every time the pointer is moved. This is to enable
+visual cues for distance-based activation.
+
+The event's payload contains all the information necessary for providing visual feedback:
+
+```typescript
+export interface DragPendingEvent {
+  id: UniqueIdentifier;
+  constraint: PointerActivationConstraint;
+  initialCoordinates: Coordinates;
+  offset?: Coordinates | undefined;
+}
+```
+
+#### `onDragAbort`
+
+A drag is considered aborted when an activation constraint for a pending drag was violated.
+Useful as a prompt to cancel any visual cue animations currently in progress.
+Note that this event will _not_ be fired when dragging ends or is canceled.

--- a/packages/core/src/components/DndContext/DndContext.tsx
+++ b/packages/core/src/components/DndContext/DndContext.tsx
@@ -70,6 +70,8 @@ import type {
   DragMoveEvent,
   DragOverEvent,
   UniqueIdentifier,
+  DragPendingEvent,
+  DragAbortEvent,
 } from '../../types';
 import {
   Accessibility,
@@ -100,6 +102,8 @@ export interface Props {
   measuring?: MeasuringConfiguration;
   modifiers?: Modifiers;
   sensors?: SensorDescriptor<any>[];
+  onDragAbort?(event: DragAbortEvent): void;
+  onDragPending?(event: DragPendingEvent): void;
   onDragStart?(event: DragStartEvent): void;
   onDragMove?(event: DragMoveEvent): void;
   onDragOver?(event: DragOverEvent): void;
@@ -344,6 +348,36 @@ export const DndContext = memo(function DndContext({
         // Sensors need to be instantiated with refs for arguments that change over time
         // otherwise they are frozen in time with the stale arguments
         context: sensorContext,
+        onAbort(id) {
+          const draggableNode = draggableNodes.get(id);
+
+          if (!draggableNode) {
+            return;
+          }
+
+          const {onDragAbort} = latestProps.current;
+          const event: DragAbortEvent = {id};
+          onDragAbort?.(event);
+          dispatchMonitorEvent({type: 'onDragAbort', event});
+        },
+        onPending(id, constraint, initialCoordinates, offset) {
+          const draggableNode = draggableNodes.get(id);
+
+          if (!draggableNode) {
+            return;
+          }
+
+          const {onDragPending} = latestProps.current;
+          const event: DragPendingEvent = {
+            id,
+            constraint,
+            initialCoordinates,
+            offset,
+          };
+
+          onDragPending?.(event);
+          dispatchMonitorEvent({type: 'onDragPending', event});
+        },
         onStart(initialCoordinates) {
           const id = activeRef.current;
 

--- a/packages/core/src/components/DndMonitor/types.ts
+++ b/packages/core/src/components/DndMonitor/types.ts
@@ -1,4 +1,6 @@
 import type {
+  DragAbortEvent,
+  DragPendingEvent,
   DragStartEvent,
   DragCancelEvent,
   DragEndEvent,
@@ -7,6 +9,8 @@ import type {
 } from '../../types';
 
 export interface DndMonitorListener {
+  onDragAbort?(event: DragAbortEvent): void;
+  onDragPending?(event: DragPendingEvent): void;
   onDragStart?(event: DragStartEvent): void;
   onDragMove?(event: DragMoveEvent): void;
   onDragOver?(event: DragOverEvent): void;
@@ -17,6 +21,8 @@ export interface DndMonitorListener {
 export interface DndMonitorEvent {
   type: keyof DndMonitorListener;
   event:
+    | DragAbortEvent
+    | DragPendingEvent
     | DragStartEvent
     | DragMoveEvent
     | DragOverEvent

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -97,6 +97,8 @@ export type {
   DragMoveEvent,
   DragOverEvent,
   DragStartEvent,
+  DragPendingEvent,
+  DragAbortEvent,
   DragCancelEvent,
   Translate,
   UniqueIdentifier,

--- a/packages/core/src/sensors/pointer/AbstractPointerSensor.ts
+++ b/packages/core/src/sensors/pointer/AbstractPointerSensor.ts
@@ -131,10 +131,12 @@ export class AbstractPointerSensor implements SensorInstance {
           this.handleStart,
           activationConstraint.delay
         );
+        this.handlePending(activationConstraint);
         return;
       }
 
       if (isDistanceConstraint(activationConstraint)) {
+        this.handlePending(activationConstraint);
         return;
       }
     }
@@ -154,6 +156,14 @@ export class AbstractPointerSensor implements SensorInstance {
       clearTimeout(this.timeoutId);
       this.timeoutId = null;
     }
+  }
+
+  private handlePending(
+    constraint: PointerActivationConstraint,
+    offset?: Coordinates | undefined
+  ): void {
+    const {active, onPending} = this.props;
+    onPending(active, constraint, this.initialCoordinates, offset);
   }
 
   private handleStart() {
@@ -216,6 +226,7 @@ export class AbstractPointerSensor implements SensorInstance {
         }
       }
 
+      this.handlePending(activationConstraint, delta);
       return;
     }
 
@@ -227,16 +238,22 @@ export class AbstractPointerSensor implements SensorInstance {
   }
 
   private handleEnd() {
-    const {onEnd} = this.props;
+    const {onAbort, onEnd} = this.props;
 
     this.detach();
+    if (!this.activated) {
+      onAbort(this.props.active);
+    }
     onEnd();
   }
 
   private handleCancel() {
-    const {onCancel} = this.props;
+    const {onAbort, onCancel} = this.props;
 
     this.detach();
+    if (!this.activated) {
+      onAbort(this.props.active);
+    }
     onCancel();
   }
 

--- a/packages/core/src/sensors/types.ts
+++ b/packages/core/src/sensors/types.ts
@@ -15,6 +15,7 @@ import type {
   ClientRect,
 } from '../types';
 import type {Collision} from '../utilities/algorithms';
+import type {PointerActivationConstraint} from './pointer';
 
 export enum Response {
   Start = 'start',
@@ -46,6 +47,13 @@ export interface SensorProps<T> {
   event: Event;
   context: MutableRefObject<SensorContext>;
   options: T;
+  onAbort(id: UniqueIdentifier): void;
+  onPending(
+    id: UniqueIdentifier,
+    constraint: PointerActivationConstraint,
+    initialCoordinates: Coordinates,
+    offset?: Coordinates | undefined
+  ): void;
   onStart(coordinates: Coordinates): void;
   onCancel(): void;
   onMove(coordinates: Coordinates): void;

--- a/packages/core/src/types/events.ts
+++ b/packages/core/src/types/events.ts
@@ -1,7 +1,9 @@
+import type {PointerActivationConstraint} from '../sensors';
 import type {Active, Over} from '../store';
 import type {Collision} from '../utilities/algorithms';
 
-import type {Translate} from './coordinates';
+import type {Coordinates, Translate} from './coordinates';
+import type {UniqueIdentifier} from '.';
 
 interface DragEvent {
   activatorEvent: Event;
@@ -9,6 +11,26 @@ interface DragEvent {
   collisions: Collision[] | null;
   delta: Translate;
   over: Over | null;
+}
+
+/**
+ * Fired if a pending drag was aborted before it started.
+ * Only meaningful in the context of activation constraints.
+ **/
+export interface DragAbortEvent {
+  id: UniqueIdentifier;
+}
+
+/**
+ * Fired when a drag is about to start pending activation constraints.
+ * @note For pointer events, it will be fired repeatedly with updated
+ * coordinates when pointer is moved until the drag starts.
+ */
+export interface DragPendingEvent {
+  id: UniqueIdentifier;
+  constraint: PointerActivationConstraint;
+  initialCoordinates: Coordinates;
+  offset?: Coordinates | undefined;
 }
 
 export interface DragStartEvent extends Pick<DragEvent, 'active'> {}

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -6,6 +6,8 @@ export type {
 } from './coordinates';
 export {Direction} from './direction';
 export type {
+  DragAbortEvent,
+  DragPendingEvent,
   DragStartEvent,
   DragCancelEvent,
   DragEndEvent,

--- a/stories/components/Draggable/Draggable.module.css
+++ b/stories/components/Draggable/Draggable.module.css
@@ -1,3 +1,9 @@
+@property --progress {
+  syntax: "<number>";
+  initial-value: 0;
+  inherits: false;
+}
+
 .Draggable {
   position: relative;
   display: flex;
@@ -22,6 +28,13 @@
     transform: translate3d(var(--translate-x, 0), var(--translate-y, 0), 0)
       scale(var(--scale, 1));
     transition: box-shadow 300ms ease;
+  }
+
+  &.pendingDelay > button {
+    animation: pending linear;
+    background-image: linear-gradient(90deg,
+      #f00d calc(var(--progress)* 1%),
+      transparent calc(var(--progress)* 1% + 1%));
   }
 
   &:not(.handle) {
@@ -126,5 +139,11 @@
     transform: translate3d(var(--translate-x, 0), var(--translate-y, 0), 0)
       scale(var(--scale));
     box-shadow: var(--box-shadow);
+  }
+}
+
+@keyframes pending {
+  100% {
+    --progress: 100;
   }
 }

--- a/stories/components/Draggable/Draggable.tsx
+++ b/stories/components/Draggable/Draggable.tsx
@@ -28,6 +28,8 @@ interface Props {
   style?: React.CSSProperties;
   buttonStyle?: React.CSSProperties;
   transform?: Transform | null;
+  isPendingDelay?: boolean;
+  children?: React.ReactNode;
 }
 
 export const Draggable = forwardRef<HTMLButtonElement, Props>(
@@ -42,6 +44,7 @@ export const Draggable = forwardRef<HTMLButtonElement, Props>(
       transform,
       style,
       buttonStyle,
+      isPendingDelay = false,
       ...props
     },
     ref
@@ -52,7 +55,8 @@ export const Draggable = forwardRef<HTMLButtonElement, Props>(
           styles.Draggable,
           dragOverlay && styles.dragOverlay,
           dragging && styles.dragging,
-          handle && styles.handle
+          handle && styles.handle,
+          isPendingDelay && styles.pendingDelay
         )}
         style={
           {
@@ -77,6 +81,7 @@ export const Draggable = forwardRef<HTMLButtonElement, Props>(
             ? draggableHorizontal
             : draggable}
           {handle ? <Handle {...(handle ? listeners : {})} /> : null}
+          {props.children}
         </button>
         {label ? <label>{label}</label> : null}
       </div>


### PR DESCRIPTION
### Context

Activation constraints are used when we want to prevent accidental dragging or when pointer press can mean more than "start dragging".

A typical use case is a button that needs to respond to both "click" and "drag" gestures. Clicks can be distinguished from drags based on how long the pointer was held pressed.

### The problem

A control that responds differently to a pointer press based on duration or distance can be confusing to use -- the user has to guess how long to keep holding or how far to keep dragging until their intent is acknowledged.

Implementing such cues is currently possible by attaching extra event listeners so that we know when a drag is pending. Furthermore, the listener needs to have access to the same constraints that were applied to the sensor initiating the drag. This can be made to work in simple cases, but it becomes error-prone and difficult to maintain in complex scenarios.

### Solution

This PR proposes the addition of two new events: `onDragPending` and `onDragAbort`.

#### `onDragPending`

A drag is considered to be pending when the pointer has been pressed and there are activation constraints that need to be satisfied before a drag can start.

This event is initially fired on pointer press. At this time `offset` (see below) will be `undefined`.

It will subsequently be fired every time the pointer is moved. This is to enable visual cues for distance-based activation.

The event's payload contains all the information necessary for providing visual feedback:

```typescript
export interface DragPendingEvent {
  id: UniqueIdentifier;
  constraint: PointerActivationConstraint;
  initialCoordinates: Coordinates;
  offset?: Coordinates | undefined;
}
```

#### `onDragAbort`

A drag is considered aborted when an activation constraint for a pending drag was violated. Useful as a prompt to cancel any visual cue animations currently in progress. Note that this event will _not_ be fired when dragging ends or is canceled.

### Demo

See [Press Delay With Visual Cue](https://irobot.github.io/dnd-kit/?path=/story/core-draggable-hooks-usedraggable--press-delay-with-visual-cue) and [Minimum Distance With Visual Cue](https://irobot.github.io/dnd-kit/?path=/story/core-draggable-hooks-usedraggable--minimum-distance-with-visual-cue)