### PR TITLE
Parse transform fix

### DIFF
--- a/.changeset/smooth-mangos-explode.md
+++ b/.changeset/smooth-mangos-explode.md
@@ -1,0 +1,5 @@
+---
+'@dnd-kit/dom': patch
+---
+
+Defensive check in case getComputedStyle().transform is null. Could be the case on < Chrome 103

--- a/packages/dom/src/utilities/transform/parseTransform.ts
+++ b/packages/dom/src/utilities/transform/parseTransform.ts
@@ -12,7 +12,9 @@ export interface Transform extends Coordinates {
 export function parseTransform(computedStyles: {
   scale: string;
   transform: string;
-  translate: string;
+  // We handled the case where translate is not a string because
+  // some versions of Chrome do not return translate in getComputedStyles despite the spec
+  translate?: string;
 }): Transform | null {
   const {scale, transform, translate} = computedStyles;
   const parsedScale = parseScale(scale);

--- a/packages/dom/src/utilities/transform/parseTranslate.ts
+++ b/packages/dom/src/utilities/transform/parseTranslate.ts
@@ -1,5 +1,5 @@
-export function parseTranslate(translate: string) {
-  if (translate === 'none') {
+export function parseTranslate(translate?: string) {
+  if (!translate || translate === 'none') {
     return null;
   }
 


### PR DESCRIPTION
Defensive check in case `getComputedStyle().transform` is `null`. Could be the case on < Chrome 103