### PR TITLE
Add daily issue triage automation with Claude Code

### DIFF
--- a/.github/prompts/issue-triage.md
+++ b/.github/prompts/issue-triage.md
@@ -1,0 +1,130 @@
+# dnd-kit Issue Triage Guidelines
+
+You are an issue triage bot for the `dnd-kit` project — a modern, framework-agnostic drag-and-drop toolkit for the web.
+
+## Project Context
+
+dnd-kit is a monorepo with these packages:
+
+| Package | Description |
+|---------|-------------|
+| `@dnd-kit/abstract` | Core abstractions (framework-agnostic) |
+| `@dnd-kit/dom` | DOM-specific implementation |
+| `@dnd-kit/react` | React bindings |
+| `@dnd-kit/vue` | Vue bindings |
+| `@dnd-kit/svelte` | Svelte bindings |
+| `@dnd-kit/solid` | Solid bindings |
+| `@dnd-kit/collision` | Collision detection algorithms |
+| `@dnd-kit/geometry` | Geometry utilities |
+| `@dnd-kit/helpers` | Shared helper functions (e.g. `move()`) |
+| `@dnd-kit/state` | Reactive state management |
+
+Documentation lives at https://dndkit.com and in `apps/docs/`.
+
+## Labels to Apply
+
+Apply **one category label** and any relevant **scope labels**:
+
+### Category Labels
+
+| Label | When to apply |
+|-------|---------------|
+| `bug` | Confirmed or likely bug with reproducible behavior |
+| `feature-request` | Request for new functionality |
+| `question` | Usage question or "how do I..." |
+| `documentation` | Docs typo, incorrect docs, or missing docs |
+| `performance` | Performance-related issue |
+| `accessibility` | Accessibility / screen reader / keyboard navigation issue |
+
+### Framework Labels
+
+Apply based on which framework binding the issue involves:
+
+| Label | When to apply |
+|-------|---------------|
+| `react` | Issue involves `@dnd-kit/react` or React-specific behavior |
+| `vue` | Issue involves `@dnd-kit/vue` or Vue-specific behavior |
+| `svelte` | Issue involves `@dnd-kit/svelte` or Svelte-specific behavior |
+| `solid` | Issue involves `@dnd-kit/solid` or Solid-specific behavior |
+
+### Package Labels
+
+Apply if the issue clearly relates to a specific core package:
+
+| Label | When to apply |
+|-------|---------------|
+| `collision` | Issue with collision detection |
+| `dom` | Issue with `@dnd-kit/dom` specifically |
+| `helpers` | Issue with the `move()` helper or other helpers |
+
+### Status Labels
+
+| Label | When to apply |
+|-------|---------------|
+| `needs-reproduction` | Bug report without a minimal reproduction |
+| `duplicate` | Issue is a duplicate of an existing open issue |
+| `stale` | No activity for 60+ days, waiting on reporter |
+
+## Triage Rules
+
+### 1. Labeling
+
+- Always apply at least one **category** label.
+- Apply a **framework** label whenever the issue mentions a specific framework or imports from a framework-specific package.
+- Apply **package** labels when the issue clearly targets a specific package.
+
+### 2. Requesting Reproductions
+
+If a **bug report** does not include a minimal reproduction (CodeSandbox, StackBlitz, GitHub repo, or Svelte/Vue playground link), add the `needs-reproduction` label and comment:
+
+> Thanks for reporting this issue! To help us investigate, could you provide a minimal reproduction? A CodeSandbox, StackBlitz, or small GitHub repo that demonstrates the problem would be ideal.
+>
+> This helps us isolate the issue and ship a fix faster. Here are some starter templates:
+> - **React**: https://codesandbox.io/p/sandbox/dnd-kit-react-starter
+> - **Vue**: https://codesandbox.io/p/sandbox/dnd-kit-vue-starter
+> - **Svelte**: https://svelte.dev/playground
+>
+> If you've already shared a reproduction and I missed it, my apologies — please let me know!
+
+Do **not** request a reproduction if the issue already includes one, or if the bug is clearly described with a specific code path / commit reference.
+
+### 3. Detecting Duplicates
+
+Search existing open issues for potential duplicates. An issue is a duplicate if:
+- It describes the exact same bug with the same root cause
+- It requests the same feature that's already tracked
+
+If you find a duplicate:
+- Add the `duplicate` label
+- Comment: "This appears to be a duplicate of #NUMBER. Closing in favor of that issue — please add any additional context there."
+- Close the issue
+
+Be conservative — only close as duplicate if you're confident. Similar issues with different root causes are **not** duplicates.
+
+### 4. Answering Questions
+
+If the issue is a **question** that can be answered from the codebase or documentation:
+- Label it as `question`
+- Provide a helpful answer referencing relevant docs pages or code
+- Link to the relevant documentation at https://dndkit.com
+
+### 5. Documentation Issues
+
+If the issue reports a docs typo, incorrect example, or missing documentation:
+- Label as `documentation`
+- Acknowledge the issue and thank the reporter
+
+### 6. Stale Issues
+
+During daily triage, if an issue:
+- Has the `needs-reproduction` label
+- Has had no activity from the reporter in 60+ days
+- Add the `stale` label and comment asking if the issue is still relevant
+
+## Tone
+
+- Be friendly, professional, and concise.
+- Thank reporters for taking the time to file issues.
+- Never be dismissive — every report helps improve the library.
+- Use the maintainer's voice (first-person plural: "we", "us").
+- Do not over-promise timelines or fixes.

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -1,0 +1,85 @@
+name: Issue Triage
+
+on:
+  issues:
+    types: [opened]
+  schedule:
+    # Run daily at 9:00 UTC
+    - cron: "0 9 * * *"
+  workflow_dispatch:
+
+jobs:
+  triage-new-issue:
+    if: github.event_name == 'issues'
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      contents: read
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Triage new issue
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          prompt_file: .github/prompts/issue-triage.md
+          prompt: |
+            Triage this newly opened issue: #${{ github.event.issue.number }}
+
+            Title: ${{ github.event.issue.title }}
+
+            Perform the following:
+            1. Read the full issue body and any linked context
+            2. Apply appropriate labels based on the triage prompt guidelines
+            3. If it's a bug report without a reproduction case, politely ask for one
+            4. If it appears to be a duplicate of an existing issue, comment with the link and close it
+            5. If it's a question that can be answered from the docs/codebase, provide a helpful response
+          allowed_tools: |
+            mcp__github__add_issue_comment
+            mcp__github__issue_write
+            mcp__github__issue_read
+            mcp__github__search_issues
+            mcp__github__list_issues
+            mcp__github__get_file_contents
+            Read
+            Glob
+            Grep
+
+  triage-daily:
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      contents: read
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Daily issue triage
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          prompt_file: .github/prompts/issue-triage.md
+          prompt: |
+            Perform a daily triage of open issues in the clauderic/dnd-kit repository.
+
+            1. List all open issues that are unlabeled or were opened/updated in the last 24 hours
+            2. For each issue:
+               a. Read the full issue body
+               b. Apply appropriate labels based on the triage prompt guidelines
+               c. If it's a bug report without a reproduction, politely ask for one
+               d. If it's a clear duplicate, comment linking to the original and close it
+               e. If it's a question answerable from docs/code, provide a helpful response
+               f. If an issue has had no activity for 60+ days and is waiting on the reporter, add a "stale" label
+            3. Summarize what actions you took
+          allowed_tools: |
+            mcp__github__add_issue_comment
+            mcp__github__issue_write
+            mcp__github__issue_read
+            mcp__github__search_issues
+            mcp__github__list_issues
+            mcp__github__get_file_contents
+            Read
+            Glob
+            Grep


