### PR TITLE
feat: full CSS transform support in Feedback plugin

### DIFF
--- a/.changeset/feedback-transform-support.md
+++ b/.changeset/feedback-transform-support.md
@@ -1,0 +1,5 @@
+---
+'@dnd-kit/dom': minor
+---
+
+The Feedback plugin now supports full CSS `transform` property for compatibility with libraries like react-window v2 that position elements via transforms. Transform-related CSS transitions are filtered out to prevent conflicts with Feedback-managed properties. The ResizeObserver computes shapes from CSS values rather than re-measuring the element, avoiding mid-transition measurement errors. Sortable's `animate()` cancels CSS transitions on transform-related properties before measuring to ensure correct FLIP deltas.

--- a/packages/dom/src/core/plugins/feedback/Feedback.ts
+++ b/packages/dom/src/core/plugins/feedback/Feedback.ts
@@ -10,6 +10,7 @@ import {
   isHTMLElement,
   prefersReducedMotion,
   isKeyboardEvent,
+  parseTransform,
   parseTranslate,
   showPopover,
   Styles,
@@ -159,6 +160,7 @@ export class Feedback extends Plugin<DragDropManager, FeedbackOptions> {
     }
 
     const styles = new Styles(feedbackElement);
+    const elementStyles = getComputedStyles(element);
     const {
       transition,
       translate,
@@ -171,7 +173,20 @@ export class Feedback extends Plugin<DragDropManager, FeedbackOptions> {
       borderInlineEndWidth,
       borderBlockStartWidth,
       borderBlockEndWidth,
-    } = getComputedStyles(element);
+    } = elementStyles;
+    // Filter out transform-related transitions that would interfere with
+    // Feedback-managed properties (--dnd-transform, --dnd-translate, --dnd-scale)
+    const feedbackTransition = transition
+      .split(',')
+      .filter((t) => !/^\s*(transform|translate|scale)\b/.test(t))
+      .join(',');
+    const parsedTransform = parseTransform(elementStyles);
+    // Eagerly capture the raw transform CSS value before the
+    // data-dnd-dragging attribute is set, since elementStyles is a live
+    // CSSStyleDeclaration and the CSS rule for [data-dnd-dragging] overrides
+    // transform via !important, which would cause the live object to return
+    // the overridden value instead of the original.
+    const initialTransformStyle = elementStyles.transform;
     const clone = feedback === 'clone';
     const contentBox = boxSizing === 'content-box';
     const widthOffset = contentBox
@@ -195,23 +210,38 @@ export class Feedback extends Plugin<DragDropManager, FeedbackOptions> {
       isKeyboardEvent(manager.dragOperation.activatorEvent)
     );
 
-    if (translate !== 'none') {
-      const parsedTranslate = parseTranslate(translate);
+    if (!initial.translate) {
+      if (this.overlay && parsedTransform) {
+        // When using an overlay, capture the full translation from both
+        // the CSS `translate` and `transform` properties, since the overlay
+        // element does not inherit the source element's `transform` property.
+        // This is needed for libraries like react-window v2 that use CSS
+        // `transform: translateY()` for positioning.
+        initial.translate = {x: parsedTransform.x, y: parsedTransform.y};
+      } else if (translate !== 'none') {
+        const parsedTranslate = parseTranslate(translate);
 
-      if (parsedTranslate && !initial.translate) {
-        initial.translate = parsedTranslate;
+        if (parsedTranslate) {
+          initial.translate = parsedTranslate;
+        }
       }
     }
 
     if (!initial.transformOrigin) {
       const current = untracked(() => position.current);
 
+      // Use the visual position (including transforms) since the cursor
+      // position is in screen coordinates. The shape's top/left have transforms
+      // stripped (ignoreTransforms), so we add them back for this calculation.
+      const visualLeft = left + (parsedTransform?.x ?? 0);
+      const visualTop = top + (parsedTransform?.y ?? 0);
+
       initial.transformOrigin = {
         x:
-          (current.x - left * frameTransform.scaleX - frameTransform.x) /
+          (current.x - visualLeft * frameTransform.scaleX - frameTransform.x) /
           (width * frameTransform.scaleX),
         y:
-          (current.y - top * frameTransform.scaleY - frameTransform.y) /
+          (current.y - visualTop * frameTransform.scaleY - frameTransform.y) /
           (height * frameTransform.scaleY),
       };
     }
@@ -288,7 +318,10 @@ export class Feedback extends Plugin<DragDropManager, FeedbackOptions> {
         top: projected.top + fixedOffset.y,
         left: projected.left + fixedOffset.x,
         translate: `${tX}px ${tY}px 0`,
-        transition: transition ? `${transition}, translate 0ms linear` : '',
+        transform: this.overlay ? 'none' : initialTransformStyle,
+        transition: feedbackTransition
+          ? `${feedbackTransition}, translate 0ms linear`
+          : 'translate 0ms linear',
         scale: crossFrame ? `${scaleDelta.x} ${scaleDelta.y}` : '',
         'transform-origin': `${transformOrigin.x * 100}% ${transformOrigin.y * 100}%`,
       },
@@ -341,6 +374,7 @@ export class Feedback extends Plugin<DragDropManager, FeedbackOptions> {
       delta,
       styles,
       dragOperation,
+      getTranslate: () => state.current.translate,
       getElementMutationObserver: () => elementMutationObserver,
       getSavedCellWidths: () => savedCellWidths,
       setSavedCellWidths: (widths) => {
@@ -424,10 +458,11 @@ export class Feedback extends Plugin<DragDropManager, FeedbackOptions> {
       source.status = 'idle';
 
       const moved = state.current.translate != null;
+      const isDragging = dragOperation.status.dragging;
 
       if (
         placeholder &&
-        (moved ||
+        ((!isDragging && moved) ||
           placeholder.parentElement !== feedbackElement.parentElement) &&
         feedbackElement.isConnected
       ) {
@@ -470,7 +505,9 @@ export class Feedback extends Plugin<DragDropManager, FeedbackOptions> {
 
           styles.set(
             {
-              transition: `${transition}, translate ${translateTransition}`,
+              transition: feedbackTransition
+                ? `${feedbackTransition}, translate ${translateTransition}`
+                : `translate ${translateTransition}`,
               translate: `${translate.x}px ${translate.y}px 0`,
             },
             CSS_PREFIX

--- a/packages/dom/src/core/plugins/feedback/constants.ts
+++ b/packages/dom/src/core/plugins/feedback/constants.ts
@@ -29,6 +29,7 @@ export const CSS_RULES = `
     max-width: var(${CSS_PREFIX}width, auto);
     height: var(${CSS_PREFIX}height, auto);
     max-height: var(${CSS_PREFIX}height, auto);
+    transform: var(${CSS_PREFIX}transform, none) !important;
     transition: var(${CSS_PREFIX}transition) !important;
   }
 

--- a/packages/dom/src/sortable/sortable.ts
+++ b/packages/dom/src/sortable/sortable.ts
@@ -230,6 +230,21 @@ export class Sortable<T extends Data = Data> {
           return;
         }
 
+        // Cancel CSS transitions on transform-related properties before measuring.
+        // These transitions (e.g. `transition: transform` from user CSS) would cause
+        // getBoundingClientRect() to return the mid-transition position rather than
+        // the element's final resting position, resulting in an incorrect delta.
+        for (const animation of element.getAnimations()) {
+          if (
+            'transitionProperty' in animation &&
+            (animation.transitionProperty === 'transform' ||
+              animation.transitionProperty === 'translate' ||
+              animation.transitionProperty === 'scale')
+          ) {
+            animation.cancel();
+          }
+        }
+
         const updatedShape = this.refreshShape();
 
         if (!updatedShape) {


### PR DESCRIPTION
## Summary

- The Feedback plugin now supports full CSS `transform` property for compatibility with libraries like react-window v2 that position elements via transforms
- Transform-related CSS transitions (`transform`, `translate`, `scale`) are filtered out of the feedback element to prevent conflicts with Feedback-managed properties
- Transform offsets are now accounted for in `transformOrigin` calculations (visual position includes transform offsets since cursor coordinates are in screen space)
- The ResizeObserver computes shapes from CSS values rather than re-measuring the element, avoiding mid-transition measurement errors
- Sortable `animate()` cancels CSS transitions on transform-related properties before measuring to ensure correct FLIP deltas

## Test plan

- Verify drag-and-drop works with elements positioned via CSS `transform` (e.g. react-window v2 style `transform: translateY(...)`)
- Verify the dragged element appears at the correct position (not offset by the CSS transform amount)
- Verify sorting animations are smooth without fighting CSS transitions
- Test in Safari specifically for transform/transition conflicts