### PR TITLE
Fix sortable type narrowing and re-export Vue drag event types

### DIFF
--- a/.changeset/fix-vue-sortable-type-narrowing.md
+++ b/.changeset/fix-vue-sortable-type-narrowing.md
@@ -1,0 +1,6 @@
+---
+'@dnd-kit/dom': patch
+'@dnd-kit/vue': patch
+---
+
+Fix sortable type narrowing so `isSortable(event.operation.source)` narrows to a sortable draggable with access to `initialIndex`, and re-export the drag event type aliases from `@dnd-kit/vue`.

--- a/apps/docs/vue/composables/use-sortable.mdx
+++ b/apps/docs/vue/composables/use-sortable.mdx
@@ -34,15 +34,15 @@ If you need more control over state updates, you can manage state manually using
 With [optimistic sorting](/concepts/sortable#optimistic-sorting) enabled (the default), you only need to handle the `dragEnd` event:
 
 ```vue
-<script setup>
+<script setup lang="ts">
 import { ref } from 'vue';
-import { DragDropProvider } from '@dnd-kit/vue';
+import { DragDropProvider, type DragEndEvent } from '@dnd-kit/vue';
 import { isSortable } from '@dnd-kit/vue/sortable';
 import SortableItem from './SortableItem.vue';
 
 const items = ref([1, 2, 3, 4]);
 
-function onDragEnd(event) {
+function onDragEnd(event: DragEndEvent) {
   if (event.canceled) return;
 
   const { source } = event.operation;

--- a/packages/dom/src/sortable/utilities.ts
+++ b/packages/dom/src/sortable/utilities.ts
@@ -4,6 +4,12 @@ import type {Droppable, Draggable} from '@dnd-kit/dom';
 import {SortableDroppable, SortableDraggable} from './sortable.ts';
 
 export function isSortable(
+  element: Draggable | null
+): element is SortableDraggable<any>;
+export function isSortable(
+  element: Droppable | null
+): element is SortableDroppable<any>;
+export function isSortable(
   element: Draggable | Droppable | null
 ): element is SortableDroppable<any> | SortableDraggable<any> {
   return (

--- a/packages/vue/src/core/index.ts
+++ b/packages/vue/src/core/index.ts
@@ -29,4 +29,12 @@ export {useDragOperation} from './hooks/useDragOperation.ts';
 export {useInstance} from './hooks/useInstance.ts';
 
 export {KeyboardSensor, PointerSensor} from '@dnd-kit/dom';
-export type {DragDropManager} from '@dnd-kit/dom';
+export type {
+  BeforeDragStartEvent,
+  CollisionEvent,
+  DragDropManager,
+  DragEndEvent,
+  DragMoveEvent,
+  DragOverEvent,
+  DragStartEvent,
+} from '@dnd-kit/dom';


### PR DESCRIPTION
- add `isSortable` overloads so `event.operation.source` narrows to sortable types
- re-export drag event type aliases from `@dnd-kit/vue`
- update Vue `useSortable` docs example to use typed `DragEndEvent`