### PR TITLE
refactor(dom): use Customizable<Plugins> for Sortable entity-level plugins

### DIFF
--- a/.changeset/customizable-sortable-plugins.md
+++ b/.changeset/customizable-sortable-plugins.md
@@ -1,0 +1,23 @@
+---
+'@dnd-kit/dom': minor
+---
+
+Sortable `plugins` now accepts `Customizable<Plugins>`, allowing a function that receives the default plugins to extend them rather than replace them.
+
+This prevents accidentally losing the default Sortable plugins (`SortableKeyboardPlugin`, `OptimisticSortingPlugin`) when adding per-entity plugin configuration such as `Feedback.configure()`.
+
+```ts
+// Extend defaults
+useSortable({
+  id: 'item',
+  index: 0,
+  plugins: (defaults) => [...defaults, Feedback.configure({ feedback: 'clone' })],
+});
+
+// Replace defaults (same behavior as before)
+useSortable({
+  id: 'item',
+  index: 0,
+  plugins: [MyPlugin],
+});
+```

--- a/.changeset/per-entity-plugin-config.md
+++ b/.changeset/per-entity-plugin-config.md
@@ -40,7 +40,7 @@ useDraggable({
 useSortable({
   id: 'item',
   index: 0,
-  plugins: [Feedback.configure({ feedback: 'clone' })],
+  plugins: (defaults) => [...defaults, Feedback.configure({ feedback: 'clone' })],
 });
 ```
 

--- a/packages/dom/src/sortable/sortable.ts
+++ b/packages/dom/src/sortable/sortable.ts
@@ -1,11 +1,12 @@
 import {batch, reactive, untracked, WeakStore} from '@dnd-kit/state';
-import type {CollisionPriority, Modifiers, Plugins} from '@dnd-kit/abstract';
+import type {CollisionPriority, Customizable, Modifiers, Plugins} from '@dnd-kit/abstract';
 import type {
   Data,
   PluginConstructor,
   Type,
   UniqueIdentifier,
 } from '@dnd-kit/abstract';
+import {resolveCustomizable} from '@dnd-kit/abstract';
 import {
   defaultCollisionDetection,
   type CollisionDetector,
@@ -55,7 +56,7 @@ const defaultPlugins: PluginConstructor[] = [
 ];
 
 export interface SortableInput<T extends Data>
-  extends DraggableInput<T>,
+  extends Omit<DraggableInput<T>, 'plugins'>,
     DroppableInput<T> {
   /**
    * The index of the sortable item within its group.
@@ -81,9 +82,19 @@ export interface SortableInput<T extends Data>
    * Bare constructors are registered globally (e.g. sortable-specific plugins).
    * Descriptors from `Plugin.configure()` are applied as per-entity plugin config.
    *
+   * Can be provided as an array (replaces defaults) or a function that receives
+   * the default plugins and returns a new array (extends defaults).
+   *
    * @default [SortableKeyboardPlugin, OptimisticSortingPlugin]
+   *
+   * @example
+   * // Extend defaults
+   * plugins: (defaults) => [...defaults, Feedback.configure({feedback: 'clone'})]
+   *
+   * // Replace defaults
+   * plugins: [MyPlugin]
    */
-  plugins?: Plugins;
+  plugins?: Customizable<Plugins>;
 }
 
 export const defaultSortableTransition: SortableTransition = {
@@ -135,11 +146,13 @@ export class Sortable<T extends Data = Data> {
       sensors,
       type,
       transition = defaultSortableTransition,
-      plugins = defaultPlugins,
+      plugins: pluginsInput,
       ...input
     }: SortableInput<T>,
     manager: DragDropManager<any, any> | undefined
   ) {
+    const plugins = resolveCustomizable(pluginsInput, defaultPlugins);
+
     this.droppable = new SortableDroppable<T>(input, manager, this);
     this.draggable = new SortableDraggable<T>(
       {
@@ -342,8 +355,8 @@ export class Sortable<T extends Data = Data> {
     return this.draggable.disabled && this.droppable.disabled;
   }
 
-  public set plugins(value: Plugins | undefined) {
-    this.draggable.plugins = value;
+  public set plugins(value: Customizable<Plugins> | undefined) {
+    this.draggable.plugins = resolveCustomizable(value, defaultPlugins);
   }
 
   public set disabled(value: boolean) {


### PR DESCRIPTION
## Summary
- Changed `SortableInput.plugins` type from `Plugins` to `Customizable<Plugins>`, matching the existing pattern used at the manager level
- Users can now pass a function to extend default plugins instead of accidentally replacing them
- The setter also resolves against defaults for reactive updates from framework hooks

```typescript
// Extend defaults (keeps SortableKeyboardPlugin + OptimisticSortingPlugin)
plugins: (defaults) => [...defaults, Feedback.configure({feedback: 'clone'})]

// Replace defaults (explicit opt-out, same behavior as before)
plugins: [MyPlugin]
```

Fixes https://github.com/clauderic/dnd-kit/issues/1965

## Test plan
- [x] TypeScript compiles cleanly across all packages (dom, react, vue, solid, svelte)
- [x] Verify passing `plugins` as a function correctly extends defaults
- [x] Verify passing `plugins` as an array still replaces defaults (backwards compatible)
- [x] Verify omitting `plugins` still uses `[SortableKeyboardPlugin, OptimisticSortingPlugin]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)