### PR TITLE
fix: abort activation controller on cleanup to prevent stale pointer capture

### DIFF
--- a/.changeset/fix-pointer-sensor-stale-activation.md
+++ b/.changeset/fix-pointer-sensor-stale-activation.md
@@ -1,0 +1,7 @@
+---
+'@dnd-kit/dom': patch
+---
+
+Fixed `setPointerCapture` error on touch devices caused by stale pointer activation.
+
+When a touch was released during the activation delay and followed by a quick re-touch, the pending delay timer from the first touch could fire with a stale `pointerId`, causing `setPointerCapture` to throw. The `PointerSensor` now properly aborts the activation controller during cleanup to cancel pending delay timers, and defensively handles `setPointerCapture` failures.

--- a/packages/dom/src/core/sensors/pointer/PointerSensor.ts
+++ b/packages/dom/src/core/sensors/pointer/PointerSensor.ts
@@ -333,7 +333,12 @@ export class PointerSensor extends Sensor<
     const ownerDocument = getDocument(event.target);
     const pointerCaptureTarget = ownerDocument.body;
 
-    pointerCaptureTarget.setPointerCapture(event.pointerId);
+    try {
+      pointerCaptureTarget.setPointerCapture(event.pointerId);
+    } catch {
+      this.handleCancel(event);
+      return;
+    }
 
     const listenerTargets = isElement(event.target)
       ? [event.target, pointerCaptureTarget]
@@ -377,6 +382,13 @@ export class PointerSensor extends Sensor<
   }
 
   protected cleanup() {
+    const {controller} = this;
+    this.controller = undefined;
+
+    if (controller && !controller.signal.aborted) {
+      controller.abort();
+    }
+
     this.latest = {
       event: undefined,
       coordinates: undefined,

--- a/packages/dom/tests/pointer-sensor.test.ts
+++ b/packages/dom/tests/pointer-sensor.test.ts
@@ -1,0 +1,81 @@
+import {describe, expect, it, jest} from 'bun:test';
+import {ActivationController} from '@dnd-kit/abstract';
+
+import {DelayConstraint} from '../src/core/sensors/pointer/DelayConstraint.ts';
+
+function createPointerEvent(
+  type: string,
+  options: Partial<PointerEvent> = {}
+): PointerEvent {
+  return {
+    type,
+    pointerId: 1,
+    clientX: 0,
+    clientY: 0,
+    ...options,
+  } as unknown as PointerEvent;
+}
+
+describe('ActivationController with DelayConstraint', () => {
+  it('should activate after the delay elapses', async () => {
+    const onActivate = jest.fn();
+    const constraint = new DelayConstraint({value: 50, tolerance: 5});
+    const controller = new ActivationController([constraint], onActivate);
+
+    controller.onEvent(createPointerEvent('pointerdown'));
+
+    expect(onActivate).not.toHaveBeenCalled();
+
+    await new Promise((resolve) => setTimeout(resolve, 80));
+
+    expect(onActivate).toHaveBeenCalledTimes(1);
+  });
+
+  it('should cancel pending activation when the controller is aborted', async () => {
+    const onActivate = jest.fn();
+    const constraint = new DelayConstraint({value: 50, tolerance: 5});
+    const controller = new ActivationController([constraint], onActivate);
+
+    controller.onEvent(createPointerEvent('pointerdown'));
+
+    expect(onActivate).not.toHaveBeenCalled();
+
+    controller.abort();
+
+    await new Promise((resolve) => setTimeout(resolve, 80));
+
+    expect(onActivate).not.toHaveBeenCalled();
+    expect(controller.signal.aborted).toBe(true);
+  });
+
+  it('should not activate if aborted just before the delay elapses', async () => {
+    const onActivate = jest.fn();
+    const constraint = new DelayConstraint({value: 50, tolerance: 5});
+    const controller = new ActivationController([constraint], onActivate);
+
+    controller.onEvent(createPointerEvent('pointerdown'));
+
+    await new Promise((resolve) => setTimeout(resolve, 40));
+
+    expect(onActivate).not.toHaveBeenCalled();
+
+    controller.abort();
+
+    await new Promise((resolve) => setTimeout(resolve, 30));
+
+    expect(onActivate).not.toHaveBeenCalled();
+  });
+
+  it('should cancel activation when pointerup arrives before the delay', async () => {
+    const onActivate = jest.fn();
+    const constraint = new DelayConstraint({value: 100, tolerance: 5});
+    const controller = new ActivationController([constraint], onActivate);
+
+    controller.onEvent(createPointerEvent('pointerdown'));
+    controller.onEvent(createPointerEvent('pointerup'));
+
+    await new Promise((resolve) => setTimeout(resolve, 150));
+
+    expect(onActivate).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

- Fixes a race condition on touch devices where `setPointerCapture` throws `"No active pointer with the given id is found"` during rapid touch-release-touch sequences.
- The `PointerSensor`'s `cleanup()` method did not abort the `ActivationController`, so the `DelayConstraint`'s `setTimeout` (250ms for touch) kept running after the pointer was released. If the user re-touched before the old timer fired, `handleStart` would be called with a stale `pointerId` from the first touch.
- Two fixes applied:
  1. **Primary**: `cleanup()` now aborts the `ActivationController`, which cascades to cancel pending `DelayConstraint` timers via the abort signal.
  2. **Defensive**: `setPointerCapture` is wrapped in try-catch. If it fails (pointer no longer active), the drag operation is cleanly cancelled.

Fixes #1913

## Test plan

- [x] Added tests verifying `DelayConstraint` timer cancellation when the controller is aborted
- [x] Added test for abort-before-delay-elapses edge case
- [x] Added test for pointerup-during-delay cancellation
- [x] All existing tests pass (17/17 in `@dnd-kit/dom`)