### PR TITLE
Fix bug with cross-document scrolling

### DIFF
--- a/.changeset/fix-cross-frame-scrolling.md
+++ b/.changeset/fix-cross-frame-scrolling.md
@@ -1,0 +1,5 @@
+---
+'@dnd-kit/dom': patch
+---
+
+Fix a bug in the `Scroller` plugin that would always use `document.getElementFromPoint` instead of the document of the source element.

--- a/packages/dom/src/core/plugins/scrolling/Scroller.ts
+++ b/packages/dom/src/core/plugins/scrolling/Scroller.ts
@@ -31,13 +31,16 @@ export class Scroller extends CorePlugin<DragDropManager> {
     let previousElementFromPoint: Element | null = null;
     let previousScrollableElements: Set<Element> | null = null;
     const elementFromPoint = computed(() => {
-      const {position} = manager.dragOperation;
+      const {position, source} = manager.dragOperation;
 
       if (!position) {
         return null;
       }
 
-      const element = getElementFromPoint(document, position.current);
+      const element = getElementFromPoint(
+        getDocument(source?.element),
+        position.current
+      );
 
       if (element) {
         previousElementFromPoint = element;

--- a/packages/dom/src/utilities/execution-context/getDocument.ts
+++ b/packages/dom/src/utilities/execution-context/getDocument.ts
@@ -3,7 +3,7 @@ import {isHTMLElement} from '../type-guards/isHTMLElement.ts';
 import {isNode} from '../type-guards/isNode.ts';
 import {isWindow} from '../type-guards/isWindow.ts';
 
-export function getDocument(target: Event['target']): Document {
+export function getDocument(target: Event['target'] | undefined): Document {
   if (!target) {
     return document;
   }


### PR DESCRIPTION
Fix a bug in the `Scroller` plugin that would always use `document.getElementFromPoint` instead of the document of the source element.