### PR TITLE
Refactor Feedback plugin

### DIFF
--- a/.changeset/refactor-feedback-plugin.md
+++ b/.changeset/refactor-feedback-plugin.md
@@ -1,0 +1,16 @@
+---
+'@dnd-kit/dom': patch
+---
+
+Refactor the Feedback plugin for improved modularity and extensibility.
+
+**StyleSheetManager** – Introduced a new generic `CorePlugin` that manages CSS stylesheet injection into document and shadow roots. Plugins can call `register(cssRules)` to declare styles and `addRoot(root)` to track additional roots. The manager reactively injects and cleans up adopted stylesheets as the drag operation's source and target roots change. The Feedback plugin now delegates all stylesheet management to the StyleSheetManager.
+
+**Configurable drop animation** – The `Feedback` plugin now accepts a `dropAnimation` option:
+
+- Pass `{ duration, easing }` to customize the built-in animation timing
+- Pass a function for full custom animation control (receives context, return a promise)
+- Pass `null` to disable the drop animation entirely
+- Omit for the default 250ms ease animation
+
+**Extracted helpers** – Observer setup (`createElementMutationObserver`, `createDocumentMutationObserver`, `createResizeObserver`) and the drop animation logic (`runDropAnimation`) are now in dedicated modules within the feedback plugin directory.

--- a/packages/dom/src/core/index.ts
+++ b/packages/dom/src/core/index.ts
@@ -36,5 +36,11 @@ export {
   PreventSelection,
   Scroller,
   ScrollListener,
+  StyleSheetManager,
 } from './plugins/index.ts';
-export type {Transition} from './plugins/index.ts';
+export type {
+  Transition,
+  DropAnimation,
+  DropAnimationOptions,
+  DropAnimationFunction,
+} from './plugins/index.ts';

--- a/packages/dom/src/core/manager/manager.ts
+++ b/packages/dom/src/core/manager/manager.ts
@@ -16,6 +16,7 @@ import {
   Scroller,
   ScrollListener,
   PreventSelection,
+  StyleSheetManager,
 } from '../plugins/index.ts';
 import {KeyboardSensor} from '../sensors/keyboard/KeyboardSensor.ts';
 import {PointerSensor} from '../sensors/pointer/PointerSensor.ts';
@@ -46,7 +47,7 @@ export class DragDropManager<
 
     super({
       ...input,
-      plugins: [ScrollListener, Scroller, ...plugins],
+      plugins: [ScrollListener, Scroller, StyleSheetManager, ...plugins],
       sensors,
       modifiers,
     });

--- a/packages/dom/src/core/plugins/feedback/Feedback.ts
+++ b/packages/dom/src/core/plugins/feedback/Feedback.ts
@@ -1,52 +1,42 @@
-import {
-  effects,
-  reactive,
-  untracked,
-  derived,
-  type CleanupFunction,
-} from '@dnd-kit/state';
+import {effects, reactive, untracked} from '@dnd-kit/state';
 import {configurator, Plugin} from '@dnd-kit/abstract';
 import {
-  animateTransform,
   DOMRectangle,
   getComputedStyles,
-  getRoot,
-  getFinalKeyframe,
   getFrameTransform,
+  getRoot,
   getWindow,
   isHTMLElement,
-  isDocument,
-  isShadowRoot,
   isKeyboardEvent,
   parseTranslate,
   showPopover,
   Styles,
   supportsPopover,
-  supportsStyle,
 } from '@dnd-kit/dom/utilities';
 import {Coordinates, Point, Rectangle} from '@dnd-kit/geometry';
 
 import type {DragDropManager} from '../../manager/index.ts';
 import type {Draggable} from '../../entities/index.ts';
+import {StyleSheetManager} from '../stylesheet/StyleSheetManager.ts';
 
-import {
-  ATTRIBUTE,
-  CSS_PREFIX,
-  CSS_RULES,
-  DROPPING_ATTRIBUTE,
-  IGNORED_ATTRIBUTES,
-  IGNORED_STYLES,
-} from './constants.ts';
+import {ATTRIBUTE, CSS_PREFIX, CSS_RULES} from './constants.ts';
 import {
   createPlaceholder,
   isSameFrame,
   isTableRow,
   preventPopoverClose,
 } from './utilities.ts';
+import {
+  createElementMutationObserver,
+  createDocumentMutationObserver,
+  createResizeObserver,
+} from './observers.ts';
+import {runDropAnimation, type DropAnimation} from './dropAnimation.ts';
 
 export interface FeedbackOptions {
   rootElement?: Element | ((source: Draggable) => Element);
   nonce?: string;
+  dropAnimation?: DropAnimation | null;
 }
 
 interface State {
@@ -62,13 +52,6 @@ interface State {
   };
 }
 
