### PR TITLE
fix(accessibility): ensure screen reader announcements update consistently

### DIFF
--- a/.changeset/stale-owls-search.md
+++ b/.changeset/stale-owls-search.md
@@ -1,0 +1,5 @@
+---
+"@dnd-kit/accessibility": patch
+---
+
+Fix screen reader announcements so repeated messages are announced consistently.

--- a/packages/accessibility/src/hooks/useAnnouncement.ts
+++ b/packages/accessibility/src/hooks/useAnnouncement.ts
@@ -4,7 +4,13 @@ export function useAnnouncement() {
   const [announcement, setAnnouncement] = useState('');
   const announce = useCallback((value: string | undefined) => {
     if (value != null) {
-      setAnnouncement(value);
+      // Clear the announcement first to ensure screen readers detect the change
+      // even when the same text is announced consecutively
+      setAnnouncement('');
+      // Use requestAnimationFrame to ensure the clear renders before setting new value
+      requestAnimationFrame(() => {
+        setAnnouncement(value);
+      });
     }
   }, []);
 


### PR DESCRIPTION
Fixes #1952 - The useAnnouncement hook now clears the announcement before setting the new value, using requestAnimationFrame to ensure screen readers detect the change.