### PR TITLE
fix: animation resolution uses last-wins semantics matching CSS composite order

### DIFF
--- a/.changeset/animation-last-wins.md
+++ b/.changeset/animation-last-wins.md
@@ -1,0 +1,5 @@
+---
+'@dnd-kit/dom': patch
+---
+
+Animation resolution now uses last-wins semantics matching CSS composite order. `getFinalKeyframe` returns the last matching keyframe across all running animations instead of short-circuiting on the first match. `getProjectedTransform` collects the latest value per CSS property (`transform`, `translate`, `scale`) rather than accumulating transforms additively.

--- a/packages/dom/src/utilities/animations/getFinalKeyframe.ts
+++ b/packages/dom/src/utilities/animations/getFinalKeyframe.ts
@@ -5,19 +5,18 @@ export function getFinalKeyframe(
   match: (keyframe: Keyframe) => boolean
 ): [Keyframe, Animation] | null {
   const animations = element.getAnimations();
+  let result: [Keyframe, Animation] | null = null;
 
-  if (animations.length > 0) {
-    for (const animation of animations) {
-      if (animation.playState !== 'running') continue;
-      const {effect} = animation;
-      const keyframes = isKeyframeEffect(effect) ? effect.getKeyframes() : [];
-      const matchedKeyframes = keyframes.filter(match);
+  for (const animation of animations) {
+    if (animation.playState !== 'running') continue;
+    const {effect} = animation;
+    const keyframes = isKeyframeEffect(effect) ? effect.getKeyframes() : [];
+    const matchedKeyframes = keyframes.filter(match);
 
-      if (matchedKeyframes.length > 0) {
-        return [matchedKeyframes[matchedKeyframes.length - 1], animation];
-      }
+    if (matchedKeyframes.length > 0) {
+      result = [matchedKeyframes[matchedKeyframes.length - 1], animation];
     }
   }
 
-  return null;
+  return result;
 }


### PR DESCRIPTION
## Summary

- `getFinalKeyframe` now returns the last matching keyframe across all running animations instead of short-circuiting on the first match
- `getProjectedTransform` rewritten to collect the latest value per CSS property (`transform`, `translate`, `scale`) from animations sorted by composite order, rather than accumulating transforms additively

### Why last-wins?

`element.getAnimations()` returns animations sorted by [composite order](https://drafts.csswg.org/web-animations-1/#animation-composite-order) (oldest first). When multiple animations target the same CSS property with `composite: "replace"` (the [default](https://developer.mozilla.org/en-US/docs/Web/CSS/animation-composition)), the last one in composite order wins — its effect value replaces everything before it. The previous approach of accumulating all transforms additively was incorrect for this default case.

The new approach iterates forward through the composite-ordered array and overwrites per-property, so the final value for each property reflects the highest-priority animation.

### Spec references

- [`element.getAnimations()`](https://drafts.csswg.org/web-animations-1/#dom-animatable-getanimations) — returns animations sorted by composite order
- [CSS Animations Level 2 §2.2 — Animation composite order](https://drafts.csswg.org/css-animations-2/#animation-composite-order) — defines ordering: CSS Transitions → CSS Animations → Web Animations API (by creation order in the [global animation list](https://drafts.csswg.org/web-animations-1/#global-animation-list))
- [`animation-composition`](https://developer.mozilla.org/en-US/docs/Web/CSS/animation-composition) — `replace` (default) means the last animation in composite order wins for a given property

### Caveats

- This implementation assumes `composite: "replace"` (the default). Animations using `composite: "add"` or `"accumulate"` would need additive/accumulative combining rather than per-property overwrite. This is a niche case not currently relevant to dnd-kit's usage.

## Test plan

- Verify drag-and-drop animations resolve correctly when multiple animations are running on the same element
- Verify FLIP animations during sorting produce correct deltas