### PR TITLE
Check for touch-action styles before dragging

### DIFF
--- a/.changeset/busy-socks-brake.md
+++ b/.changeset/busy-socks-brake.md
@@ -1,0 +1,5 @@
+---
+'@dnd-kit/dom': patch
+---
+
+Check touch-action CSS property before allowing touch-based dragging

--- a/packages/dom/src/core/sensors/pointer/PointerSensor.ts
+++ b/packages/dom/src/core/sensors/pointer/PointerSensor.ts
@@ -8,6 +8,7 @@ import {
 } from '@dnd-kit/abstract';
 import type {Coordinates} from '@dnd-kit/geometry';
 import {
+  getComputedStyles,
   getDocument,
   getDocuments,
   getEventCoordinates,
@@ -73,6 +74,16 @@ const defaults = Object.freeze<PointerSensorOptions>({
   preventActivation(event, source) {
     const {target} = event;
 
+    if (event.pointerType === 'touch') {
+      const activator = source.handle ?? source.element;
+      if (activator) {
+        const touchAction = getComputedStyles(activator).touchAction;
+        if (touchAction !== 'none') {
+          return true;
+        }
+      }
+    }
+
     if (target === source.element) return false;
     if (target === source.handle) return false;
     if (!isElement(target)) return false;
@@ -115,8 +126,8 @@ export class PointerSensor extends Sensor<
   }
 
   protected activationConstraints(
-    event: PointerEvent, 
-    source: Draggable, 
+    event: PointerEvent,
+    source: Draggable,
     options = this.options
   ) {
     const {activationConstraints = defaults.activationConstraints} =


### PR DESCRIPTION
Adds touch-action CSS detection to PointerSensor's default `preventActivation` function. Only allows touch-based dragging when `touch-action: none` is set, preventing activation attempts that the browser would cancel for scroll/gesture handling.
