### PR TITLE
fix: use fixed event listeners to address race conditions

### DIFF
--- a/.changeset/use-fixed-event-listeners.md
+++ b/.changeset/use-fixed-event-listeners.md
@@ -1,0 +1,5 @@
+---
+'@dnd-kit/dom': patch
+---
+
+Use fixed event listeners in PointerSensor to address race conditions preventing `pointermove` and `pointerup` events from firing when document changes during a drag.


### PR DESCRIPTION
Refactor the PointerSensor to use fixed event listeners, rather than dynamic ones, preventing race conditions that can occur if the document changed during drag, such as when dragging across frames.

To reproduce, rapidly drag items from the host to the iframe in the iframe stories.