### PR TITLE
fix: correct missing closing quotes in SortableContext docs examples

### DIFF
--- a/apps/docs/legacy/presets/sortable/sortable-context.mdx
+++ b/apps/docs/legacy/presets/sortable/sortable-context.mdx
@@ -83,9 +83,9 @@ You may also nest `SortableContext` providers within other `SortableContext` pro
 
 // Good, nested DndContexts
 <DndContext>
-  <SortableContext items={["A, "B", "C"]}>
+  <SortableContext items={["A", "B", "C"]}>
     <DndContext>
-      <SortableContext items={["A, "B", "C"]}>
+      <SortableContext items={["A", "B", "C"]}>
         {/* ... */}
       </SortableContext>
     </DndContext>
@@ -94,8 +94,8 @@ You may also nest `SortableContext` providers within other `SortableContext` pro
 
 // Bad, nested Sortable contexts with `id` collisions
 <DndContext>
-  <SortableContext items={["A, "B", "C"]}>
-    <SortableContext items={["A, "B", "C"]}>
+  <SortableContext items={["A", "B", "C"]}>
+    <SortableContext items={["A", "B", "C"]}>
       {/* ... */}
     </SortableContext>
   </SortableContext>
@@ -103,7 +103,7 @@ You may also nest `SortableContext` providers within other `SortableContext` pro
 
 // Good, nested Sortable contexts with unique `id`s
 <DndContext>
-  <SortableContext items={["A, "B", "C"]}>
+  <SortableContext items={["A", "B", "C"]}>
     <SortableContext items={[1, 2, 3]}>
       {/* ... */}
     </SortableContext>


### PR DESCRIPTION
Fixes #1894

## Summary
Five code examples in the legacy `SortableContext` documentation had a missing closing quote after `"A` — i.e. `["A, "B", "C"]` instead of `["A", "B", "C"]`. Fixed all five occurrences in the nested `DndContext` usage examples.

## Test plan
- Visual check of the rendered docs at `/presets/sortable/sortable-context` to confirm the code examples now show syntactically valid JSX.

---
*Automated fix by Claude Code*