### PR TITLE
Expose ergonomic DragDropEvent type aliases

### DIFF
--- a/.changeset/expose-drag-event-types.md
+++ b/.changeset/expose-drag-event-types.md
@@ -1,0 +1,7 @@
+---
+'@dnd-kit/abstract': patch
+'@dnd-kit/dom': patch
+'@dnd-kit/react': patch
+---
+
+Expose ergonomic type aliases for drag and drop event handlers: `CollisionEvent`, `BeforeDragStartEvent`, `DragStartEvent`, `DragMoveEvent`, `DragOverEvent`, and `DragEndEvent`. These types are re-exported from `@dnd-kit/dom` and `@dnd-kit/react` for convenience.

--- a/packages/abstract/src/core/index.ts
+++ b/packages/abstract/src/core/index.ts
@@ -3,6 +3,12 @@ export type {
   DragDropManagerInput,
   DragActions,
   DragDropEvents,
+  CollisionEvent,
+  BeforeDragStartEvent,
+  DragStartEvent,
+  DragMoveEvent,
+  DragOverEvent,
+  DragEndEvent,
   DragOperation,
   Renderer,
 } from './manager/index.ts';

--- a/packages/abstract/src/core/manager/events.ts
+++ b/packages/abstract/src/core/manager/events.ts
@@ -146,6 +146,42 @@ export type DragDropEvents<
   ): void;
 };
 
+export type CollisionEvent<
+  T extends Draggable = Draggable,
+  U extends Droppable = Droppable,
+  V extends DragDropManager<T, U> = DragDropManager<T, U>,
+> = DragDropEvents<T, U, V>['collision'];
+
+export type BeforeDragStartEvent<
+  T extends Draggable = Draggable,
+  U extends Droppable = Droppable,
+  V extends DragDropManager<T, U> = DragDropManager<T, U>,
+> = DragDropEvents<T, U, V>['beforedragstart'];
+
+export type DragStartEvent<
+  T extends Draggable = Draggable,
+  U extends Droppable = Droppable,
+  V extends DragDropManager<T, U> = DragDropManager<T, U>,
+> = DragDropEvents<T, U, V>['dragstart'];
+
+export type DragMoveEvent<
+  T extends Draggable = Draggable,
+  U extends Droppable = Droppable,
+  V extends DragDropManager<T, U> = DragDropManager<T, U>,
+> = DragDropEvents<T, U, V>['dragmove'];
+
+export type DragOverEvent<
+  T extends Draggable = Draggable,
+  U extends Droppable = Droppable,
+  V extends DragDropManager<T, U> = DragDropManager<T, U>,
+> = DragDropEvents<T, U, V>['dragover'];
+
+export type DragEndEvent<
+  T extends Draggable = Draggable,
+  U extends Droppable = Droppable,
+  V extends DragDropManager<T, U> = DragDropManager<T, U>,
+> = DragDropEvents<T, U, V>['dragend'];
+
 /**
  * Monitors and dispatches drag and drop events.
  *

--- a/packages/abstract/src/core/manager/index.ts
+++ b/packages/abstract/src/core/manager/index.ts
@@ -1,7 +1,15 @@
 export {DragDropManager} from './manager.ts';
 export type {DragDropManagerInput} from './manager.ts';
 export type {DragActions} from './actions.ts';
-export type {DragDropEvents} from './events.ts';
+export type {
+  DragDropEvents,
+  CollisionEvent,
+  BeforeDragStartEvent,
+  DragStartEvent,
+  DragMoveEvent,
+  DragOverEvent,
+  DragEndEvent,
+} from './events.ts';
 export {Status as DragOperationStatus} from './status.ts';
 export type {DragOperationSnapshot as DragOperation} from './operation.ts';
 export type {DragDropRegistry} from './registry.ts';

--- a/packages/dom/src/core/index.ts
+++ b/packages/dom/src/core/index.ts
@@ -1,6 +1,15 @@
 export {DragDropManager, defaultPreset} from './manager/index.ts';
 export type {DragDropManagerInput} from './manager/index.ts';
 
+export type {
+  CollisionEvent,
+  BeforeDragStartEvent,
+  DragStartEvent,
+  DragMoveEvent,
+  DragOverEvent,
+  DragEndEvent,
+} from './manager/events.ts';
+
 export {Draggable, Droppable} from './entities/index.ts';
 export type {
   DraggableInput,

--- a/packages/dom/src/core/manager/events.ts
+++ b/packages/dom/src/core/manager/events.ts
@@ -1,0 +1,14 @@
+import type {DragDropEvents} from '@dnd-kit/abstract';
+
+import type {Draggable} from '../entities/draggable/draggable.ts';
+import type {Droppable} from '../entities/droppable/droppable.ts';
+import type {DragDropManager} from './manager.ts';
+
+type Events = DragDropEvents<Draggable, Droppable, DragDropManager>;
+
+export type CollisionEvent = Events['collision'];
+export type BeforeDragStartEvent = Events['beforedragstart'];
+export type DragStartEvent = Events['dragstart'];
+export type DragMoveEvent = Events['dragmove'];
+export type DragOverEvent = Events['dragover'];
+export type DragEndEvent = Events['dragend'];

--- a/packages/react/src/core/index.ts
+++ b/packages/react/src/core/index.ts
@@ -28,4 +28,12 @@ export {useDragOperation} from './hooks/useDragOperation.ts';
 export {useInstance} from './hooks/useInstance.ts';
 
 export {KeyboardSensor, PointerSensor} from '@dnd-kit/dom';
-export type {DragDropManager} from '@dnd-kit/dom';
+export type {
+  DragDropManager,
+  CollisionEvent,
+  BeforeDragStartEvent,
+  DragStartEvent,
+  DragMoveEvent,
+  DragOverEvent,
+  DragEndEvent,
+} from '@dnd-kit/dom';


### PR DESCRIPTION
Add type aliases for all drag and drop events: CollisionEvent, BeforeDragStartEvent, DragStartEvent, DragMoveEvent, DragOverEvent, and DragEndEvent.

- Abstract package: generic types with sensible defaults
- DOM package: pre-specialized with DOM entity types
- React package: re-exports from DOM

Closes #1835
Closes #1837