### PR TITLE
fix: rebind listeners on effect to address race condition

### DIFF
--- a/.changeset/rebind-listeners-on-effect.md
+++ b/.changeset/rebind-listeners-on-effect.md
@@ -1,0 +1,5 @@
+---
+'@dnd-kit/dom': patch
+---
+
+Rebind PointerSensor event listeners on effect to eliminate some race conditions when the document changes.


### PR DESCRIPTION
This fix rebinds the PointerSensor listeners in the effect callback, as the document may change between effects. The existing implementation yielded a race condition that meant that the listeners would sometimes not fire when rapidly dragging between frames.

Although this fix improves the behaviour, the issue sometimes still occurs and likely requires further investigation.