### PR TITLE
docs: add manager param to event handler signatures

### DIFF
--- a/apps/docs/react/components/drag-drop-provider.mdx
+++ b/apps/docs/react/components/drag-drop-provider.mdx
@@ -116,8 +116,7 @@ Pass an array to fully replace the defaults:
 
 ```jsx
 import {DragDropProvider} from '@dnd-kit/react';
-import {PointerSensor, KeyboardSensor Accessibility, AutoScroller} from '@dnd-kit/dom';
-import {RestrictToWindow} from '@dnd-kit/dom/modifiers';
+import {PointerSensor, KeyboardSensor} from '@dnd-kit/dom';
 
 function App() {
   return (
@@ -154,27 +153,27 @@ function App() {
 
 ### Events
 
-<ParamField path="onBeforeDragStart" type="(event: BeforeDragStartEvent) => void">
+<ParamField path="onBeforeDragStart" type="(event: BeforeDragStartEvent, manager: DragDropManager) => void">
   Called before dragging starts. Call `event.preventDefault()` to cancel.
 </ParamField>
 
-<ParamField path="onDragStart" type="(event: DragStartEvent) => void">
+<ParamField path="onDragStart" type="(event: DragStartEvent, manager: DragDropManager) => void">
   Called when dragging begins.
 </ParamField>
 
-<ParamField path="onDragMove" type="(event: DragMoveEvent) => void">
+<ParamField path="onDragMove" type="(event: DragMoveEvent, manager: DragDropManager) => void">
   Called when the dragged element moves.
 </ParamField>
 
-<ParamField path="onDragOver" type="(event: DragOverEvent) => void">
+<ParamField path="onDragOver" type="(event: DragOverEvent, manager: DragDropManager) => void">
   Called when dragging over a droppable target. Call `event.preventDefault()` to prevent the default behavior of plugins that respond to this event.
 </ParamField>
 
-<ParamField path="onDragEnd" type="(event: DragEndEvent) => void">
+<ParamField path="onDragEnd" type="(event: DragEndEvent, manager: DragDropManager) => void">
   Called when dragging ends, whether dropped on a target or not.
 </ParamField>
 
-<ParamField path="onCollision" type="(event: CollisionEvent) => void">
+<ParamField path="onCollision" type="(event: CollisionEvent, manager: DragDropManager) => void">
   Called when collisions are detected. Call `event.preventDefault()` to prevent automatic target selection.
 </ParamField>
 


### PR DESCRIPTION
## Summary

- Update DragDropProvider event handler documentation to include the `manager` parameter in the type signatures (e.g. `(event: DragStartEvent, manager: DragDropManager) => void`)

## Test plan

- Docs-only change, no runtime impact