### PR TITLE
fix: defer flushSync in useDeepSignal to avoid React lifecycle violation

### DIFF
--- a/.changeset/use-deep-signal-flush-sync.md
+++ b/.changeset/use-deep-signal-flush-sync.md
@@ -1,0 +1,7 @@
+---
+'@dnd-kit/react': patch
+---
+
+Fix `useDeepSignal` calling `flushSync` from within a React lifecycle method.
+
+When signal updates are triggered synchronously from a React effect (e.g. during a `useEffect` batch), calling `flushSync` directly violates React's internal invariant. The synchronous re-render is now deferred to a microtask via `queueMicrotask`, which runs after the current React batch completes but before the next paint.

--- a/packages/react/src/hooks/useDeepSignal.ts
+++ b/packages/react/src/hooks/useDeepSignal.ts
@@ -36,7 +36,14 @@ export function useDeepSignal<T extends object | null | undefined>(
       }
 
       if (stale) {
-        sync ? flushSync(forceUpdate) : forceUpdate();
+        if (sync) {
+          // Defer flushSync to a microtask to avoid calling it from within
+          // a React lifecycle method (e.g. useEffect batch), which happens when
+          // signal updates are triggered synchronously from a React effect
+          queueMicrotask(() => flushSync(forceUpdate));
+        } else {
+          forceUpdate();
+        }
       }
     });
   }, [target]);


### PR DESCRIPTION
## Summary

- **Deferred `flushSync`**: When `useDeepSignal` detects a stale signal value that requires a synchronous re-render, it now defers the `flushSync(forceUpdate)` call to a `queueMicrotask` instead of calling it inline.

- **Why**: Signal updates can fire synchronously during a React effect batch (e.g. when entity id changes trigger signal effects that propagate to `useDeepSignal`). Calling `flushSync` from within a React lifecycle method violates React's internal invariant and produces a warning. The microtask runs after the current React batch completes but before the next paint, preserving the synchronous rendering semantics.

## Files changed

| File | Change |
|------|--------|
| `packages/react/src/hooks/useDeepSignal.ts` | Wrap `flushSync` in `queueMicrotask` |

## Test plan

- [ ] Verify no React `flushSync` warnings in console during drag operations
- [ ] Verify synchronous re-renders still happen promptly (no visual lag)
- [ ] Verify sortable animations still work correctly