### PR TITLE
feat: add keyboardTransition option to Feedback plugin

### DIFF
--- a/.changeset/feedback-keyboard-transition.md
+++ b/.changeset/feedback-keyboard-transition.md
@@ -1,0 +1,13 @@
+---
+'@dnd-kit/dom': minor
+---
+
+Add `keyboardTransition` option to the `Feedback` plugin for customizing or disabling the CSS transition applied when moving elements via keyboard.
+
+By default, keyboard-driven moves animate with `250ms cubic-bezier(0.25, 1, 0.5, 1)`. You can now customize the `duration` and `easing`, or set the option to `null` to disable the transition entirely.
+
+```ts
+Feedback.configure({
+  keyboardTransition: { duration: 150, easing: 'ease-out' },
+})
+```

--- a/apps/docs/extend/plugins/feedback.mdx
+++ b/apps/docs/extend/plugins/feedback.mdx
@@ -102,6 +102,16 @@ function App() {
   - `DropAnimationFunction` — provide a fully custom animation function
 </ParamField>
 
+<ParamField path="keyboardTransition" type="KeyboardTransition | null">
+  Customize or disable the CSS transition applied when moving elements via keyboard.
+
+  By default, keyboard-driven moves animate with `250ms cubic-bezier(0.25, 1, 0.5, 1)`. This transition is automatically disabled when the user prefers reduced motion.
+
+  - `undefined` (default) — use the built-in keyboard transition
+  - `null` — disable the transition (moves are instant, like pointer operations)
+  - `{ duration, easing }` — customize the transition duration (in ms) and CSS easing function
+</ParamField>
+
 <ParamField path="rootElement" type="Element | ((source: Draggable) => Element)">
   An element (or a function returning one) to use as the root container for the dragged element. When set, the dragged element is moved into this container during the drag operation.
 </ParamField>

--- a/packages/dom/src/core/plugins/feedback/Feedback.ts
+++ b/packages/dom/src/core/plugins/feedback/Feedback.ts
@@ -35,9 +35,15 @@ import {
 } from './observers.ts';
 import {runDropAnimation, type DropAnimation} from './dropAnimation.ts';
 
+export interface KeyboardTransition {
+  duration?: number;
+  easing?: string;
+}
+
 export interface FeedbackOptions {
   rootElement?: Element | ((source: Draggable) => Element);
   dropAnimation?: DropAnimation | null;
+  keyboardTransition?: KeyboardTransition | null;
 }
 
 interface State {
@@ -454,9 +460,12 @@ export class Feedback extends Plugin<DragDropManager, FeedbackOptions> {
           const previousTranslate = state.current.translate;
           const modifiers = untracked(() => dragOperation.modifiers);
           const currentShape = untracked(() => dragOperation.shape?.current);
+          const keyboardTransition = options?.keyboardTransition;
           const translateTransition =
-            isKeyboardOperation && !reducedMotion
-              ? '250ms cubic-bezier(0.25, 1, 0.5, 1)'
+            isKeyboardOperation &&
+            !reducedMotion &&
+            keyboardTransition !== null
+              ? `${keyboardTransition?.duration ?? 250}ms ${keyboardTransition?.easing ?? 'cubic-bezier(0.25, 1, 0.5, 1)'}`
               : '0ms linear';
 
           styles.set(

--- a/packages/dom/src/core/plugins/feedback/index.ts
+++ b/packages/dom/src/core/plugins/feedback/index.ts
@@ -1,4 +1,5 @@
 export {Feedback} from './Feedback.ts';
+export type {KeyboardTransition} from './Feedback.ts';
 export type {Transition} from './types.ts';
 export type {
   DropAnimation,

--- a/packages/dom/src/core/plugins/index.ts
+++ b/packages/dom/src/core/plugins/index.ts
@@ -8,6 +8,7 @@ export type {
   DropAnimation,
   DropAnimationOptions,
   DropAnimationFunction,
+  KeyboardTransition,
 } from './feedback/index.ts';
 
 export {AutoScroller, Scroller, ScrollListener} from './scrolling/index.ts';


### PR DESCRIPTION
## Summary

- Adds a `keyboardTransition` option to the `Feedback` plugin, allowing consumers to customize or disable the CSS transition applied when moving elements via keyboard.
- The option accepts `{ duration, easing }` for customization, or `null` to disable the transition entirely (instant moves, like pointer operations).
- Defaults to the existing behavior: `250ms cubic-bezier(0.25, 1, 0.5, 1)`, automatically disabled when the user prefers reduced motion.
- Exports the new `KeyboardTransition` type from `@dnd-kit/dom`.
- Documents the new option on the Feedback plugin docs page.

## Test plan

- [ ] Verify default keyboard sorting transition is unchanged (250ms ease-out curve)
- [ ] Verify `keyboardTransition: null` makes keyboard moves instant
- [ ] Verify custom `{ duration: 500, easing: 'linear' }` applies correctly
- [ ] Verify `prefers-reduced-motion` still disables the transition regardless of the option