### PR TITLE
Improve Feedback clone performance by avoiding innerHtml reset on every mutation

### DIFF
--- a/.changeset/orange-eyes-raise.md
+++ b/.changeset/orange-eyes-raise.md
@@ -1,0 +1,5 @@
+---
+'@dnd-kit/dom': patch
+---
+
+Improve Feedback clone performance by avoiding innerHtml reset on every mutation

--- a/packages/dom/src/core/plugins/feedback/Feedback.ts
+++ b/packages/dom/src/core/plugins/feedback/Feedback.ts
@@ -299,16 +299,27 @@ export class Feedback extends Plugin<DragDropManager, FeedbackOptions> {
     if (placeholder) {
       resizeObserver.observe(placeholder);
 
-      elementMutationObserver = new MutationObserver(() => {
-        for (const attribute of Array.from(element.attributes)) {
-          if (
-            attribute.name.startsWith('aria-') ||
-            IGNORED_ATTRIBUTES.includes(attribute.name)
-          ) {
+      elementMutationObserver = new MutationObserver((mutations) => {
+        let hasChildrenMutations = false;
+
+        for (const mutation of mutations) {
+          if (mutation.type !== 'attributes') {
+            // Should never happen, but defensive programming just in case
             continue;
           }
 
-          if (attribute.name === 'style') {
+          // Attribute name is guaranteed to be non-null if type is "attributes"
+          // https://developer.mozilla.org/en-US/docs/Web/API/MutationRecord/attributeName#value
+          const attributeName = mutation.attributeName!;
+
+          if (mutation.target !== element) {
+            hasChildrenMutations = true;
+          } else if (
+            attributeName.startsWith('aria-') ||
+            IGNORED_ATTRIBUTES.includes(attributeName)
+          ) {
+            continue;
+          } else if (attributeName === 'style') {
             if (supportsStyle(element) && supportsStyle(placeholder)) {
               for (const key of Object.values(element.style)) {
                 if (
@@ -324,13 +335,18 @@ export class Feedback extends Plugin<DragDropManager, FeedbackOptions> {
                 );
               }
             }
-            continue;
-          }
+          } else {
+            const attributeValue = element.getAttribute(attributeName);
 
-          placeholder.setAttribute(attribute.name, attribute.value);
+            if (attributeValue !== null) {
+              placeholder.setAttribute(attributeName, attributeValue);
+            } else {
+              placeholder.removeAttribute(attributeName);
+            }
+          }
         }
 
-        if (clone) {
+        if (hasChildrenMutations && clone) {
           placeholder.innerHTML = element.innerHTML;
         }
       });

--- a/packages/dom/src/core/plugins/feedback/Feedback.ts
+++ b/packages/dom/src/core/plugins/feedback/Feedback.ts
@@ -303,6 +303,11 @@ export class Feedback extends Plugin<DragDropManager, FeedbackOptions> {
         let hasChildrenMutations = false;
 
         for (const mutation of mutations) {
+          if (mutation.target !== element) {
+            hasChildrenMutations = true;
+            continue;
+          }
+
           if (mutation.type !== 'attributes') {
             // Should never happen, but defensive programming just in case
             continue;
@@ -312,14 +317,14 @@ export class Feedback extends Plugin<DragDropManager, FeedbackOptions> {
           // https://developer.mozilla.org/en-US/docs/Web/API/MutationRecord/attributeName#value
           const attributeName = mutation.attributeName!;
 
-          if (mutation.target !== element) {
-            hasChildrenMutations = true;
-          } else if (
+          if (
             attributeName.startsWith('aria-') ||
             IGNORED_ATTRIBUTES.includes(attributeName)
           ) {
             continue;
-          } else if (attributeName === 'style') {
+          }
+
+          if (attributeName === 'style') {
             if (supportsStyle(element) && supportsStyle(placeholder)) {
               for (const key of Object.values(element.style)) {
                 if (


### PR DESCRIPTION
It avoids layout thrashing 

## Before

<img width="596" alt="Screenshot 2025-04-30 at 5 58 10 PM" src="https://github.com/user-attachments/assets/ff85ba28-b902-4c2c-ac6f-9c9c8ba0bf28" />

## After

<img width="633" alt="Screenshot 2025-04-30 at 6 03 18 PM" src="https://github.com/user-attachments/assets/7936342d-fd73-4b29-8de2-b946cb575868" />