### PR TITLE
fix(dom): rewrite scrollIntoViewIfNeeded with manual offset calculations

### DIFF
--- a/.changeset/scroll-into-view-rewrite.md
+++ b/.changeset/scroll-into-view-rewrite.md
@@ -1,5 +1,5 @@
 ---
-'@dnd-kit/dom': patch
+'@dnd-kit/dom': minor
 ---
 
-Rewrite `scrollIntoViewIfNeeded` with manual scroll calculations for more predictable behavior in nested scroll containers.
+Rewrite `scrollIntoViewIfNeeded` with manual offset calculations for correct behavior in nested scroll containers. The `centerIfNeeded` boolean parameter has been replaced with an options object accepting `block` and `inline` properties (`'center'`, `'nearest'`, or `'none'`).

--- a/apps/stories-solid/stories/Sortable/Horizontal/Horizontal.stories.tsx
+++ b/apps/stories-solid/stories/Sortable/Horizontal/Horizontal.stories.tsx
@@ -23,3 +23,12 @@ export const BasicSetup: Story = {
     },
   },
 };
+
+export const NestedScroll: Story = {
+  name: 'Nested scroll',
+  render: () => (
+    <div style={{width: '100vw', 'overflow-x': 'auto', 'margin-left': '50vw'}}>
+      <App />
+    </div>
+  ),
+};

--- a/apps/stories-solid/stories/Sortable/Vertical/Vertical.stories.tsx
+++ b/apps/stories-solid/stories/Sortable/Vertical/Vertical.stories.tsx
@@ -50,3 +50,12 @@ export const WithDragHandle: Story = {
     },
   },
 };
+
+export const NestedScroll: Story = {
+  name: 'Nested scroll',
+  render: () => (
+    <div style={{height: '100vh', 'overflow-y': 'auto', 'margin-top': '50vh'}}>
+      <App />
+    </div>
+  ),
+};

--- a/apps/stories-svelte/stories/Sortable/Horizontal/Horizontal.stories.ts
+++ b/apps/stories-svelte/stories/Sortable/Horizontal/Horizontal.stories.ts
@@ -3,6 +3,7 @@ import type {Meta, StoryObj} from '@storybook/svelte-vite';
 import HorizontalSortableApp from './HorizontalSortableApp.svelte';
 import horizontalSortableSource from './HorizontalSortableApp.svelte?raw';
 import horizontalSortableItemSource from './HorizontalSortableItem.svelte?raw';
+import NestedScrollHorizontalSortableApp from './NestedScrollHorizontalSortableApp.svelte';
 import {
   baseStyles,
   sortableStyles,
@@ -27,4 +28,9 @@ export const BasicSetup: Story = {
       },
     },
   },
+};
+
+export const NestedScroll: Story = {
+  name: 'Nested scroll',
+  render: () => ({Component: NestedScrollHorizontalSortableApp}),
 };

--- a/apps/stories-svelte/stories/Sortable/Horizontal/NestedScrollHorizontalSortableApp.svelte
+++ b/apps/stories-svelte/stories/Sortable/Horizontal/NestedScrollHorizontalSortableApp.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+  import HorizontalSortableApp from './HorizontalSortableApp.svelte';
+</script>
+
+<div style="width: 100vw; overflow-x: auto; margin-left: 50vw">
+  <HorizontalSortableApp />
+</div>

--- a/apps/stories-svelte/stories/Sortable/NestedScrollSortableApp.svelte
+++ b/apps/stories-svelte/stories/Sortable/NestedScrollSortableApp.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+  import SortableApp from './SortableApp.svelte';
+</script>
+
+<div style="height: 100vh; overflow-y: auto; margin-top: 50vh">
+  <SortableApp />
+</div>

--- a/apps/stories-svelte/stories/Sortable/Vertical/Vertical.stories.ts
+++ b/apps/stories-svelte/stories/Sortable/Vertical/Vertical.stories.ts
@@ -6,6 +6,7 @@ import sortableItemSource from '../SortableItem.svelte?raw';
 import SortableDragHandleApp from '../SortableDragHandleApp.svelte';
 import sortableDragHandleSource from '../SortableDragHandleApp.svelte?raw';
 import sortableItemWithHandleSource from '../SortableItemWithHandle.svelte?raw';
+import NestedScrollSortableApp from '../NestedScrollSortableApp.svelte';
 import {
   baseStyles,
   handleStyles,
@@ -47,4 +48,9 @@ export const WithDragHandle: Story = {
       },
     },
   },
