### PR TITLE
fix: import path for RestrictToWindow in docs

### DIFF
--- a/apps/docs/react/components/drag-drop-provider.mdx
+++ b/apps/docs/react/components/drag-drop-provider.mdx
@@ -89,8 +89,8 @@ import {
   DragDropProvider,
   PointerSensor,
   KeyboardSensor,
-  RestrictToWindow,
 } from '@dnd-kit/react';
+import { RestrictToWindow } from '@dnd-kit/dom/modifiers';
 
 function App() {
   return (


### PR DESCRIPTION
the import path in the documentation is wrong, the correct should be:

```js
import { RestrictToWindow } from '@dnd-kit/dom/modifiers';
```

instead of
```js
import { RestrictToWindow } from '@dnd-kit/react';
```