### PR TITLE
fix: remove inherited body padding in iframe story

### DIFF
--- a/apps/stories/stories/react/Sortable/Iframe/IframeExample.tsx
+++ b/apps/stories/stories/react/Sortable/Iframe/IframeExample.tsx
@@ -91,7 +91,7 @@ export function IframeLists({
 
           <style
             dangerouslySetInnerHTML={{
-              __html: 'body { background: transparent; margin: 0 !important; }',
+              __html: 'body { background: transparent; margin: 0 !important; padding: 0 !important; }',
             }}
           />
           <div className={bodyClassName}>


### PR DESCRIPTION
## Summary

- Fixes misaligned sortable items in the Iframe storybook story caused by Storybook's default `padding: 1rem` on `body` being inherited into the iframe via `auto-frame-component`.
- Adds `padding: 0 !important` alongside the existing `margin: 0 !important` reset in the iframe's inline style.

## Test plan

- [x] Visual verification — iframe list items should align flush with the container, matching the host list