+};
+
+export const NestedScroll: Story = {
+  name: 'Nested scroll',
+  render: () => ({Component: NestedScrollSortableApp}),
 };

--- a/apps/stories-vanilla/stories/Sortable/Horizontal/Horizontal.stories.ts
+++ b/apps/stories-vanilla/stories/Sortable/Horizontal/Horizontal.stories.ts
@@ -23,3 +23,17 @@ export const BasicSetup: Story = {
     },
   },
 };
+
+export const NestedScroll: Story = {
+  name: 'Nested scroll',
+  render: () => {
+    const wrapper = document.createElement('div');
+    Object.assign(wrapper.style, {
+      width: '100vw',
+      overflowX: 'auto',
+      marginLeft: '50vw',
+    });
+    wrapper.appendChild(App());
+    return wrapper;
+  },
+};

--- a/apps/stories-vanilla/stories/Sortable/Sortable.stories.ts
+++ b/apps/stories-vanilla/stories/Sortable/Sortable.stories.ts
@@ -23,3 +23,17 @@ export const BasicSetup: Story = {
     },
   },
 };
+
+export const NestedScroll: Story = {
+  name: 'Nested scroll',
+  render: () => {
+    const wrapper = document.createElement('div');
+    Object.assign(wrapper.style, {
+      height: '100vh',
+      overflowY: 'auto',
+      marginTop: '50vh',
+    });
+    wrapper.appendChild(App());
+    return wrapper;
+  },
+};

--- a/apps/stories-vue/stories/Sortable/Horizontal/Horizontal.stories.ts
+++ b/apps/stories-vue/stories/Sortable/Horizontal/Horizontal.stories.ts
@@ -23,3 +23,11 @@ export const BasicSetup: Story = {
     },
   },
 };
+
+export const NestedScroll: Story = {
+  name: 'Nested scroll',
+  render: () => ({
+    components: {HorizontalSortableApp},
+    template: '<div style="width: 100vw; overflow-x: auto; margin-left: 50vw"><HorizontalSortableApp /></div>',
+  }),
+};

--- a/apps/stories-vue/stories/Sortable/Vertical/Vertical.stories.ts
+++ b/apps/stories-vue/stories/Sortable/Vertical/Vertical.stories.ts
@@ -42,3 +42,11 @@ export const WithDragHandle: Story = {
     },
   },
 };
+
+export const NestedScroll: Story = {
+  name: 'Nested scroll',
+  render: () => ({
+    components: {SortableApp},
+    template: '<div style="height: 100vh; overflow-y: auto; margin-top: 50vh"><SortableApp /></div>',
+  }),
+};

--- a/apps/stories/stories/react/Sortable/Horizontal/Horizontal.stories.tsx
+++ b/apps/stories/stories/react/Sortable/Horizontal/Horizontal.stories.tsx
@@ -80,3 +80,16 @@ export const Debug: Story = {
     debug: true,
   },
 };
+
+export const NestedScroll: Story = {
+  name: 'Nested scroll',
+  args: {
+    ...defaultArgs,
+    itemCount: 50,
+  },
+  render: (args) => (
+    <div style={{width: '100vw', overflowX: 'auto', marginLeft: '50vw'}}>
+      <SortableExample {...args} />
+    </div>
+  ),
+};

--- a/apps/stories/stories/react/Sortable/Vertical/Vertical.stories.tsx
+++ b/apps/stories/stories/react/Sortable/Vertical/Vertical.stories.tsx
@@ -142,3 +142,15 @@ export const AutoScrollCustomSpeed: AutoScrollStory = {
     acceleration: 50,
   },
 };
+
+export const NestedScroll: Story = {
+  name: 'Nested scroll',
+  args: {
+    itemCount: 50,
+  },
+  render: (args) => (
+    <div style={{height: '100vh', overflowY: 'auto', marginTop: '50vh'}}>
+      <SortableExample {...args} />
+    </div>
+  ),
+};

--- a/packages/dom/src/utilities/scroll/scrollIntoViewIfNeeded.ts
+++ b/packages/dom/src/utilities/scroll/scrollIntoViewIfNeeded.ts
@@ -1,75 +1,135 @@
-import {getComputedStyles} from '../styles/getComputedStyles.ts';
 import {isHTMLElement} from '../type-guards/isHTMLElement.ts';
-import {getFirstScrollableAncestor} from './getScrollableAncestors.ts';
+import {getScrollableAncestors} from './getScrollableAncestors.ts';
 
