### PR TITLE
Refactor React renderer

### DIFF
--- a/.changeset/optimistic-sorting-microtask.md
+++ b/.changeset/optimistic-sorting-microtask.md
@@ -1,0 +1,5 @@
+---
+'@dnd-kit/dom': patch
+---
+
+**OptimisticSortingPlugin**: Fixed a bug where using `queueMicrotask` in the `dragover` event of to check if `event.defaultPrevented()` was called by consumers was causing the order that we capture to be stale in the event that the consumer updates the order of sortable items before the micortask runs, which can happen in React for consumers using `useOptimistic` to update state optimistically.

--- a/.changeset/react-renderer-refactor.md
+++ b/.changeset/react-renderer-refactor.md
@@ -1,0 +1,5 @@
+---
+'@dnd-kit/react': patch
+---
+
+Refactor renderer to better handle calls to `useOptimistic` to update state during transitions.

--- a/packages/react/src/core/context/renderer.ts
+++ b/packages/react/src/core/context/renderer.ts
@@ -8,7 +8,7 @@ import {
   useMemo,
 } from 'react';
 import type {Renderer as AbstractRenderer} from '@dnd-kit/abstract';
-import {useConstant, useIsomorphicLayoutEffect} from '@dnd-kit/react/hooks';
+import {useIsomorphicLayoutEffect} from '@dnd-kit/react/hooks';
 
 export type ReactRenderer = {
   renderer: AbstractRenderer;

--- a/packages/react/src/core/context/renderer.ts
+++ b/packages/react/src/core/context/renderer.ts
@@ -1,40 +1,55 @@
-import {useTransition, useState, useRef, useLayoutEffect} from 'react';
-import type {Renderer} from '@dnd-kit/abstract';
-import {useConstant, useOnValueChange} from '@dnd-kit/react/hooks';
+import {
+  forwardRef,
+  memo,
+  startTransition,
+  useImperativeHandle,
+  useState,
+  useRef,
+  useMemo,
+} from 'react';
+import type {Renderer as AbstractRenderer} from '@dnd-kit/abstract';
+import {useConstant, useIsomorphicLayoutEffect} from '@dnd-kit/react/hooks';
 
-export function useRenderer() {
-  const [_, startTransition] = useTransition();
-  const [transitionCount, setTransitionCount] = useState(0);
-  const rendering = useRef<Promise<void>>(null);
-  const resolver = useRef<() => void>(null);
-  const renderer = useConstant<Renderer>(() => ({
-    get rendering() {
-      return rendering.current ?? Promise.resolve();
-    },
-  }));
+export type ReactRenderer = {
+  renderer: AbstractRenderer;
+  trackRendering: (callback: () => void) => void;
+};
 
-  useOnValueChange(
-    transitionCount,
-    () => {
+export const Renderer = memo(
+  forwardRef<ReactRenderer, {children: React.ReactNode}>(({children}, ref) => {
+    const [transitionCount, setTransitionCount] = useState(0);
+    const rendering = useRef<Promise<void>>(null);
+    const resolver = useRef<() => void>(null);
+    const renderer = useMemo<ReactRenderer>(
+      () => ({
+        renderer: {
+          get rendering() {
+            return rendering.current ?? Promise.resolve();
+          },
+        },
+        trackRendering(callback: () => void) {
+          if (!rendering.current) {
+            rendering.current = new Promise<void>((resolve) => {
+              resolver.current = resolve;
+            });
+          }
+
+          startTransition(() => {
+            callback();
+            setTransitionCount((count) => count + 1);
+          });
+        },
+      }),
+      []
+    );
+
+    useIsomorphicLayoutEffect(() => {
       resolver.current?.();
       rendering.current = null;
-    },
-    useLayoutEffect
-  );
+    }, [children, transitionCount]);
 
-  return {
-    renderer,
-    trackRendering(callback: () => void) {
-      if (!rendering.current) {
-        rendering.current = new Promise<void>((resolve) => {
-          resolver.current = resolve;
-        });
-      }
+    useImperativeHandle(ref, () => renderer);
 
-      startTransition(() => {
-        callback();
-        setTransitionCount((count) => count + 1);
-      });
-    },
-  };
-}
+    return null;
+  })
+);


### PR DESCRIPTION
Refactor the `useRenderer` hook into a component. Making it a component isolates the re-renders caused by incrementing the `transitionCount` to only that component rather than the entire `<DragDropProvider>` and its children. In addition, I am also now passing the `children` to the `<Renderer>` to detect any eager re-renders during a transition which could happen due to `useOptimistic` calls or if the transition is split into different batches.