### PR TITLE
Handle touch and pointer cancel events

### DIFF
--- a/.changeset/handle-cancel-events.md
+++ b/.changeset/handle-cancel-events.md
@@ -1,0 +1,5 @@
+---
+'@dnd-kit/core': patch
+---
+
+Handle `touchcancel` and `pointercancel` events.

--- a/packages/core/src/sensors/pointer/AbstractPointerSensor.ts
+++ b/packages/core/src/sensors/pointer/AbstractPointerSensor.ts
@@ -32,6 +32,7 @@ interface EventDescriptor {
 }
 
 export interface PointerEventHandlers {
+  cancel?: EventDescriptor;
   move: EventDescriptor;
   end: EventDescriptor;
 }
@@ -109,6 +110,11 @@ export class AbstractPointerSensor implements SensorInstance {
 
     this.listeners.add(events.move.name, this.handleMove, {passive: false});
     this.listeners.add(events.end.name, this.handleEnd);
+
+    if (events.cancel) {
+      this.listeners.add(events.cancel.name, this.handleCancel);
+    }
+
     this.windowListeners.add(EventName.Resize, this.handleCancel);
     this.windowListeners.add(EventName.DragStart, preventDefault);
     this.windowListeners.add(EventName.VisibilityChange, this.handleCancel);

--- a/packages/core/src/sensors/pointer/PointerSensor.ts
+++ b/packages/core/src/sensors/pointer/PointerSensor.ts
@@ -9,6 +9,7 @@ import {
 } from './AbstractPointerSensor';
 
 const events: PointerEventHandlers = {
+  cancel: {name: 'pointercancel'},
   move: {name: 'pointermove'},
   end: {name: 'pointerup'},
 };

--- a/packages/core/src/sensors/touch/TouchSensor.ts
+++ b/packages/core/src/sensors/touch/TouchSensor.ts
@@ -9,6 +9,7 @@ import {
 import type {SensorProps} from '../types';
 
 const events: PointerEventHandlers = {
+  cancel: {name: 'touchcancel'},
   move: {name: 'touchmove'},
   end: {name: 'touchend'},
 };


### PR DESCRIPTION
This PR adds support for handling `touchcancel` and `pointercancel` events in the `@dnd-kit/core` package.