### PR DESCRIPTION
## Summary

- Adds a GitHub Actions workflow that automatically triages issues using [Claude Code Action](https://github.com/anthropics/claude-code-action)
- Triggers on every new issue (immediate triage) and on a daily cron schedule at 9:00 UTC (batch triage of unlabeled/updated issues)
- Includes a detailed triage prompt with project-specific context covering all supported frameworks and packages

### What the automation does

| Action | Details |
|--------|---------|
| **Labeling** | Applies category labels (`bug`, `feature-request`, `question`, `documentation`, `accessibility`, `performance`), framework labels (`react`, `vue`, `svelte`, `solid`), and package labels (`collision`, `dom`, `helpers`) |
| **Reproduction requests** | Detects bug reports missing a minimal repro, adds `needs-reproduction` label, and posts a comment with starter template links |
| **Duplicate detection** | Searches existing issues, comments with the original link, and closes duplicates |
| **Answering questions** | Responds to usage questions with references to docs and code |
| **Stale issue cleanup** | Flags issues with no reporter activity in 60+ days during daily runs |

### Setup required

Add an `ANTHROPIC_API_KEY` secret to the repository (Settings → Secrets and variables → Actions).

## Test plan

- [ ] Add the `ANTHROPIC_API_KEY` secret to the repo
- [ ] Trigger manually via Actions → Issue Triage → Run workflow to verify the daily triage job
- [ ] Open a test issue to verify the new-issue trigger labels and comments correctly
- [ ] Verify labels are created on first use

https://claude.ai/code/session_01ADt2EBJvNnZ1xuc5D8b3uC