-interface StyleSheetRegistration {
-  cleanup: CleanupFunction;
-  instances: Set<Feedback>;
-}
-
-const styleSheetRegistry = new Map<Document | ShadowRoot, StyleSheetRegistration>();
-
 export class Feedback extends Plugin<DragDropManager, FeedbackOptions> {
   @reactive
   public accessor overlay: Element | undefined;
@@ -81,8 +64,34 @@ export class Feedback extends Plugin<DragDropManager, FeedbackOptions> {
   constructor(manager: DragDropManager, options?: FeedbackOptions) {
     super(manager, options);
 
-    this.registerEffect(this.#injectStyles);
+    const styleSheetManager = manager.registry.plugins.get(
+      StyleSheetManager as any
+    ) as StyleSheetManager | undefined;
+
+    const unregisterStyles = styleSheetManager?.register(CSS_RULES);
+
+    if (unregisterStyles) {
+      const originalDestroy = this.destroy.bind(this);
+      this.destroy = () => {
+        unregisterStyles();
+        originalDestroy();
+      };
+    }
+
+    this.registerEffect(this.#trackOverlayRoot.bind(this, styleSheetManager));
     this.registerEffect(this.#render);
+  }
+
+  #trackOverlayRoot(styleSheetManager: StyleSheetManager | undefined) {
+    const {overlay} = this;
+
+    if (!overlay || !styleSheetManager) return;
+
+    const root = getRoot(overlay);
+
+    if (!root) return;
+
+    return styleSheetManager.addRoot(root);
   }
 
   #render() {
@@ -109,6 +118,8 @@ export class Feedback extends Plugin<DragDropManager, FeedbackOptions> {
       return;
     }
 
+    /* ---- Geometry computation ---- */
+
     const {initial} = state;
     const feedbackElement = this.overlay ?? element;
     const frameTransform = getFrameTransform(feedbackElement);
@@ -130,9 +141,6 @@ export class Feedback extends Plugin<DragDropManager, FeedbackOptions> {
       height = height / scaleDelta.y;
     }
 
-    let elementMutationObserver: MutationObserver | undefined;
-    let documentMutationObserver: MutationObserver | undefined;
-    let savedCellWidths: string[] | undefined;
     const styles = new Styles(feedbackElement);
     const {
       transition,
@@ -201,7 +209,7 @@ export class Feedback extends Plugin<DragDropManager, FeedbackOptions> {
         y: relativeTop,
       };
 
-      // Compoensate for transformOrigin when scaling
+      // Compensate for transformOrigin when scaling
       if (scaleDelta.x !== 1 || scaleDelta.y !== 1) {
         const {scaleX, scaleY} = elementFrameTransform;
         const {x: tX, y: tY} = transformOrigin;
@@ -245,16 +253,14 @@ export class Feedback extends Plugin<DragDropManager, FeedbackOptions> {
       top: top + delta.y,
     };
 
+    /* ---- Apply initial feedback styles ---- */
+
     feedbackElement.setAttribute(ATTRIBUTE, 'true');
 
     const transform = untracked(() => dragOperation.transform);
     const initialTranslate = initial.translate ?? {x: 0, y: 0};
     const tX = transform.x * frameTransform.scaleX + initialTranslate.x;
     const tY = transform.y * frameTransform.scaleY + initialTranslate.y;
-    const translateString = `${tX}px ${tY}px 0`;
-    const transitionString = transition
-      ? `${transition}, translate 0ms linear`
-      : '';
 
     styles.set(
       {
@@ -262,13 +268,15 @@ export class Feedback extends Plugin<DragDropManager, FeedbackOptions> {
         height: height - heightOffset,
         top: projected.top,
         left: projected.left,
-        translate: translateString,
-        transition: transitionString,
+        translate: `${tX}px ${tY}px 0`,
+        transition: transition ? `${transition}, translate 0ms linear` : '',
         scale: crossFrame ? `${scaleDelta.x} ${scaleDelta.y}` : '',
         'transform-origin': `${transformOrigin.x * 100}% ${transformOrigin.y * 100}%`,
       },
       CSS_PREFIX
     );
+
+    /* ---- Placeholder setup ---- */
 
     if (placeholder) {
       element.insertAdjacentElement('afterend', placeholder);
@@ -283,6 +291,8 @@ export class Feedback extends Plugin<DragDropManager, FeedbackOptions> {
       }
     }
 
+    /* ---- Popover promotion ---- */
+
     if (supportsPopover(feedbackElement)) {
       if (!feedbackElement.hasAttribute('popover')) {
         feedbackElement.setAttribute('popover', 'manual');
@@ -291,48 +301,34 @@ export class Feedback extends Plugin<DragDropManager, FeedbackOptions> {
       feedbackElement.addEventListener('beforetoggle', preventPopoverClose);
     }
 
-    const resizeObserver = new ResizeObserver(() => {
-      if (!placeholder) return;
+    /* ---- Observers ---- */
 
-      const placeholderShape = new DOMRectangle(placeholder, {
-        frameTransform,
-        ignoreTransforms: true,
-      });
-      const origin = transformOrigin ?? {x: 1, y: 1};
-      const dX = (width - placeholderShape.width) * origin.x + delta.x;
-      const dY = (height - placeholderShape.height) * origin.y + delta.y;
+    let elementMutationObserver: MutationObserver | undefined;
+    let documentMutationObserver: MutationObserver | undefined;
+    let savedCellWidths: string[] | undefined;
 
-      styles.set(
-        {
-          width: placeholderShape.width - widthOffset,
-          height: placeholderShape.height - heightOffset,
-          top: top + dY,
-          left: left + dX,
-        },
-        CSS_PREFIX
-      );
-      elementMutationObserver?.takeRecords();
-
-      /* Table cells need to have their width set explicitly because the feedback element is position fixed */
-      if (isTableRow(element) && isTableRow(placeholder)) {
-        const cells = Array.from(element.cells);
-        const placeholderCells = Array.from(placeholder.cells);
-
-        if (!savedCellWidths) {
-          savedCellWidths = cells.map((cell) => cell.style.width);
-        }
-
-        for (const [index, cell] of cells.entries()) {
-          const placeholderCell = placeholderCells[index];
-
-          cell.style.width = `${placeholderCell.getBoundingClientRect().width}px`;
-        }
-      }
-
-      dragOperation.shape = new DOMRectangle(feedbackElement);
+    const resizeObserver = createResizeObserver({
+      placeholder: placeholder!,
+      element,
+      feedbackElement,
+      frameTransform,
+      transformOrigin,
+      width,
+      height,
+      top,
+      left,
+      widthOffset,
+      heightOffset,
+      delta,
+      styles,
+      dragOperation,
+      getElementMutationObserver: () => elementMutationObserver,
+      getSavedCellWidths: () => savedCellWidths,
+      setSavedCellWidths: (widths) => {
+        savedCellWidths = widths;
+      },
     });
 
-    /* Initialize drag operation shape */
     const initialShape = new DOMRectangle(feedbackElement);
     untracked(() => (dragOperation.shape = initialShape));
 
@@ -352,126 +348,33 @@ export class Feedback extends Plugin<DragDropManager, FeedbackOptions> {
     if (placeholder) {
       resizeObserver.observe(placeholder);
 
-      elementMutationObserver = new MutationObserver((mutations) => {
-        let hasChildrenMutations = false;
-
-        for (const mutation of mutations) {
-          if (mutation.target !== element) {
-            hasChildrenMutations = true;
-            continue;
-          }
-
-          if (mutation.type !== 'attributes') {
-            // Should never happen, but defensive programming just in case
-            continue;
-          }
-
-          // Attribute name is guaranteed to be non-null if type is "attributes"
-          // https://developer.mozilla.org/en-US/docs/Web/API/MutationRecord/attributeName#value
-          const attributeName = mutation.attributeName!;
-
-          if (
-            attributeName.startsWith('aria-') ||
-            IGNORED_ATTRIBUTES.includes(attributeName)
-          ) {
-            continue;
-          }
-
-          const attributeValue = element.getAttribute(attributeName);
-
-          if (attributeName === 'style') {
-            if (supportsStyle(element) && supportsStyle(placeholder)) {
-              const styles = element.style;
-
-              for (const key of Array.from(placeholder.style)) {
-                if (styles.getPropertyValue(key) === '') {
-                  placeholder.style.removeProperty(key);
-                }
-              }
-
-              for (const key of Array.from(styles)) {
-                if (
-                  IGNORED_STYLES.includes(key) ||
-                  key.startsWith(CSS_PREFIX)
-                ) {
-                  continue;
-                }
-
-                const value = styles.getPropertyValue(key);
-
-                placeholder.style.setProperty(key, value);
-              }
-            }
-          } else if (attributeValue !== null) {
-            placeholder.setAttribute(attributeName, attributeValue);
-          } else {
-            placeholder.removeAttribute(attributeName);
-          }
-        }
-
-        if (hasChildrenMutations && clone) {
-          placeholder.innerHTML = element.innerHTML;
-        }
-      });
-
-      elementMutationObserver.observe(element, {
-        attributes: true,
-        subtree: true,
-        childList: true,
-      });
-
-      /* Make sure the placeholder and the source element positions are always in sync */
-      documentMutationObserver = new MutationObserver((entries) => {
-        for (const entry of entries) {
-          if (entry.addedNodes.length === 0) continue;
-
-          for (const node of Array.from(entry.addedNodes)) {
-            if (
-              node.contains(element) &&
-              element.nextElementSibling !== placeholder
-            ) {
-              /* Update the position of the placeholder when the source element is moved */
-              element.insertAdjacentElement('afterend', placeholder);
-              /* Force the source element to be promoted back to the top layer */
-              showPopover(feedbackElement);
-              return;
-            }
-
-            if (
-              node.contains(placeholder) &&
-              placeholder.previousElementSibling !== element
-            ) {
-              /* Update the position of the source element when the placeholder is moved */
-              placeholder.insertAdjacentElement('beforebegin', element);
-              /* Force the source element to be promoted back to the top layer */
-              showPopover(feedbackElement);
-              return;
-            }
-          }
-        }
-      });
-
-      /* Observe mutations on the element's owner document body */
-      documentMutationObserver.observe(element.ownerDocument.body, {
-        childList: true,
-        subtree: true,
-      });
+      elementMutationObserver = createElementMutationObserver(
+        element,
+        placeholder,
+        clone
+      );
+      documentMutationObserver = createDocumentMutationObserver(
+        element,
+        placeholder,
+        feedbackElement
+      );
     }
+
+    /* ---- Cleanup ---- */
 
     const id = manager.dragOperation.source?.id;
 
     const restoreFocus = () => {
-      if (!isKeyboardOperation || id == null) {
-        return;
-      }
+      if (!isKeyboardOperation || id == null) return;
 
       const draggable = manager.registry.draggables.get(id);
-      const element = draggable?.handle ?? draggable?.element;
+      const focusTarget = draggable?.handle ?? draggable?.element;
 
-      if (isHTMLElement(element)) {
-        element.focus();
+      if (isHTMLElement(focusTarget)) {
+        focusTarget.focus();
       }
     };
+
     const cleanup = () => {
       elementMutationObserver?.disconnect();
       documentMutationObserver?.disconnect();
@@ -512,6 +415,10 @@ export class Feedback extends Plugin<DragDropManager, FeedbackOptions> {
 
       placeholder?.remove();
     };
+
+    /* ---- Reactive effects ---- */
+
+    const dropAnimationConfig = options?.dropAnimation;
 
     const cleanupEffects = effects(
       // Update transform on move
@@ -555,7 +462,6 @@ export class Feedback extends Plugin<DragDropManager, FeedbackOptions> {
             dragOperation.shape = Rectangle.from(
               currentShape.boundingRectangle
             ).translate(
-              // Need to take into account frame transform when optimistically updating shape
               delta.x * frameTransform.scaleX,
               delta.y * frameTransform.scaleY
             );
@@ -569,7 +475,6 @@ export class Feedback extends Plugin<DragDropManager, FeedbackOptions> {
       // Drop animation
       function () {
         if (dragOperation.status.dropped) {
-          // Dispose of the effect
           this.dispose();
 
           source.status = 'dropping';
@@ -578,106 +483,30 @@ export class Feedback extends Plugin<DragDropManager, FeedbackOptions> {
           const moved = translate != null;
 
           if (!translate && element !== feedbackElement) {
-            translate = {
-              x: 0,
-              y: 0,
-            };
+            translate = {x: 0, y: 0};
           }
 
-          if (!translate) {
+          if (!translate || dropAnimationConfig === null) {
             cleanup();
             return;
           }
 
-          const dropAnimation = () => {
-            {
-              /* Force the source element to be promoted to the top layer before animating it */
-              showPopover(feedbackElement);
-
-              // Pause any translate transitions that are running on the feedback element
-              const [, animation] =
-                getFinalKeyframe(
-                  feedbackElement,
-                  (keyframe) => 'translate' in keyframe
-                ) ?? [];
-
-              animation?.pause();
-
-              const target = placeholder ?? element;
-              const options = {
-                frameTransform: isSameFrame(feedbackElement, target)
-                  ? null
-                  : undefined,
-              };
-              const current = new DOMRectangle(feedbackElement, options);
-              // With a keyboard activator, since there is a transition on the translate property,
-              // the translate value may not be the same as the computed value if the transition is still running.
-              const currentTranslate =
-                parseTranslate(getComputedStyles(feedbackElement).translate) ??
-                translate;
-              const final = new DOMRectangle(target, options);
-              const delta = Rectangle.delta(current, final, source.alignment);
-              const finalTranslate = {
-                x: currentTranslate.x - delta.x,
-                y: currentTranslate.y - delta.y,
-              };
-              const heightKeyframes =
-                Math.round(current.intrinsicHeight) !==
-                Math.round(final.intrinsicHeight)
-                  ? {
-                      minHeight: [
-                        `${current.intrinsicHeight}px`,
-                        `${final.intrinsicHeight}px`,
-                      ],
-                      maxHeight: [
-                        `${current.intrinsicHeight}px`,
-                        `${final.intrinsicHeight}px`,
-                      ],
-                    }
-                  : {};
-              const widthKeyframes =
-                Math.round(current.intrinsicWidth) !==
-                Math.round(final.intrinsicWidth)
-                  ? {
-                      minWidth: [
-                        `${current.intrinsicWidth}px`,
-                        `${final.intrinsicWidth}px`,
-                      ],
-                      maxWidth: [
-                        `${current.intrinsicWidth}px`,
-                        `${final.intrinsicWidth}px`,
-                      ],
-                    }
-                  : {};
-
-              styles.set({transition}, CSS_PREFIX);
-              feedbackElement.setAttribute(DROPPING_ATTRIBUTE, '');
-              elementMutationObserver?.takeRecords();
-
-              animateTransform({
-                element: feedbackElement,
-                keyframes: {
-                  ...heightKeyframes,
-                  ...widthKeyframes,
-                  translate: [
-                    `${currentTranslate.x}px ${currentTranslate.y}px 0`,
-                    `${finalTranslate.x}px ${finalTranslate.y}px 0`,
-                  ],
-                },
-                options: {
-                  duration: moved || feedbackElement !== element ? 250 : 0,
-                  easing: 'ease',
-                },
-              }).then(() => {
-                feedbackElement.removeAttribute(DROPPING_ATTRIBUTE);
-                animation?.finish();
-                cleanup();
-                requestAnimationFrame(restoreFocus);
-              });
-            }
-          };
-
-          manager.renderer.rendering.then(dropAnimation);
+          manager.renderer.rendering.then(() => {
+            runDropAnimation({
+              element,
+              feedbackElement,
+              placeholder,
+              translate: translate!,
+              moved,
+              transition,
+              alignment: source.alignment,
+              styles,
+              animation: dropAnimationConfig ?? undefined,
+              getElementMutationObserver: () => elementMutationObserver,
+              cleanup,
+              restoreFocus,
+            });
+          });
         }
       }
     );
@@ -686,107 +515,6 @@ export class Feedback extends Plugin<DragDropManager, FeedbackOptions> {
       cleanup();
       cleanupEffects();
     };
-  }
-
-  @derived
-  private get sourceRoot() {
-    const {source} = this.manager.dragOperation;
-    return getRoot(source?.element ?? null);
-  }
-
-  @derived
-  private get targetRoot() {
-    const {target} = this.manager.dragOperation;
-    return getRoot(target?.element ?? null);
-  }
-
-  @derived
-  private get roots(): Set<Document | ShadowRoot> {
-    const {status} = this.manager.dragOperation;
-
-    if (status.initializing || status.initialized) {
-      const roots = [this.sourceRoot, this.targetRoot].filter(root => root != null);
-      return new Set(roots);
-    }
-
-    return new Set();
-  }
-
-  #injectStyles() {
-    const {roots} = this;
-
-    for (const root of roots) {
-      let registration = styleSheetRegistry.get(root);
-
-      if (!registration) {
-        // check adoptedStyleSheets support
-        if (
-          !(
-            'adoptedStyleSheets' in root &&
-            Array.isArray(root.adoptedStyleSheets)
-          ) && process.env.NODE_ENV !== 'production'
-        ) {
-          console.error("Cannot inject styles: This browser doesn't support adoptedStyleSheets");
-        }
-
-        // Get the CSSStyleSheet constructor from the target document's context
-        // This is necessary because CSSStyleSheet instances cannot be shared across documents
-        // (e.g., between a parent document and a same-origin iframe)
-        const targetWindow = isDocument(root)
-          ? root.defaultView
-          : root.ownerDocument.defaultView;
-        const {CSSStyleSheet} = targetWindow ?? {};
-
-        if (!CSSStyleSheet) {
-          if (process.env.NODE_ENV !== 'production') {
-            console.error("Cannot inject styles: CSSStyleSheet constructor not available");
-          }
-          continue;
-        }
-
-        // Create the stylesheet in the target document's context
-        const sheet = new CSSStyleSheet();
-        sheet.replaceSync(CSS_RULES);
-        root.adoptedStyleSheets.push(sheet);
-
-        registration = {
-          cleanup: () => {
-            if (
-              isDocument(root) ||
-              (isShadowRoot(root) && root.host?.isConnected)
-            ) {
-              // remove the stylesheet from the root's adoptedStyleSheets
-              const index = root.adoptedStyleSheets.indexOf(sheet);
-              if (index != -1) {
-                root.adoptedStyleSheets.splice(index, 1);
-              }
-            }
-          },
-          instances: new Set(),
-        };
-        styleSheetRegistry.set(root, registration);
-      }
-
-      // Track this instance for this document
-      registration.instances.add(this);
-    }
-  }
-
-  public destroy(): void {
-    super.destroy();
-
-    // Clean up documents this instance was tracking
-    for (const [root, registration] of styleSheetRegistry.entries()) {
-      if (registration.instances.has(this)) {
-        registration.instances.delete(this);
-
-        // If no more instances are using this document, clean it up
-        if (registration.instances.size === 0) {
-          registration.cleanup();
-          styleSheetRegistry.delete(root);
-        }
-      }
-    }
   }
 
   static configure = configurator(Feedback);

--- a/packages/dom/src/core/plugins/feedback/dropAnimation.ts
+++ b/packages/dom/src/core/plugins/feedback/dropAnimation.ts
@@ -1,0 +1,153 @@
+import {
+  animateTransform,
+  DOMRectangle,
+  getComputedStyles,
+  getFinalKeyframe,
+  parseTranslate,
+  showPopover,
+  type Styles,
+} from '@dnd-kit/dom/utilities';
+import {Rectangle, type Coordinates, type Alignment} from '@dnd-kit/geometry';
+
+import {CSS_PREFIX, DROPPING_ATTRIBUTE} from './constants.ts';
+import {isSameFrame} from './utilities.ts';
+
+export interface DropAnimationOptions {
+  /** Duration in milliseconds. @default 250 */
+  duration?: number;
+  /** CSS easing function. @default 'ease' */
+  easing?: string;
+}
+
+export type DropAnimationFunction = (context: {
+  element: Element;
+  feedbackElement: Element;
+  placeholder: Element | null | undefined;
+  translate: Coordinates;
+  moved: boolean;
+}) => Promise<void> | void;
+
+export type DropAnimation = DropAnimationOptions | DropAnimationFunction;
+
+const DEFAULT_DURATION = 250;
+const DEFAULT_EASING = 'ease';
+
+export interface DropAnimationContext {
+  element: Element;
+  feedbackElement: Element;
+  placeholder: Element | null | undefined;
+  translate: Coordinates;
+  moved: boolean;
+  transition: string;
+  alignment: Alignment | undefined;
+  styles: Styles;
+  animation: DropAnimation | undefined;
+  getElementMutationObserver: () => MutationObserver | undefined;
+  cleanup: () => void;
+  restoreFocus: () => void;
+}
+
+export function runDropAnimation(ctx: DropAnimationContext): void {
+  const {animation} = ctx;
+
+  if (typeof animation === 'function') {
+    const result = animation({
+      element: ctx.element,
+      feedbackElement: ctx.feedbackElement,
+      placeholder: ctx.placeholder,
+      translate: ctx.translate,
+      moved: ctx.moved,
+    });
+
+    Promise.resolve(result).then(() => {
+      ctx.cleanup();
+      requestAnimationFrame(ctx.restoreFocus);
+    });
+
+    return;
+  }
+
+  const {
+    duration = DEFAULT_DURATION,
+    easing = DEFAULT_EASING,
+  } = animation ?? {};
+
+  showPopover(ctx.feedbackElement);
+
+  const [, runningAnimation] =
+    getFinalKeyframe(
+      ctx.feedbackElement,
+      (keyframe) => 'translate' in keyframe
+    ) ?? [];
+
+  runningAnimation?.pause();
+
+  const target = ctx.placeholder ?? ctx.element;
+  const options = {
+    frameTransform: isSameFrame(ctx.feedbackElement, target)
+      ? null
+      : undefined,
+  };
+  const current = new DOMRectangle(ctx.feedbackElement, options);
+  const currentTranslate =
+    parseTranslate(getComputedStyles(ctx.feedbackElement).translate) ??
+    ctx.translate;
+  const final = new DOMRectangle(target, options);
+  const delta = Rectangle.delta(current, final, ctx.alignment);
+  const finalTranslate = {
+    x: currentTranslate.x - delta.x,
+    y: currentTranslate.y - delta.y,
+  };
+  const heightKeyframes =
+    Math.round(current.intrinsicHeight) !== Math.round(final.intrinsicHeight)
+      ? {
+          minHeight: [
+            `${current.intrinsicHeight}px`,
+            `${final.intrinsicHeight}px`,
+          ],
+          maxHeight: [
+            `${current.intrinsicHeight}px`,
+            `${final.intrinsicHeight}px`,
+          ],
+        }
+      : {};
+  const widthKeyframes =
+    Math.round(current.intrinsicWidth) !== Math.round(final.intrinsicWidth)
+      ? {
+          minWidth: [
+            `${current.intrinsicWidth}px`,
+            `${final.intrinsicWidth}px`,
+          ],
+          maxWidth: [
+            `${current.intrinsicWidth}px`,
+            `${final.intrinsicWidth}px`,
+          ],
+        }
+      : {};
+
+  ctx.styles.set({transition: ctx.transition}, CSS_PREFIX);
+  ctx.feedbackElement.setAttribute(DROPPING_ATTRIBUTE, '');
+  ctx.getElementMutationObserver()?.takeRecords();
+
+  animateTransform({
+    element: ctx.feedbackElement,
+    keyframes: {
+      ...heightKeyframes,
+      ...widthKeyframes,
+      translate: [
+        `${currentTranslate.x}px ${currentTranslate.y}px 0`,
+        `${finalTranslate.x}px ${finalTranslate.y}px 0`,
+      ],
+    },
+    options: {
+      duration:
+        ctx.moved || ctx.feedbackElement !== ctx.element ? duration : 0,
+      easing,
+    },
+  }).then(() => {
+    ctx.feedbackElement.removeAttribute(DROPPING_ATTRIBUTE);
+    runningAnimation?.finish();
+    ctx.cleanup();
+    requestAnimationFrame(ctx.restoreFocus);
+  });
+}

--- a/packages/dom/src/core/plugins/feedback/index.ts
+++ b/packages/dom/src/core/plugins/feedback/index.ts
@@ -1,2 +1,7 @@
 export {Feedback} from './Feedback.ts';
 export type {Transition} from './types.ts';
+export type {
+  DropAnimation,
+  DropAnimationOptions,
+  DropAnimationFunction,
+} from './dropAnimation.ts';

--- a/packages/dom/src/core/plugins/feedback/observers.ts
+++ b/packages/dom/src/core/plugins/feedback/observers.ts
@@ -1,0 +1,184 @@
+import {
+  supportsStyle,
+  showPopover,
+  DOMRectangle,
+  type Styles,
+} from '@dnd-kit/dom/utilities';
+import type {Coordinates} from '@dnd-kit/geometry';
+
+import {CSS_PREFIX, IGNORED_ATTRIBUTES, IGNORED_STYLES} from './constants.ts';
+import {isTableRow} from './utilities.ts';
+
+export function createElementMutationObserver(
+  element: Element,
+  placeholder: Element,
+  clone: boolean
+): MutationObserver {
+  const observer = new MutationObserver((mutations) => {
+    let hasChildrenMutations = false;
+
+    for (const mutation of mutations) {
+      if (mutation.target !== element) {
+        hasChildrenMutations = true;
+        continue;
+      }
+
+      if (mutation.type !== 'attributes') {
+        continue;
+      }
+
+      // Attribute name is guaranteed to be non-null if type is "attributes"
+      // https://developer.mozilla.org/en-US/docs/Web/API/MutationRecord/attributeName#value
+      const attributeName = mutation.attributeName!;
+
+      if (
+        attributeName.startsWith('aria-') ||
+        IGNORED_ATTRIBUTES.includes(attributeName)
+      ) {
+        continue;
+      }
+
+      const attributeValue = element.getAttribute(attributeName);
+
+      if (attributeName === 'style') {
+        if (supportsStyle(element) && supportsStyle(placeholder)) {
+          const styles = element.style;
+
+          for (const key of Array.from(placeholder.style)) {
+            if (styles.getPropertyValue(key) === '') {
+              placeholder.style.removeProperty(key);
+            }
+          }
+
+          for (const key of Array.from(styles)) {
+            if (
+              IGNORED_STYLES.includes(key) ||
+              key.startsWith(CSS_PREFIX)
+            ) {
+              continue;
+            }
+
+            const value = styles.getPropertyValue(key);
+
+            placeholder.style.setProperty(key, value);
+          }
+        }
+      } else if (attributeValue !== null) {
+        placeholder.setAttribute(attributeName, attributeValue);
+      } else {
+        placeholder.removeAttribute(attributeName);
+      }
+    }
+
+    if (hasChildrenMutations && clone) {
+      placeholder.innerHTML = element.innerHTML;
+    }
+  });
+
+  observer.observe(element, {
+    attributes: true,
+    subtree: true,
+    childList: true,
+  });
+
+  return observer;
+}
+
+export function createDocumentMutationObserver(
+  element: Element,
+  placeholder: Element,
+  feedbackElement: Element
+): MutationObserver {
+  const observer = new MutationObserver((entries) => {
+    for (const entry of entries) {
+      if (entry.addedNodes.length === 0) continue;
+
+      for (const node of Array.from(entry.addedNodes)) {
+        if (
+          node.contains(element) &&
+          element.nextElementSibling !== placeholder
+        ) {
+          element.insertAdjacentElement('afterend', placeholder);
+          showPopover(feedbackElement);
+          return;
+        }
+
+        if (
+          node.contains(placeholder) &&
+          placeholder.previousElementSibling !== element
+        ) {
+          placeholder.insertAdjacentElement('beforebegin', element);
+          showPopover(feedbackElement);
+          return;
+        }
+      }
+    }
+  });
+
+  observer.observe(element.ownerDocument.body, {
+    childList: true,
+    subtree: true,
+  });
+
+  return observer;
+}
+
+export interface ResizeObserverContext {
+  placeholder: Element;
+  element: Element;
+  feedbackElement: Element;
+  frameTransform: {x: number; y: number; scaleX: number; scaleY: number};
+  transformOrigin: Coordinates;
+  width: number;
+  height: number;
+  top: number;
+  left: number;
+  widthOffset: number;
+  heightOffset: number;
+  delta: Coordinates;
+  styles: Styles;
+  dragOperation: {shape: any};
+  getElementMutationObserver: () => MutationObserver | undefined;
+  getSavedCellWidths: () => string[] | undefined;
+  setSavedCellWidths: (widths: string[]) => void;
+}
+
+export function createResizeObserver(ctx: ResizeObserverContext): ResizeObserver {
+  return new ResizeObserver(() => {
+    const placeholderShape = new DOMRectangle(ctx.placeholder, {
+      frameTransform: ctx.frameTransform,
+      ignoreTransforms: true,
+    });
+    const origin = ctx.transformOrigin ?? {x: 1, y: 1};
+    const dX = (ctx.width - placeholderShape.width) * origin.x + ctx.delta.x;
+    const dY = (ctx.height - placeholderShape.height) * origin.y + ctx.delta.y;
+
+    ctx.styles.set(
+      {
+        width: placeholderShape.width - ctx.widthOffset,
+        height: placeholderShape.height - ctx.heightOffset,
+        top: ctx.top + dY,
+        left: ctx.left + dX,
+      },
+      CSS_PREFIX
+    );
+    ctx.getElementMutationObserver()?.takeRecords();
+
+    if (isTableRow(ctx.element) && isTableRow(ctx.placeholder)) {
+      const cells = Array.from(ctx.element.cells);
+      const placeholderCells = Array.from(ctx.placeholder.cells);
+
+      if (!ctx.getSavedCellWidths()) {
+        ctx.setSavedCellWidths(cells.map((cell) => cell.style.width));
+      }
+
+      for (const [index, cell] of cells.entries()) {
+        const placeholderCell = placeholderCells[index];
+
+        cell.style.width = `${placeholderCell.getBoundingClientRect().width}px`;
+      }
+    }
+
+    ctx.dragOperation.shape = new DOMRectangle(ctx.feedbackElement);
+  });
+}

--- a/packages/dom/src/core/plugins/index.ts
+++ b/packages/dom/src/core/plugins/index.ts
@@ -4,7 +4,14 @@ export {Cursor} from './cursor/index.ts';
 
 export {Feedback} from './feedback/index.ts';
 export type {Transition} from './feedback/types.ts';
+export type {
+  DropAnimation,
+  DropAnimationOptions,
+  DropAnimationFunction,
+} from './feedback/index.ts';
 
 export {AutoScroller, Scroller, ScrollListener} from './scrolling/index.ts';
 
 export {PreventSelection} from './selection/PreventSelection.ts';
+
+export {StyleSheetManager} from './stylesheet/StyleSheetManager.ts';

--- a/packages/dom/src/core/plugins/stylesheet/StyleSheetManager.ts
+++ b/packages/dom/src/core/plugins/stylesheet/StyleSheetManager.ts
@@ -1,0 +1,191 @@
+import {CorePlugin} from '@dnd-kit/abstract';
+import {derived, reactive, untracked} from '@dnd-kit/state';
+import {getRoot, isDocument, isShadowRoot} from '@dnd-kit/dom/utilities';
+
+import type {DragDropManager} from '../../manager/index.ts';
+
+type CleanupFunction = () => void;
+
+interface SheetRegistration {
+  sheet: CSSStyleSheet;
+  refCount: number;
+  cleanup: CleanupFunction;
+}
+
+const sheetRegistry = new Map<
+  Document | ShadowRoot,
+  Map<string, SheetRegistration>
+>();
+
+export class StyleSheetManager extends CorePlugin<DragDropManager> {
+  #registeredRules = new Set<string>();
+
+  @reactive
+  private accessor additionalRoots = new Set<Document | ShadowRoot>();
+
+  constructor(manager: DragDropManager) {
+    super(manager);
+
+    this.registerEffect(this.#syncStyles);
+  }
+
+  /**
+   * Registers CSS rules to be injected into the active drag operation's
+   * document and shadow roots. The StyleSheetManager handles tracking
+   * which roots need the styles and cleaning up when they're no longer needed.
+   *
+   * Returns a cleanup function that unregisters the rules.
+   */
+  public register(cssRules: string): CleanupFunction {
+    this.#registeredRules.add(cssRules);
+
+    return () => {
+      this.#registeredRules.delete(cssRules);
+    };
+  }
+
+  /**
+   * Adds an additional root to track for style injection.
+   * Returns a cleanup function that removes the root.
+   */
+  public addRoot(root: Document | ShadowRoot): CleanupFunction {
+    untracked(() => {
+      const roots = new Set(this.additionalRoots);
+      roots.add(root);
+      this.additionalRoots = roots;
+    });
+
+    return () => {
+      untracked(() => {
+        const roots = new Set(this.additionalRoots);
+        roots.delete(root);
+        this.additionalRoots = roots;
+      });
+    };
+  }
+
+  @derived
+  private get sourceRoot() {
+    const {source} = this.manager.dragOperation;
+    return getRoot(source?.element ?? null);
+  }
+
+  @derived
+  private get targetRoot() {
+    const {target} = this.manager.dragOperation;
+    return getRoot(target?.element ?? null);
+  }
+
+  @derived
+  private get roots(): Set<Document | ShadowRoot> {
+    const {status} = this.manager.dragOperation;
+
+    if (status.initializing || status.initialized) {
+      const roots = [this.sourceRoot, this.targetRoot].filter(
+        (root) => root != null
+      );
+      return new Set([...roots, ...this.additionalRoots]);
+    }
+
+    return new Set();
+  }
+
+  #syncStyles() {
+    const {roots} = this;
+    const cleanups: CleanupFunction[] = [];
+
+    for (const root of roots) {
+      for (const cssRules of this.#registeredRules) {
+        cleanups.push(this.#inject(root, cssRules));
+      }
+    }
+
+    return () => {
+      for (const cleanup of cleanups) {
+        cleanup();
+      }
+    };
+  }
+
+  #inject(root: Document | ShadowRoot, cssRules: string): CleanupFunction {
+    let rootSheets = sheetRegistry.get(root);
+
+    if (!rootSheets) {
+      rootSheets = new Map();
+      sheetRegistry.set(root, rootSheets);
+    }
+
+    let registration = rootSheets.get(cssRules);
+
+    if (!registration) {
+      if (
+        !(
+          'adoptedStyleSheets' in root &&
+          Array.isArray(root.adoptedStyleSheets)
+        ) &&
+        process.env.NODE_ENV !== 'production'
+      ) {
+        console.error(
+          "Cannot inject styles: This browser doesn't support adoptedStyleSheets"
+        );
+      }
+
+      const targetWindow = isDocument(root)
+        ? root.defaultView
+        : root.ownerDocument.defaultView;
+      const {CSSStyleSheet} = targetWindow ?? {};
+
+      if (!CSSStyleSheet) {
+        if (process.env.NODE_ENV !== 'production') {
+          console.error(
+            'Cannot inject styles: CSSStyleSheet constructor not available'
+          );
+        }
+
+        return () => {};
+      }
+
+      const sheet = new CSSStyleSheet();
+      sheet.replaceSync(cssRules);
+      root.adoptedStyleSheets.push(sheet);
+
+      registration = {
+        sheet,
+        refCount: 0,
+        cleanup: () => {
+          if (
+            isDocument(root) ||
+            (isShadowRoot(root) && root.host?.isConnected)
+          ) {
+            const index = root.adoptedStyleSheets.indexOf(sheet);
+            if (index !== -1) {
+              root.adoptedStyleSheets.splice(index, 1);
+            }
+          }
+
+          rootSheets!.delete(cssRules);
+
+          if (rootSheets!.size === 0) {
+            sheetRegistry.delete(root);
+          }
+        },
+      };
+      rootSheets.set(cssRules, registration);
+    }
+
+    registration.refCount++;
+
+    let disposed = false;
+
+    return () => {
+      if (disposed) return;
+      disposed = true;
+
+      registration!.refCount--;
+
+      if (registration!.refCount === 0) {
+        registration!.cleanup();
+      }
+    };
+  }
+}


### PR DESCRIPTION
Refactor the Feedback plugin for improved modularity and extensibility.

**StyleSheetManager** – Introduced a new generic `CorePlugin` that manages CSS stylesheet injection into document and shadow roots. Plugins can call `register(cssRules)` to declare styles and `addRoot(root)` to track additional roots. The manager reactively injects and cleans up adopted stylesheets as the drag operation's source and target roots change. The Feedback plugin now delegates all stylesheet management to the StyleSheetManager.

**Configurable drop animation** – The `Feedback` plugin now accepts a `dropAnimation` option:

- Pass `{ duration, easing }` to customize the built-in animation timing
- Pass a function for full custom animation control (receives context, return a promise)
- Pass `null` to disable the drop animation entirely
- Omit for the default 250ms ease animation

**Extracted helpers** – Observer setup (`createElementMutationObserver`, `createDocumentMutationObserver`, `createResizeObserver`) and the drop animation logic (`runDropAnimation`) are now in dedicated modules within the feedback plugin directory.