### PR TITLE
documentation fix for accessing a non-existent property of onDragEnd Events

### DIFF
--- a/apps/docs/react/quickstart.mdx
+++ b/apps/docs/react/quickstart.mdx
@@ -104,8 +104,8 @@ function App() {
       onDragEnd={(event) => {
         if (event.canceled) return;
 
-        const isDropped = event.target?.id === 'droppable';
-        setIsDropped(isDropped);
+        const {target} = event.operation;
+        setIsDropped(target?.id === 'droppable');
       }}
     >
       {!isDropped && <Draggable />}
@@ -178,7 +178,7 @@ function App() {
       onDragEnd={(event) => {
         if (event.canceled) return;
 
-        setTarget(event.target?.id);
+        setTarget(event.operation.target?.id);
       }}
     >
       {!target ? draggable : null}


### PR DESCRIPTION
I've tried to replicated [react quick start example](https://next.dndkit.com/react/quickstart#putting-all-the-pieces-together), but my IDE says that there is no property "target" in onDragEnd Event objects and it code doesn't work. 

I also found source code for interactive examples where used different property https://github.com/clauderic/dnd-kit/blob/experimental/apps/stories/stories/react/Droppable/docs/examples/QuickStart.jsx