### PR TITLE
Collision type update

### DIFF
--- a/.changeset/early-doors-leave.md
+++ b/.changeset/early-doors-leave.md
@@ -1,0 +1,6 @@
+---
+'@dnd-kit/abstract': minor
+'@dnd-kit/react': minor
+---
+
+Adds `data` property to `Collision` type and exports sensors through `@dnd-kit/react`

--- a/.changeset/early-doors-leave.md
+++ b/.changeset/early-doors-leave.md
@@ -1,6 +1,5 @@
 ---
 '@dnd-kit/abstract': minor
-'@dnd-kit/react': minor
 ---
 
-Adds `data` property to `Collision` type and exports sensors through `@dnd-kit/react`
+Adds new `data` property to `Collision` type

--- a/.changeset/olive-lobsters-relate.md
+++ b/.changeset/olive-lobsters-relate.md
@@ -1,0 +1,5 @@
+---
+'@dnd-kit/react': minor
+---
+
+Exports sensors from `@dnd-kit/dom` through `@dnd-kit/react`

--- a/apps/docs/react/hooks/use-sortable.mdx
+++ b/apps/docs/react/hooks/use-sortable.mdx
@@ -100,7 +100,7 @@ The `useSortable` hook accepts all of the same arguments as the [useDraggable](/
 </ParamField>
 
 <ParamField path="accepts" type="string | number | Symbol | (type: string | number | Symbol) => boolean">
-  Optionally supply a type of draggable element to only allow it to be dropped over certina droppable targets that [accept](#) this `type`.
+  Optionally supply a type of draggable element to only allow it to be dropped over certain droppable targets that [accept](#) this `type`.
 </ParamField>
 
 <ParamField path="collisionDetector" type="(input: CollisionDetectorInput) => Collision | null">

--- a/packages/abstract/src/core/collision/types.ts
+++ b/packages/abstract/src/core/collision/types.ts
@@ -24,6 +24,7 @@ export interface Collision {
   priority: CollisionPriority | number;
   type: CollisionType;
   value: number;
+  data?: Record<string, any>;
 }
 
 export type Collisions = Collision[];

--- a/packages/react/src/core/index.ts
+++ b/packages/react/src/core/index.ts
@@ -23,3 +23,5 @@ export {
 export {useDragOperation} from './hooks/useDragOperation.ts';
 
 export {useInstance} from './hooks/useInstance.ts';
+
+export {KeyboardSensor, PointerSensor} from '@dnd-kit/dom';


### PR DESCRIPTION
This PR includes 3 different commits
 - Adds optional data type to Collision type. This will allow to any useful `data` through collision, accessible through `onCollision`.
 - Fixes typo in the `useSortable` documentation
 - Exports Keyboard and Pointer sensors through `dnd-kit/react`

