### PR TITLE
Add option `shouldActivate` on `KeyboardSensor`

### DIFF
--- a/.changeset/silly-falcons-cheer.md
+++ b/.changeset/silly-falcons-cheer.md
@@ -2,4 +2,4 @@
 '@dnd-kit/dom': patch
 ---
 
-Add option `activateOnPropagatedEvents` on KeyboardSensor to activate on propagated events
+Add option `shouldActivate` on `KeyboardSensor`. By default `KeyboardSensor` activates if the Keyboard event is triggered from the `Draggable` `element` or `handle`. `shouldActivate` let the user override this behavior.

--- a/.changeset/silly-falcons-cheer.md
+++ b/.changeset/silly-falcons-cheer.md
@@ -1,0 +1,5 @@
+---
+'@dnd-kit/dom': patch
+---
+
+Add option `activateOnPropagatedEvents` on KeyboardSensor to activate on propagated events

--- a/packages/dom/src/core/sensors/keyboard/KeyboardSensor.ts
+++ b/packages/dom/src/core/sensors/keyboard/KeyboardSensor.ts
@@ -29,10 +29,19 @@ export type KeyboardCodes = {
 
 export interface KeyboardSensorOptions {
   keyboardCodes?: KeyboardCodes;
-  shouldActivate?(event: KeyboardEvent, source: Draggable): boolean;
+  shouldActivate?(args: {
+    event: KeyboardEvent;
+    source: Draggable;
+    manager: DragDropManager;
+  }): boolean;
 }
 
-const DEFAULT_SHOULD_ACTIVATE = (event: KeyboardEvent, source: Draggable) => {
+const DEFAULT_SHOULD_ACTIVATE = (args: {
+  event: KeyboardEvent;
+  source: Draggable;
+  manager: DragDropManager;
+}) => {
+  const {event, source} = args;
   const target = source.handle ?? source.element;
   return event.target === target;
 };
@@ -107,7 +116,7 @@ export class KeyboardSensor extends Sensor<
 
     const shouldActivate = options?.shouldActivate ?? DEFAULT_SHOULD_ACTIVATE;
 
-    if (shouldActivate(event, source)) {
+    if (shouldActivate({event, source, manager: this.manager})) {
       const {keyboardCodes = DEFAULT_KEYBOARD_CODES} = options ?? {};
 
       if (!keyboardCodes.start.includes(event.code)) {

--- a/packages/dom/src/core/sensors/keyboard/KeyboardSensor.ts
+++ b/packages/dom/src/core/sensors/keyboard/KeyboardSensor.ts
@@ -29,8 +29,13 @@ export type KeyboardCodes = {
 
 export interface KeyboardSensorOptions {
   keyboardCodes?: KeyboardCodes;
-  activateOnPropagatedEvents?: boolean;
+  shouldActivate?(event: KeyboardEvent, source: Draggable): boolean;
 }
+
+const DEFAULT_SHOULD_ACTIVATE = (event: KeyboardEvent, source: Draggable) => {
+  const target = source.handle ?? source.element;
+  return event.target === target;
+};
 
 const DEFAULT_KEYBOARD_CODES: KeyboardCodes = {
   start: ['Space', 'Enter'],
@@ -100,9 +105,9 @@ export class KeyboardSensor extends Sensor<
       return;
     }
 
-    const target = source.handle ?? source.element;
+    const shouldActivate = options?.shouldActivate ?? DEFAULT_SHOULD_ACTIVATE;
 
-    if (event.target === target || options?.activateOnPropagatedEvents) {
+    if (shouldActivate(event, source)) {
       const {keyboardCodes = DEFAULT_KEYBOARD_CODES} = options ?? {};
 
       if (!keyboardCodes.start.includes(event.code)) {

--- a/packages/dom/src/core/sensors/keyboard/KeyboardSensor.ts
+++ b/packages/dom/src/core/sensors/keyboard/KeyboardSensor.ts
@@ -114,19 +114,20 @@ export class KeyboardSensor extends Sensor<
       return;
     }
 
-    const shouldActivate = options?.shouldActivate ?? DEFAULT_SHOULD_ACTIVATE;
+    const {
+      keyboardCodes = DEFAULT_KEYBOARD_CODES,
+      shouldActivate = DEFAULT_SHOULD_ACTIVATE,
+    } = options ?? {};
+
+    if (!keyboardCodes.start.includes(event.code)) {
+      return;
+    }
+
+    if (!this.manager.dragOperation.status.idle) {
+      return;
+    }
 
     if (shouldActivate({event, source, manager: this.manager})) {
-      const {keyboardCodes = DEFAULT_KEYBOARD_CODES} = options ?? {};
-
-      if (!keyboardCodes.start.includes(event.code)) {
-        return;
-      }
-
-      if (!this.manager.dragOperation.status.idle) {
-        return;
-      }
-
       this.handleStart(event, source, options);
     }
   };

--- a/packages/dom/src/core/sensors/keyboard/KeyboardSensor.ts
+++ b/packages/dom/src/core/sensors/keyboard/KeyboardSensor.ts
@@ -29,6 +29,7 @@ export type KeyboardCodes = {
 
 export interface KeyboardSensorOptions {
   keyboardCodes?: KeyboardCodes;
+  activateOnPropagatedEvents?: boolean;
 }
 
 const DEFAULT_KEYBOARD_CODES: KeyboardCodes = {
@@ -99,10 +100,9 @@ export class KeyboardSensor extends Sensor<
       return;
     }
 
-    if (
-      (!source.handle && source.element && event.target === source.element) ||
-      (source.handle && event.target === source.handle)
-    ) {
+    const target = source.handle ?? source.element;
+
+    if (event.target === target || options?.activateOnPropagatedEvents) {
       const {keyboardCodes = DEFAULT_KEYBOARD_CODES} = options ?? {};
 
       if (!keyboardCodes.start.includes(event.code)) {


### PR DESCRIPTION
Currently `KeyboardSensor` does not activate if the event is coming from a descendent. `shouldActivate` lets us override this behavior.