### PR TITLE
fix: Tree utilities - setProperty(...) mutates items directly

### DIFF
--- a/stories/3 - Examples/Tree/utilities.ts
+++ b/stories/3 - Examples/Tree/utilities.ts
@@ -161,19 +161,24 @@ export function setProperty<T extends keyof TreeItem>(
   id: UniqueIdentifier,
   property: T,
   setter: (value: TreeItem[T]) => TreeItem[T]
-) {
-  for (const item of items) {
+): TreeItems {
+  return items.map((item) => {
     if (item.id === id) {
-      item[property] = setter(item[property]);
-      continue;
+      return {
+        ...item,
+        [property]: setter(item[property]),
+      };
     }
 
     if (item.children.length) {
-      item.children = setProperty(item.children, id, property, setter);
+      return {
+        ...item,
+        children: setProperty(item.children, id, property, setter),
+      };
     }
-  }
 
-  return [...items];
+    return item;
+  });
 }
 
 function countChildren(items: TreeItem[], count = 0): number {


### PR DESCRIPTION
Using `setItems` with `setProperty` in `SortableTree.handleCollapse` creates flaky behavior due to React’s state batching. Due to `handleCollapse` is triggered twice in rapid succession, the state toggles twice, effectively canceling the change (setting value from `false` to `true` and then back from `true` to `false`). This results in collapsed flipping back to its original value.