### PR TITLE
Patch fix PointerSensor crash on Android

### DIFF
--- a/.changeset/rare-pans-love.md
+++ b/.changeset/rare-pans-love.md
@@ -1,0 +1,5 @@
+---
+'@dnd-kit/dom': patch
+---
+
+Fixed PointerSensor crash on Android caused by unhandled pointercancel events.

--- a/packages/dom/src/core/sensors/pointer/PointerSensor.ts
+++ b/packages/dom/src/core/sensors/pointer/PointerSensor.ts
@@ -226,6 +226,10 @@ export class PointerSensor extends Sensor<
           capture: true,
         },
       },
+      {                                                                     
+        type: 'pointercancel',                 
+        listener: this.handleCancel,                                        
+      },   
       {
         // Cancel activation if there is a competing Drag and Drop interaction
         type: 'dragstart',


### PR DESCRIPTION
PointerSensor listens for pointermove, pointerup, and dragstart after pointerdown, but not pointercancel. On Android, the browser frequently cancels touch pointers during the activation delay period. When the delay timer fires, handleStart calls setPointerCapture with a pointer ID that no longer exists, throwing an uncaught DOMException.

This fix adds pointercancel to the listener bindings in handlePointerDown, mapped to the existing handleCancel handler. This matches how @dnd-kit/core v6 handled it in AbstractPointerSensor.

I did not add tests as it did not seem to fit into the current e2e structure, but can attempt to if needed. 