### PR TITLE
Runs `dropEffectCleanup` right after its effect

### DIFF
--- a/.changeset/big-mugs-notice.md
+++ b/.changeset/big-mugs-notice.md
@@ -1,0 +1,5 @@
+---
+'@dnd-kit/dom': patch
+---
+
+Fixes cleanup issue where user would be stuck in dragging mode

--- a/packages/dom/src/core/plugins/feedback/Feedback.ts
+++ b/packages/dom/src/core/plugins/feedback/Feedback.ts
@@ -558,6 +558,8 @@ export class Feedback extends Plugin<DragDropManager, FeedbackOptions> {
     // Drop animation
     dropEffectCleanup = effect(() => {
       if (dragOperation.status.dropped) {
+        queueMicrotask(() => dropEffectCleanup?.());
+
         const onComplete = cleanup;
         cleanup = undefined;
 


### PR DESCRIPTION
This solves a bug where double tapping quick on a drag handle in a slow internet/pc would make the user be stuck in "dragging" mode.