### PR TITLE
[experimental] docs(react/quickstart): update install commands for yarn, pnpm, and bun

### DIFF
--- a/apps/docs/react/quickstart.mdx
+++ b/apps/docs/react/quickstart.mdx
@@ -32,7 +32,6 @@ Before getting started, make sure you install `@dnd-kit/react` in your project:
   ```bash bun
   bun add @dnd-kit/react
   ```
-
 </CodeGroup>
 
 ## Making elements draggable


### PR DESCRIPTION
This PR updates the installation commands in the Quickstart section of the documentation.

Previously, the examples used the install command for all package managers.
Since yarn, pnpm, and bun use add to install dependencies, the documentation has been updated to reflect the correct commands.