### PR TITLE
End keyboard drag operation when pressing tab

### DIFF
--- a/.changeset/end-on-tab.md
+++ b/.changeset/end-on-tab.md
@@ -1,0 +1,5 @@
+---
+'@dnd-kit/core': patch
+---
+
+Added `Tab` to the list of default key codes that end a drag and drop operation. Can be customized by passing in a custom list of `keyCodes` to the KeyboardSensor options.

--- a/packages/core/src/sensors/keyboard/defaults.ts
+++ b/packages/core/src/sensors/keyboard/defaults.ts
@@ -3,7 +3,7 @@ import {KeyboardCoordinateGetter, KeyboardCode, KeyboardCodes} from './types';
 export const defaultKeyboardCodes: KeyboardCodes = {
   start: [KeyboardCode.Space, KeyboardCode.Enter],
   cancel: [KeyboardCode.Esc],
-  end: [KeyboardCode.Space, KeyboardCode.Enter],
+  end: [KeyboardCode.Space, KeyboardCode.Enter, KeyboardCode.Tab],
 };
 
 export const defaultKeyboardCoordinateGetter: KeyboardCoordinateGetter = (

--- a/packages/core/src/sensors/keyboard/types.ts
+++ b/packages/core/src/sensors/keyboard/types.ts
@@ -9,6 +9,7 @@ export enum KeyboardCode {
   Up = 'ArrowUp',
   Esc = 'Escape',
   Enter = 'Enter',
+  Tab = 'Tab',
 }
 
 export type KeyboardCodes = {


### PR DESCRIPTION
Resolves https://github.com/clauderic/dnd-kit/issues/857

This PR takes a different approach from https://github.com/clauderic/dnd-kit/pull/1087 and only de-activates the drag operation when the `Tab` key is pressed. This mostly accomplishes the same thing, but feels like a less risky change as there could be all sorts of factors that cause the draggable item to lose focus.