### PR TITLE
fix: auto scroll on inverted element

### DIFF
--- a/.changeset/fix-auto-scroll-in-inverted-element.md
+++ b/.changeset/fix-auto-scroll-in-inverted-element.md
@@ -1,0 +1,5 @@
+---
+'@dnd-kit/dom': patch
+---
+
+Fixed a bug where auto-scroll does not wotk with inverted element


### PR DESCRIPTION
## Where
On a visually inverted element _(for example in a messaging app, your message list is inverted)_ 

## What
Approaching a dragged element to the edges of the inverted element scrolls in the opposite direction.