### PR TITLE
fix: fix playground errors

### DIFF
--- a/playground/.gitignore
+++ b/playground/.gitignore
@@ -1,3 +1,3 @@
 node_modules
-.cache
+.parcel-cache
 dist

--- a/playground/index.html
+++ b/playground/index.html
@@ -14,6 +14,6 @@
   </style>
   <body>
     <div id="root"></div>
-    <script src="./index.tsx"></script>
+    <script src="./index.tsx" type="module"></script>
   </body>
 </html>

--- a/playground/package.json
+++ b/playground/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@dnd-kit/playground",
   "version": "1.0.0",
-  "main": "index.js",
   "license": "MIT",
   "scripts": {
     "start": "parcel index.html",
@@ -12,7 +11,7 @@
   },
   "alias": {
     "@dnd-kit/core": "../packages/core",
-    "@dnd-kit/accesssibility": "../packages/accesssibility",
+    "@dnd-kit/accessibility": "../packages/accessibility",
     "@dnd-kit/modifiers": "../packages/modifiers",
     "@dnd-kit/sortable": "../packages/sortable",
     "@dnd-kit/utilities": "../packages/utilities",
@@ -23,7 +22,7 @@
   "devDependencies": {
     "@types/react": "^16.9.11",
     "@types/react-dom": "^16.8.4",
-    "parcel": "^1.12.3",
+    "parcel": "^2.16.0",
     "typescript": "^3.4.5"
   }
 }


### PR DESCRIPTION
Fix errors of running "yarn start:playground":
1. fix a spelling error of "accessibility";
2. update the version of parcel;
3. set the type of <script> to be module;
4. update the .gitignore file accordingly.