-export function scrollIntoViewIfNeeded(el: Element, centerIfNeeded = false) {
+type ScrollPosition = 'center' | 'nearest' | 'none';
+
+interface ScrollIntoViewOptions {
+  block?: ScrollPosition;
+  inline?: ScrollPosition;
+}
+
+export function scrollIntoViewIfNeeded(
+  el: Element,
+  {block = 'nearest', inline = 'nearest'}: ScrollIntoViewOptions = {}
+) {
   if (!isHTMLElement(el)) {
     return;
   }
 
-  const parent = getFirstScrollableAncestor(el);
+  const scrollableAncestors = getScrollableAncestors(el);
+  const processedAncestors: HTMLElement[] = [];
 
-  if (!isHTMLElement(parent)) {
-    return;
-  }
-
-  const parentComputedStyle = getComputedStyles(parent, true),
-    parentBorderTopWidth = parseInt(
-      parentComputedStyle.getPropertyValue('border-top-width')
-    ),
-    parentBorderLeftWidth = parseInt(
-      parentComputedStyle.getPropertyValue('border-left-width')
-    ),
-    overTop = el.offsetTop - parent.offsetTop < parent.scrollTop,
-    overBottom =
-      el.offsetTop - parent.offsetTop + el.clientHeight - parentBorderTopWidth >
-      parent.scrollTop + parent.clientHeight,
-    overLeft = el.offsetLeft - parent.offsetLeft < parent.scrollLeft,
-    overRight =
-      el.offsetLeft -
-        parent.offsetLeft +
-        el.clientWidth -
-        parentBorderLeftWidth >
-      parent.scrollLeft + parent.clientWidth,
-    alignWithTop = overTop && !overBottom;
-
-  if ((overTop || overBottom) && centerIfNeeded) {
-    parent.scrollTop =
-      el.offsetTop -
-      parent.offsetTop -
-      parent.clientHeight / 2 -
-      parentBorderTopWidth +
-      el.clientHeight / 2;
-  }
-
-  if ((overLeft || overRight) && centerIfNeeded) {
-    parent.scrollLeft =
-      el.offsetLeft -
-      parent.offsetLeft -
-      parent.clientWidth / 2 -
-      parentBorderLeftWidth +
-      el.clientWidth / 2;
-  }
-
-  if ((overTop || overBottom || overLeft || overRight) && !centerIfNeeded) {
-    if (alignWithTop) {
-      parent.scrollTop = el.offsetTop - parent.offsetTop;
-    } else if (overBottom) {
-      parent.scrollTop =
-        el.offsetTop -
-        parent.offsetTop +
-        el.clientHeight -
-        parent.clientHeight;
+  for (const ancestor of scrollableAncestors) {
+    if (!isHTMLElement(ancestor)) {
+      continue;
     }
 
-    if (overLeft) {
-      parent.scrollLeft = el.offsetLeft - parent.offsetLeft;
-    } else if (overRight) {
-      parent.scrollLeft =
-        el.offsetLeft -
-        parent.offsetLeft +
-        el.clientWidth -
-        parent.clientWidth;
+    const {top, left} = getOffsetRelativeTo(el, ancestor);
+
+    // For outer scrollable containers, adjust for the scroll positions
+    // of intermediate (already-processed) scrollable containers so that
+    // we compute where the element *visually* appears rather than where
+    // it sits in the layout.
+    let adjustedTop = top;
+    let adjustedLeft = left;
+
+    for (const inner of processedAncestors) {
+      adjustedTop -= inner.scrollTop;
+      adjustedLeft -= inner.scrollLeft;
     }
+
+    if (block !== 'none') {
+      const overTop = adjustedTop < ancestor.scrollTop;
+      const overBottom =
+        adjustedTop + el.offsetHeight >
+        ancestor.scrollTop + ancestor.clientHeight;
+
+      if (overTop !== overBottom) {
+        if (block === 'center') {
+          ancestor.scrollTop =
+            adjustedTop - ancestor.clientHeight / 2 + el.offsetHeight / 2;
+        } else if (overTop) {
+          ancestor.scrollTop = adjustedTop;
+        } else {
+          ancestor.scrollTop =
+            adjustedTop + el.offsetHeight - ancestor.clientHeight;
+        }
+      }
+    }
+
+    if (inline !== 'none') {
+      const overLeft = adjustedLeft < ancestor.scrollLeft;
+      const overRight =
+        adjustedLeft + el.offsetWidth >
+        ancestor.scrollLeft + ancestor.clientWidth;
+
+      if (overLeft !== overRight) {
+        if (inline === 'center') {
+          ancestor.scrollLeft =
+            adjustedLeft - ancestor.clientWidth / 2 + el.offsetWidth / 2;
+        } else if (overLeft) {
+          ancestor.scrollLeft = adjustedLeft;
+        } else {
+          ancestor.scrollLeft =
+            adjustedLeft + el.offsetWidth - ancestor.clientWidth;
+        }
+      }
+    }
+
+    processedAncestors.push(ancestor);
   }
+}
+
+/**
+ * Computes the absolute layout offset of an element's border-box
+ * by walking the offsetParent chain. The result is independent of
+ * any scroll positions.
+ *
+ * Note: SVG elements are not currently supported. If an SVG element
+ * is encountered in the offsetParent chain, the walk stops early.
+ */
+function getDocumentOffset(element: HTMLElement): {top: number; left: number} {
+  let top = 0;
+  let left = 0;
+  let current: HTMLElement | null = element;
+
+  while (current) {
+    top += current.offsetTop;
+    left += current.offsetLeft;
+
+    const offsetParent: Element | null = current.offsetParent;
+
+    if (!isHTMLElement(offsetParent)) {
+      break;
+    }
+
+    // clientTop/clientLeft are the border widths of the offsetParent.
+    // Add them to bridge from the offsetParent's padding edge (where
+    // offsetTop is measured from) to its border-box edge so the next
+    // iteration's offsetTop accumulates correctly.
+    top += offsetParent.clientTop;
+    left += offsetParent.clientLeft;
+
+    current = offsetParent;
+  }
+
+  return {top, left};
+}
+
+/**
+ * Returns the element's border-box position relative to the ancestor's
+ * padding edge (content area), which is the coordinate space that
+ * scrollTop / scrollLeft operate in.
+ */
+function getOffsetRelativeTo(
+  element: HTMLElement,
+  ancestor: HTMLElement
+): {top: number; left: number} {
+  const elOffset = getDocumentOffset(element);
+  const ancestorOffset = getDocumentOffset(ancestor);
+
+  return {
+    top: elOffset.top - ancestorOffset.top - ancestor.clientTop,
+    left: elOffset.left - ancestorOffset.left - ancestor.clientLeft,
+  };
 }


### PR DESCRIPTION
## Summary

Rewrites `scrollIntoViewIfNeeded` to fix offset calculation issues and support nested scrollable containers.

### Offset calculation fix
The previous implementation used `el.offsetTop - parent.offsetTop`, which only works when both elements share the same `offsetParent`. This breaks when the scrollable ancestor isn't the element's direct `offsetParent` (e.g. intermediate positioned elements exist).

The new implementation walks the `offsetParent` chain via `getDocumentOffset` to compute absolute layout positions, then derives the relative offset. This uses `offsetTop`/`offsetLeft` (layout properties unaffected by CSS transforms or animations) rather than `getBoundingClientRect`, which is important for dnd-kit since elements are frequently mid-transform during drag operations.

### Nested scrollable container support
Now iterates **all** scrollable ancestors (innermost → outermost) instead of only the first one. For outer containers, the layout offset is adjusted by subtracting the `scrollTop`/`scrollLeft` of already-processed inner containers to compute where the element *visually* appears.

### New `block`/`inline` options
Replaces the `centerIfNeeded` boolean with `block` and `inline` options, each accepting:
- `'nearest'` (default) — scroll minimum amount, only if not visible
- `'center'` — center the element, only if not visible
- `'none'` — skip scrolling on that axis entirely

The `'none'` option is necessary for implementing single-axis keyboard navigation (see [#1959](https://github.com/clauderic/dnd-kit/discussions/1959)). For example, in a kanban board with columns taller than the viewport, moving a card horizontally between columns should not cause the page to scroll vertically to align the target column's top with the viewport — it should only scroll on the axis corresponding to the move direction. We may include a built-in option in the future to automatically restrict scrolling to the keyboard move direction's axis.

### Browser `nearest` behavior
When an element is larger than the viewport (overflows on both edges), scrolling is skipped — matching the browser's native `scrollIntoView({ block: 'nearest' })` behavior.

Fixes https://github.com/clauderic/dnd-kit/issues/1958

## Test plan
- [x] Added "Nested scroll" stories for vertical and horizontal sortable lists across all frameworks (React, Vue, Svelte, Solid, Vanilla)
- [x] Verify keyboard-driven sorting scrolls both inner container and page in nested scroll stories
- [x] Verify single-container scrolling still works correctly in existing stories