### PR TITLE
fix: batch entity id changes to prevent collision oscillation

### DIFF
--- a/.changeset/entity-batched-id-changes.md
+++ b/.changeset/entity-batched-id-changes.md
@@ -1,0 +1,12 @@
+---
+'@dnd-kit/abstract': minor
+'@dnd-kit/dom': minor
+---
+
+Batch entity identity changes to prevent collision oscillation during virtualized sorting.
+
+When entities swap ids (e.g. as `react-window` recycles DOM nodes during a drag), multiple registry updates could fire in an interleaved order, causing the collision detector to momentarily see stale or duplicate entries and oscillate between targets.
+
+Entity `id` changes are now deferred to a microtask and flushed atomically in a single `batch()`, ensuring:
+- The collision notifier skips detection while id changes are pending
+- The registry cleans up ghost registrations (stale keys left behind after an id swap)

--- a/packages/abstract/src/core/collision/notifier.ts
+++ b/packages/abstract/src/core/collision/notifier.ts
@@ -1,5 +1,6 @@
 import {effects, untracked} from '@dnd-kit/state';
 
+import {Entity} from '../entities/index.ts';
 import {DragDropManager} from '../manager/index.ts';
 import {CorePlugin} from '../plugins/index.ts';
 import {defaultPreventable} from '../manager/events.ts';
@@ -29,6 +30,10 @@ export class CollisionNotifier extends CorePlugin {
         const {collisions} = collisionObserver;
 
         if (collisionObserver.isDisabled()) {
+          return;
+        }
+
+        if (Entity.pendingIdChanges) {
           return;
         }
 

--- a/packages/abstract/src/core/manager/operation.ts
+++ b/packages/abstract/src/core/manager/operation.ts
@@ -122,7 +122,9 @@ export class DragOperation<T extends Draggable, U extends Droppable>
   /**
    * Gets the source draggable entity.
    *
-   * @returns The current draggable entity or the previous one if the current is not found
+   * @returns The current draggable entity, falling back to the previous
+   * instance to bridge the gap when React unmounts and remounts a sortable
+   * during reparenting (e.g. moving an item between columns).
    */
   @derived
   public get source(): T | null {

--- a/packages/dom/src/sortable/sortable.ts
+++ b/packages/dom/src/sortable/sortable.ts
@@ -366,10 +366,8 @@ export class Sortable<T extends Data = Data> {
   }
 
   public set id(id: UniqueIdentifier) {
-    batch(() => {
-      this.droppable.id = id;
-      this.draggable.id = id;
-    });
+    this.droppable.id = id;
+    this.draggable.id = id;
   }
 
   public get id() {


### PR DESCRIPTION
## Summary

- **Deferred entity id changes**: `Entity.id` setter now queues changes to a microtask and flushes them atomically via `batch()`, ensuring that when entities swap ids (e.g. during virtualized sorting where `react-window` recycles DOM nodes), all registry updates happen in a single transaction.

- **Collision notifier guard**: `CollisionNotifier` skips collision detection while entity id changes are pending, preventing oscillation from stale/interleaved registry state.

- **Registry ghost cleanup**: `EntityRegistry.register()` now removes stale entries when an entity re-registers under a new key, preventing ghost registrations left behind after an id swap.

## Files changed

| File | Change |
|------|--------|
| `packages/abstract/src/core/entities/entity/entity.ts` | Deferred id signal with `pendingIdChanges` static map |
| `packages/abstract/src/core/entities/entity/registry.ts` | Ghost registration cleanup + conditional unregister |
| `packages/abstract/src/core/collision/notifier.ts` | Skip collision detection during pending id changes |
| `packages/abstract/src/core/manager/operation.ts` | Keep `#previousSource` fallback for React reparenting gap |

## Test plan

- [ ] Verify basic drag-and-drop still works (non-virtualized lists)
- [ ] Verify sorting in virtualized lists (react-window) does not cause collision oscillation
- [ ] Verify reparenting between columns (MultipleLists) still animates correctly
- [ ] Verify keyboard-driven sorting still works
- [ ] Verify sorting across multiple groups still works
- [ ] Run existing e2e test suite