### PR TITLE
prevent vertical or horizontal scrolling individually

### DIFF
--- a/packages/core/src/utilities/scroll/getScrollDirectionAndSpeed.ts
+++ b/packages/core/src/utilities/scroll/getScrollDirectionAndSpeed.ts
@@ -31,7 +31,9 @@ export function getScrollDirectionAndSpeed(
     width: scrollContainerRect.width * thresholdPercentage.x,
   };
 
-  if (!isTop && top <= scrollContainerRect.top + threshold.height) {
+  if (threshold.height === 0) {
+    speed.y = 0;
+  } else if (!isTop && top <= scrollContainerRect.top + threshold.height) {
     // Scroll Up
     direction.y = Direction.Backward;
     speed.y =
@@ -53,7 +55,9 @@ export function getScrollDirectionAndSpeed(
       );
   }
 
-  if (!isRight && right >= scrollContainerRect.right - threshold.width) {
+  if (threshold.width === 0) {
+    speed.x = 0;
+  } else if (!isRight && right >= scrollContainerRect.right - threshold.width) {
     // Scroll Right
     direction.x = Direction.Forward;
     speed.x =


### PR DESCRIPTION
 hi, thank you for your great work on dnd-kit.

there is a scenario where we need to drag a table with many columns vertically, and we hope that this scenario will prevent horizontal scrolling during dragging. (#1794)

we can already prevent vertical or horizontal scrolling individually by setting threshold.x or threshold.y to 0, but we call `scrollBy(Infinity, {number})` actually, I set speed and direction to 0 when threshold set to 0.