### PR TITLE
docs: fix imports in DragDropProvider example

### DIFF
--- a/apps/docs/react/components/drag-drop-provider.mdx
+++ b/apps/docs/react/components/drag-drop-provider.mdx
@@ -116,7 +116,8 @@ Pass an array to fully replace the defaults:
 
 ```jsx
 import {DragDropProvider} from '@dnd-kit/react';
-import {PointerSensor, KeyboardSensor} from '@dnd-kit/dom';
+import {PointerSensor, KeyboardSensor Accessibility, AutoScroller} from '@dnd-kit/dom';
+import {RestrictToWindow} from '@dnd-kit/dom/modifiers';
 
 function App() {
   return (


### PR DESCRIPTION
The example code was using Accessibility, AutoScroller, and RestrictToWindow without importing them. I added the missing imports and organized the import paths correctly to match the library structure.