### PR TITLE
feat: add side effects;

### DIFF
--- a/packages/accessibility/package.json
+++ b/packages/accessibility/package.json
@@ -18,6 +18,7 @@
   },
   "main": "dist/index.js",
   "module": "dist/accessibility.esm.js",
+  "sideEffects": false,
   "typings": "dist/index.d.ts",
   "files": [
     "README.md",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -17,6 +17,7 @@
     "prepublish": "npm run build"
   },
   "main": "dist/index.js",
+  "sideEffects": false,
   "module": "dist/core.esm.js",
   "typings": "dist/index.d.ts",
   "files": [

--- a/packages/modifiers/package.json
+++ b/packages/modifiers/package.json
@@ -18,6 +18,7 @@
   },
   "main": "dist/index.js",
   "module": "dist/modifiers.esm.js",
+  "sideEffects": false,
   "typings": "dist/index.d.ts",
   "files": [
     "README.md",

--- a/packages/sortable/package.json
+++ b/packages/sortable/package.json
@@ -18,6 +18,7 @@
   },
   "main": "dist/index.js",
   "module": "dist/sortable.esm.js",
+  "sideEffects": false,
   "typings": "dist/index.d.ts",
   "files": [
     "README.md",

--- a/packages/utilities/package.json
+++ b/packages/utilities/package.json
@@ -18,6 +18,7 @@
   },
   "main": "dist/index.js",
   "module": "dist/utilities.esm.js",
+  "sideEffects": false,
   "typings": "dist/index.d.ts",
   "files": [
     "README.md",


### PR DESCRIPTION
Add side effects to package.json, help bundlers cut unused code with treeshake. Good for esm, modules, named imports.

rollup https://rollupjs.org/configuration-options/#treeshake-modulesideeffects
webpack https://webpack.js.org/guides/tree-shaking/#mark-the-file-as-side-effect-free
