### PR TITLE
Fix typo: rename `sevent` to `event` in onDragEnd handler

### DIFF
--- a/apps/docs/react/guides/multiple-sortable-lists.mdx
+++ b/apps/docs/react/guides/multiple-sortable-lists.mdx
@@ -109,7 +109,7 @@ export function App() {
 
         if (event.canceled || source.type !== 'column') return;
 
-        setColumnOrder((columns) => move(columns, sevent));
+        setColumnOrder((columns) => move(columns, event));
       }}
     >
       <div className="Root">


### PR DESCRIPTION
Corrected a typographical error in the onDragEnd handler where the variable `event` was mistakenly written as `sevent`.