### PR TITLE
Ensure showPopover is not called when popover is already visible

### DIFF
--- a/.changeset/moody-cats-nail.md
+++ b/.changeset/moody-cats-nail.md
@@ -1,0 +1,5 @@
+---
+'@dnd-kit/dom': patch
+---
+
+Ensure showPopover is not called when popover is already visible

--- a/packages/dom/src/utilities/popover/showPopover.ts
+++ b/packages/dom/src/utilities/popover/showPopover.ts
@@ -4,7 +4,8 @@ export function showPopover(element: Element) {
   if (
     supportsPopover(element) &&
     element.isConnected &&
-    element.hasAttribute('popover')
+    element.hasAttribute('popover') &&
+    !element.matches(':popover-open')
   ) {
     element.showPopover();
   }


### PR DESCRIPTION
Can throw from here: https://chromium.googlesource.com/chromium/src/+/9113d3f656b1994717686b9710b4460d9f0eab78/third_party/blink/renderer/core/html/html_element.cc#1286