### PR TITLE
fix: preserve SVG namespace in clone feedback placeholder sync

### DIFF
--- a/.changeset/feedback-svg-placeholder.md
+++ b/.changeset/feedback-svg-placeholder.md
@@ -1,0 +1,9 @@
+---
+'@dnd-kit/dom': patch
+---
+
+Fix clone feedback placeholder dropping inline SVG children during mutation sync.
+
+The element mutation observer used `innerHTML` to sync child changes from the dragged element to its placeholder. This text-based serialization loses SVG namespace information, causing inline SVG elements (e.g. icon components) to be stripped from the placeholder. The placeholder then measures with incorrect dimensions, producing a misaligned drop animation.
+
+Replaced `innerHTML` with `replaceChildren(...element.cloneNode(true).childNodes)`, which performs a namespace-aware deep clone.

--- a/packages/dom/src/core/plugins/feedback/observers.ts
+++ b/packages/dom/src/core/plugins/feedback/observers.ts
@@ -72,7 +72,7 @@ export function createElementMutationObserver(
     }
 
     if (hasChildrenMutations && clone) {
-      placeholder.innerHTML = element.innerHTML;
+      placeholder.replaceChildren(...element.cloneNode(true).childNodes);
     }
   });
 


### PR DESCRIPTION
## Summary

- Replace `innerHTML` with `replaceChildren(...element.cloneNode(true).childNodes)` in the element mutation observer for clone feedback placeholders
- `innerHTML` serializes/parses as HTML, stripping SVG namespace info from inline `<svg>` children (e.g. Lucide icons), causing the placeholder to measure with wrong dimensions and the drop animation to land at the wrong position

## Test plan

- [x] Drag a sortable item with `feedback="clone"` that contains inline SVG children (e.g. a badge with a Lucide icon next to text)
- [x] Verify the placeholder preserves the SVG and measures at the correct dimensions
- [x] Verify the drop animation lands at the correct position

Closes #1962

🤖 Generated with [Claude Code](https://claude.com/claude-code)