### PR TITLE
fix: remove entries from Listeners set on cleanup to prevent memory leak

### DIFF
--- a/.changeset/fix-listeners-memory-leak.md
+++ b/.changeset/fix-listeners-memory-leak.md
@@ -1,0 +1,5 @@
+---
+"@dnd-kit/dom": patch
+---
+
+Fixed memory leak in `Listeners` class where the `bind` cleanup function did not remove entries from the internal `entries` set, causing detached DOM nodes to be retained in memory.

--- a/packages/dom/src/utilities/event-listeners/Listeners.ts
+++ b/packages/dom/src/utilities/event-listeners/Listeners.ts
@@ -29,9 +29,13 @@ export class Listeners {
       }
     }
 
+    const allEntries = this.entries;
+
     return function cleanup() {
-      for (const [target, {type, listener, options}] of entries) {
+      for (const entry of entries) {
+        const [target, {type, listener, options}] = entry;
         target.removeEventListener(type, listener, options);
+        allEntries.delete(entry);
       }
     };
   }


### PR DESCRIPTION
Fixes #1751

## Summary

The `Listeners.bind()` method stores `EventListenerEntry` references in `this.entries` but the returned cleanup function only called `removeEventListener` — it did not remove the corresponding entries from `this.entries`. This caused `this.entries` to accumulate references to detached DOM nodes, preventing garbage collection after elements were removed.

The fix ensures that when the cleanup function returned by `bind()` is called, it removes each entry from `this.entries` in addition to calling `removeEventListener`, so that the `Listeners` instance no longer holds references to event targets that have been cleaned up.

## Test plan
- Load the [reproduction sandbox](https://codesandbox.io/p/sandbox/hhgc4d) from the issue
- Perform multiple drag-and-drop operations
- Take a heap snapshot in Chrome DevTools → Memory tab
- Verify that "Objects retained by detached DOM nodes" no longer shows growing references from `this.entries`

---
*Automated fix by Claude Code*