### PR TITLE
Fix useDeepSignal reactivity timing in Vue adapter

### DIFF
--- a/packages/vue/src/composables/useDeepSignal.ts
+++ b/packages/vue/src/composables/useDeepSignal.ts
@@ -36,7 +36,7 @@ export function useDeepSignal<T extends object | null | undefined>(
         }
       })
     );
-  });
+  }, {flush: 'post'});
 
   return computed(() => {
     const _target = toValue(target);


### PR DESCRIPTION
## Summary

- Fixes a reactivity timing bug in the Vue `useDeepSignal` composable where `watchEffect` ran eagerly during `setup()`, creating the `@preact/signals-core` effect before the template had rendered. This meant the `tracked` map was empty, so the effect subscribed to zero signals and `dirty.value` was never incremented -- leaving computed refs like `isDragging`, `isDropping`, etc. permanently stale.
- Adds `{ flush: 'post' }` to defer the effect creation until after the template renders and the Proxy get traps have populated the `tracked` map, matching the behavior of the React (`useLayoutEffect`) and Solid (`createEffect`) adapters.

## Test plan

- [x] Run Vue storybook (`stories-vue`) and verify `data-shadow` updates on custom elements (`button-component`, `container-component`) during drag
- [x] Verify sortable `isDragging` state reflects correctly on `<div>` elements as well
- [x] Run existing Playwright e2e tests for `stories-vue`