### PR TITLE
fix typo in utilities readme and package.json

### DIFF
--- a/packages/utilities/README.md
+++ b/packages/utilities/README.md
@@ -2,4 +2,4 @@
 
 [![Stable release](https://img.shields.io/npm/v/@dnd-kit/utilities.svg)](https://npm.im/@dnd-kit/sortable)
 
-Internal utilities to bee shared between `@dnd-kit` packages.
+Internal utilities to be shared between `@dnd-kit` packages.

--- a/packages/utilities/package.json
+++ b/packages/utilities/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@dnd-kit/utilities",
   "version": "3.2.2",
-  "description": "Internal utilities to bee shared between `@dnd-kit` packages",
+  "description": "Internal utilities to be shared between `@dnd-kit` packages",
   "author": "Claudéric Demers",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
* This typo was visible on the NPM page for `dnd-kit/utilities` as seen [here](https://www.npmjs.com/package/@dnd-kit/utilities)
* Updated `bee` to `be` in `packages/utilities/README.md` and `packages/utilities/package.json`