### PR TITLE
fix(dom): reposition Feedback placeholder when siblings move around source

### DIFF
--- a/.changeset/feedback-placeholder-sibling-reorder.md
+++ b/.changeset/feedback-placeholder-sibling-reorder.md
@@ -1,0 +1,7 @@
+---
+'@dnd-kit/dom': patch
+---
+
+Fix Feedback plugin placeholder not repositioning when siblings are moved around a stationary source element.
+
+When a VDOM framework (e.g., Preact, Vue) reorders sibling elements during a drag operation, the source element and placeholder may remain in the DOM but no longer be adjacent. The existing `documentMutationObserver` only handled cases where the source or placeholder itself was re-added to the DOM. This adds a fallback adjacency check after processing all mutation entries, ensuring the placeholder stays next to the source element regardless of how siblings are rearranged.

--- a/packages/dom/src/core/plugins/feedback/observers.ts
+++ b/packages/dom/src/core/plugins/feedback/observers.ts
@@ -114,6 +114,19 @@ export function createDocumentMutationObserver(
         }
       }
     }
+
+    // Handle the case where siblings were moved around a stationary
+    // source element (e.g., a VDOM framework reordered children).
+    // The addedNodes won't contain the element or placeholder, but
+    // they may no longer be adjacent.
+    if (
+      element.isConnected &&
+      placeholder.isConnected &&
+      element.nextElementSibling !== placeholder
+    ) {
+      element.insertAdjacentElement('afterend', placeholder);
+      showPopover(feedbackElement);
+    }
   });
 
   observer.observe(element.ownerDocument.body, {


### PR DESCRIPTION
## Summary

Fixes an issue where the Feedback plugin's placeholder gets stranded when a VDOM framework (e.g., Preact, Vue) reorders sibling elements around a stationary source during drag.

### Problem

The `documentMutationObserver` in the Feedback plugin checks `addedNodes` to detect when the source element or placeholder is re-added to the DOM and repositions them to stay adjacent. However, when a framework reorders *siblings* (moving `<p>` and `<a>` around a stationary `<h1>` source), neither the source nor the placeholder appears in `addedNodes`. The observer fires but takes no action, leaving the placeholder at its old position.

This causes:
- Incorrect layout (placeholder not adjacent to source)
- Broken collision detection (droppable shapes at wrong positions)
- Oscillating or skipped sort targets during drag

### Fix

After processing all mutation entries, add a fallback adjacency check: if the source and placeholder are both connected to the DOM but no longer adjacent, reposition the placeholder after the source element.

## Test plan

- [x] Drag reorder in a Preact/Vue app where the framework handles DOM reconciliation (not OptimisticSortingPlugin)
- [x] Verify placeholder stays adjacent to source after each swap
- [x] Verify collision detection works correctly in both directions (drag down then back up)
- [x] Existing React sortable stories still work correctly


🤖 Generated with [Claude Code](https://claude.com/claude-code)