### PR TITLE
Add fallback logic to type-guards when instance checks fail to identify instances

### DIFF
--- a/.changeset/fallback-element-checks.md
+++ b/.changeset/fallback-element-checks.md
@@ -1,0 +1,5 @@
+---
+'@dnd-kit/dom': patch
+---
+
+Add fallback logic to type-guards when instance checks fail to identify instances, for example to test if an element is an `Element` or `HTMLElement` or `SVGElement`.

--- a/packages/dom/src/utilities/type-guards/isDocument.ts
+++ b/packages/dom/src/utilities/type-guards/isDocument.ts
@@ -3,5 +3,8 @@ import {getWindow} from '../execution-context/getWindow.ts';
 export function isDocument(node: Node): node is Document {
   const {Document} = getWindow(node);
 
-  return node instanceof Document;
+  return (
+    node instanceof Document ||
+    ('nodeType' in node && node.nodeType === Node.DOCUMENT_NODE)
+  );
 }

--- a/packages/dom/src/utilities/type-guards/isElement.ts
+++ b/packages/dom/src/utilities/type-guards/isElement.ts
@@ -1,5 +1,11 @@
 import {getWindow} from '../execution-context/getWindow.ts';
+import {isNode} from './isNode.ts';
 
 export function isElement(target: EventTarget | null): target is Element {
-  return target instanceof getWindow(target).Element;
+  if (!target) return false;
+
+  return (
+    target instanceof getWindow(target).Element ||
+    (isNode(target) && target.nodeType === Node.ELEMENT_NODE)
+  );
 }

--- a/packages/dom/src/utilities/type-guards/isHTMLElement.ts
+++ b/packages/dom/src/utilities/type-guards/isHTMLElement.ts
@@ -5,5 +5,10 @@ import {isWindow} from './isWindow.ts';
 export function isHTMLElement(node: Node | Window | null): node is HTMLElement {
   if (!node || isWindow(node)) return false;
 
-  return node instanceof getWindow(node).HTMLElement;
+  return (
+    node instanceof getWindow(node).HTMLElement ||
+    ('namespaceURI' in node &&
+      typeof node.namespaceURI === 'string' &&
+      node.namespaceURI.endsWith('html'))
+  );
 }

--- a/packages/dom/src/utilities/type-guards/isSVGElement.ts
+++ b/packages/dom/src/utilities/type-guards/isSVGElement.ts
@@ -1,5 +1,10 @@
 import {getWindow} from '../execution-context/getWindow.ts';
 
 export function isSVGElement(node: Node): node is SVGElement {
-  return node instanceof getWindow(node).SVGElement;
+  return (
+    node instanceof getWindow(node).SVGElement ||
+    ('namespaceURI' in node &&
+      typeof node.namespaceURI === 'string' &&
+      node.namespaceURI.endsWith('svg'))
+  );
 }

--- a/packages/dom/src/utilities/type-guards/supportsStyle.ts
+++ b/packages/dom/src/utilities/type-guards/supportsStyle.ts
@@ -1,10 +1,13 @@
-import {getWindow} from '../execution-context/getWindow.ts';
-
 export function supportsStyle(
   element: Element
 ): element is Element & {style: CSSStyleDeclaration} {
   return (
     'style' in element &&
-    element.style instanceof getWindow(element).CSSStyleDeclaration
+    typeof element.style === 'object' &&
+    element.style !== null &&
+    'setProperty' in element.style &&
+    'removeProperty' in element.style &&
+    typeof element.style.setProperty === 'function' &&
+    typeof element.style.removeProperty === 'function'
   );
 }


### PR DESCRIPTION
Add fallback logic to type-guards when instance checks fail to identify instances, for example to test if an element is an `Element` or `HTMLElement` or `SVGElement`.