### PR TITLE
Rename StyleSheetManager to StyleInjector and centralize nonce

### DIFF
--- a/.changeset/refactor-style-injector.md
+++ b/.changeset/refactor-style-injector.md
@@ -1,0 +1,32 @@
+---
+'@dnd-kit/dom': minor
+---
+
+Renamed `StyleSheetManager` to `StyleInjector` and centralized CSP `nonce` configuration.
+
+The `StyleInjector` plugin now accepts a `nonce` option that is applied to all injected `<style>` elements. The `nonce` options have been removed from the `Cursor`, `PreventSelection`, and `Feedback` plugin options.
+
+Before:
+
+```ts
+const manager = new DragDropManager({
+  plugins: (defaults) => [
+    ...defaults,
+    Cursor.configure({ nonce: 'abc123' }),
+    PreventSelection.configure({ nonce: 'abc123' }),
+  ],
+});
+```
+
+After:
+
+```ts
+const manager = new DragDropManager({
+  plugins: (defaults) => [
+    ...defaults,
+    StyleInjector.configure({ nonce: 'abc123' }),
+  ],
+});
+```
+
+The `Cursor` and `PreventSelection` plugins now route their style injection through the `StyleInjector`, so all injected styles respect the centralized `nonce` configuration.

--- a/packages/dom/src/core/index.ts
+++ b/packages/dom/src/core/index.ts
@@ -37,7 +37,7 @@ export {
   PreventSelection,
   Scroller,
   ScrollListener,
-  StyleSheetManager,
+  StyleInjector,
 } from './plugins/index.ts';
 export type {
   Transition,

--- a/packages/dom/src/core/manager/manager.ts
+++ b/packages/dom/src/core/manager/manager.ts
@@ -17,7 +17,7 @@ import {
   Scroller,
   ScrollListener,
   PreventSelection,
-  StyleSheetManager,
+  StyleInjector,
 } from '../plugins/index.ts';
 import {KeyboardSensor} from '../sensors/keyboard/KeyboardSensor.ts';
 import {PointerSensor} from '../sensors/pointer/PointerSensor.ts';
@@ -46,7 +46,7 @@ export class DragDropManager<
 
     super({
       ...input,
-      plugins: [ScrollListener, Scroller, StyleSheetManager, ...plugins],
+      plugins: [ScrollListener, Scroller, StyleInjector, ...plugins],
       sensors,
       modifiers,
     });

--- a/packages/dom/src/core/plugins/feedback/Feedback.ts
+++ b/packages/dom/src/core/plugins/feedback/Feedback.ts
@@ -19,7 +19,7 @@ import {Coordinates, Point, Rectangle} from '@dnd-kit/geometry';
 
 import type {DragDropManager} from '../../manager/index.ts';
 import type {Draggable} from '../../entities/index.ts';
-import {StyleSheetManager} from '../stylesheet/StyleSheetManager.ts';
+import {StyleInjector} from '../stylesheet/StyleInjector.ts';
 
 import {ATTRIBUTE, CSS_PREFIX, CSS_RULES} from './constants.ts';
 import {
@@ -37,7 +37,6 @@ import {runDropAnimation, type DropAnimation} from './dropAnimation.ts';
 
 export interface FeedbackOptions {
   rootElement?: Element | ((source: Draggable) => Element);
-  nonce?: string;
   dropAnimation?: DropAnimation | null;
 }
 
@@ -76,11 +75,11 @@ export class Feedback extends Plugin<DragDropManager, FeedbackOptions> {
   constructor(manager: DragDropManager, options?: FeedbackOptions) {
     super(manager, options);
 
-    const styleSheetManager = manager.registry.plugins.get(
-      StyleSheetManager as any
-    ) as StyleSheetManager | undefined;
+    const styleInjector = manager.registry.plugins.get(
+      StyleInjector as any
+    ) as StyleInjector | undefined;
 
-    const unregisterStyles = styleSheetManager?.register(CSS_RULES);
+    const unregisterStyles = styleInjector?.register(CSS_RULES);
 
     if (unregisterStyles) {
       const originalDestroy = this.destroy.bind(this);
@@ -90,20 +89,20 @@ export class Feedback extends Plugin<DragDropManager, FeedbackOptions> {
       };
     }
 
-    this.registerEffect(this.#trackOverlayRoot.bind(this, styleSheetManager));
+    this.registerEffect(this.#trackOverlayRoot.bind(this, styleInjector));
     this.registerEffect(this.#render);
   }
 
-  #trackOverlayRoot(styleSheetManager: StyleSheetManager | undefined) {
+  #trackOverlayRoot(styleInjector: StyleInjector | undefined) {
     const {overlay} = this;
 
-    if (!overlay || !styleSheetManager) return;
+    if (!overlay || !styleInjector) return;
 
     const root = getRoot(overlay);
 
     if (!root) return;
 
-    return styleSheetManager.addRoot(root);
+    return styleInjector.addRoot(root);
   }
 
   #render() {

--- a/packages/dom/src/core/plugins/index.ts
+++ b/packages/dom/src/core/plugins/index.ts
@@ -14,4 +14,4 @@ export {AutoScroller, Scroller, ScrollListener} from './scrolling/index.ts';
 
 export {PreventSelection} from './selection/PreventSelection.ts';
 
-export {StyleSheetManager} from './stylesheet/StyleSheetManager.ts';
+export {StyleInjector} from './stylesheet/StyleInjector.ts';


### PR DESCRIPTION
## Summary

- Renames `StyleSheetManager` to `StyleInjector` for a clearer public-facing API name
- Adds a `nonce` option to `StyleInjector` for centralized CSP support across all injected `<style>` elements
- Refactors `Cursor` and `PreventSelection` to route their style injection through `StyleInjector` instead of creating `<style>` elements directly
- Removes the per-plugin `nonce` options from `Cursor`, `PreventSelection`, and `Feedback` (which declared it but never used it)

### Migration

Before:

```ts
const manager = new DragDropManager({
  plugins: (defaults) => [
    ...defaults,
    Cursor.configure({ nonce: 'abc123' }),
    PreventSelection.configure({ nonce: 'abc123' }),
  ],
});
```

After:

```ts
const manager = new DragDropManager({
  plugins: (defaults) => [
    ...defaults,
    StyleInjector.configure({ nonce: 'abc123' }),
  ],
});
```

## Test plan

- [ ] Verify drag operations work correctly (cursor changes, selection prevented, feedback styles applied)
- [ ] Verify CSP nonce is applied to all injected `<style>` elements when configured
- [ ] Verify Shadow DOM style injection still uses `adoptedStyleSheets`
