### PR TITLE
[Experimental] Introduce `useDragHandle` hook

### DIFF
--- a/packages/react/src/core/draggable/useDragHandle.ts
+++ b/packages/react/src/core/draggable/useDragHandle.ts
@@ -1,0 +1,36 @@
+import {useRef} from 'react';
+import type {UniqueIdentifier} from '@dnd-kit/abstract';
+import {useComputed, useOnElementChange} from '@dnd-kit/react/hooks';
+import type {RefOrValue} from '@dnd-kit/react/utilities';
+
+import {useDragDropManager} from '../hooks/useDragDropManager.ts';
+
+export interface UseDragHandleInput {
+  id: UniqueIdentifier;
+  element?: RefOrValue<Element>;
+}
+
+/**
+ * A hook that allows you to set the drag handle for a draggable element.
+ *
+ * @param id - The unique identifier of the draggable element.
+ * @param element - The ref or value of the drag handle element if you already have a reference to it.
+ * @returns A ref that you can attach to the drag handle element
+ */
+export function useDragHandle({id, element}: UseDragHandleInput) {
+  const manager = useDragDropManager();
+  const handleRef = useRef<Element | null>(null);
+  const draggableInstance = useComputed(
+    () => manager?.registry.draggables.get(id),
+    [id]
+  ).value;
+  const value = handleRef.current ?? element;
+
+  useOnElementChange(value, (handle) => {
+    if (!draggableInstance) return;
+
+    draggableInstance.handle = handle;
+  });
+
+  return handleRef;
+}

--- a/packages/react/src/core/index.ts
+++ b/packages/react/src/core/index.ts
@@ -9,6 +9,10 @@ export {
   useDraggable,
   type UseDraggableInput,
 } from './draggable/useDraggable.ts';
+export {
+  useDragHandle,
+  type UseDragHandleInput,
+} from './draggable/useDragHandle.ts';
 export {DragOverlay} from './draggable/DragOverlay.tsx';
 
 export {


### PR DESCRIPTION
This PR introduces a `useDragHandle` hook that allows React consumers to set a drag handle in a different location than where `useDraggable` or `useSortable` is used.

Resolves https://github.com/clauderic/dnd-kit/issues/1738

### Example usage — two separate components

Below the draggable is declared in a row component, while the dedicated handle lives in a different component.

```tsx
import {DragDropProvider} from '@dnd-kit/react';
import {useSortable} from '@dnd-kit/react/sortable';
import {useDragHandle} from '@dnd-kit/react';

import {
  ColumnDef,
  Row,
  flexRender,
  useReactTable,
  getCoreRowModel,
} from '@tanstack/react-table';

// ─────────────────────────────────────────────────────
// Cell renderer — only cares about being the drag handle
// ─────────────────────────────────────────────────────
function DragCell({rowId}: {rowId: string}) {
  const handleRef = useDragHandle({id: rowId});   // same id as the row
  return (
    <button ref={handleRef} aria-label="Drag row" style={{cursor: 'grab'}}>
      ⠿
    </button>
  );
}

// ─────────────────────────────────────────────────────
// Draggable row — owns the sortable behaviour
// ─────────────────────────────────────────────────────
function DraggableRow({row}: {row: Row<Person>}) {
  const {ref} = useSortable({id: row.id, index: row.index});        // row itself is sortable
  return (
    <tr ref={ref}>
      {row.getVisibleCells().map((cell) => (
        <td key={cell.id}>{flexRender(cell.column.columnDef.cell, cell.getContext())}</td>
      ))}
    </tr>
  );
}

// ─────────────────────────────────────────────────────
// Table setup (irrelevant plumbing omitted for clarity)
// ─────────────────────────────────────────────────────
function App() {
  const columns = React.useMemo<ColumnDef<Person>[]>(() => [
    {                                             // dedicated “move” column
      id: 'drag',
      header: '↕︎',
      size: 40,
      cell: ({row}) => <DragCell rowId={row.id} />, // ← handle rendered here
    },
    // …other columns…
  ], []);

  const table = useReactTable({
    data, columns, getCoreRowModel: getCoreRowModel(), getRowId: r => r.id,
  });

  return (
    <DragDropProvider>
      <table>
        <tbody>
          {table.getRowModel().rows.map((row) => (
            <DraggableRow key={row.id} row={row} />
          ))}
        </tbody>
      </table>
    </DragDropProvider>
  );
}
```

The key takeaway: `useDragHandle` does **not** need to live in the same component where `useDraggable`/`useSortable` is invoked—perfect for table rows, list items with nested actions, or any layout where the “grab-area” is rendered deeper in the tree.