### PR TITLE
feat(ci): add continuous releases

### DIFF
--- a/.github/workflows/continous-release.yml
+++ b/.github/workflows/continous-release.yml
@@ -1,0 +1,31 @@
+name: Continuous Release
+on:
+  pull_request:
+  push:
+    branches:
+      - "**"
+    tags:
+      - "!**"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    environment: production
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Setup node
+        uses: actions/setup-node@v2
+        with:
+          node-version: 20
+          # https://github.com/atlassian/changesets/issues/550#issuecomment-811245508
+          registry-url: https://registry.npmjs.org
+
+      - uses: oven-sh/setup-bun@v1
+      - run: bun install && bun run build
+
+      - name: Publish
+        run: npx pkg-pr-new publish './packages/*'


### PR DESCRIPTION
This PR adds a continuous release workflow that allows testing of PR and commit changes without having to publish them using [`pkg-pr-new`](https://github.com/stackblitz-labs/pkg.pr.new). It will continuously build PRs and pushes and publish the packages to a registry operated by Stackblitz, not to NPM.

This app is used by a bunch of large projects in the ecosystem, e.g. vite, vue, nuxt, svelte. 

It will require the app to be authorized to work on this repo, see https://github.com/stackblitz-labs/pkg.pr.new?tab=readme-ov-file#setup

I've set this up on my fork, so you can see the result of this action:

https://github.com/hanneskuettner/dnd-kit/pull/2#issuecomment-2827198663

I'm positive this can be further extended to also create a Stackblitz instance for the storybook so people can play around with the build.