### PR TITLE
fix: don't lockup in React strict mode when using DragDropManager

### DIFF
--- a/.changeset/fix-strict-mode-provider.md
+++ b/.changeset/fix-strict-mode-provider.md
@@ -1,0 +1,1 @@
+fix: don't lockup in React strict mode when using DragDropManager with the default manager

--- a/packages/react/src/core/hooks/useInstance.ts
+++ b/packages/react/src/core/hooks/useInstance.ts
@@ -16,9 +16,7 @@ export function useInstance<T extends Instance>(
   initializer: (manager: DragDropManager<any, any> | undefined) => T
 ): T {
   const manager = useDragDropManager() ?? undefined;
-  const [instance] = useState<T>(() =>
-    initializer(manager === defaultManager ? undefined : manager)
-  );
+  const [instance] = useState<T>(() => initializer(undefined));
 
   useEffect(() => {
     instance.manager = manager;


### PR DESCRIPTION
Avoid passing the manager to the state `initializer`, as this causes issues with React strict mode. Instead, rely on the `useEffect` callback, already defined.

The `manager` arg passed back to the initializer function will now always be undefined, making it redundant.

It's still possible to cause strict mode to fail when using your own initalizer function to define a manager outside of dnd-kit, and pass it into the `DragDropProvider`.