### PR TITLE
fix(docs): replace DndContext with DragDropProvider in React Quickstart example

### DIFF
--- a/apps/docs/react/quickstart.mdx
+++ b/apps/docs/react/quickstart.mdx
@@ -161,7 +161,7 @@ Let's try adding more droppable targets to our example:
 
 ```jsx App.js
 import React, {useState} from 'react';
-import {DndContext} from '@dnd-kit/core';
+import {DragDropProvider} from '@dnd-kit/react';
 
 import {Droppable} from './Droppable';
 import {Draggable} from './Draggable';


### PR DESCRIPTION
The example was using DndContext from @dnd-kit/core, but the JSX was already using <DragDropProvider> as the wrapper component — so the code was broken out of the box.
Fixed the import to match the actual component used in the example:

import {DndContext} from '@dnd-kit/core' → import {DragDropProvider} from '@dnd-kit/react'