### PR TITLE
fix: treat sticky elements as scrollable ancestors, not fixed

### DIFF
--- a/.changeset/fix-sticky-autoscroll.md
+++ b/.changeset/fix-sticky-autoscroll.md
@@ -1,0 +1,5 @@
+---
+"@dnd-kit/dom": patch
+---
+
+Fixed autoscroll failing when sortable items are inside a `position: sticky` container. The `isFixed` utility was incorrectly treating sticky-positioned elements the same as fixed-positioned elements, which caused `getScrollableAncestors` to stop traversal at the sticky element and skip the actual scrollable container.

--- a/packages/dom/src/utilities/scroll/isFixed.ts
+++ b/packages/dom/src/utilities/scroll/isFixed.ts
@@ -4,7 +4,5 @@ export function isFixed(
   node: Element,
   computedStyle: CSSStyleDeclaration = getComputedStyles(node, true)
 ): boolean {
-  return (
-    computedStyle.position === 'fixed' || computedStyle.position === 'sticky'
-  );
+  return computedStyle.position === 'fixed';
 }


### PR DESCRIPTION
Fixes #1756

## Summary

The `isFixed` utility was returning `true` for both `position: fixed` and `position: sticky` elements. In `getScrollableAncestors`, when an `isFixed` element was encountered, traversal would stop immediately and fall back to `document.scrollingElement` — bypassing any actual scrollable containers in between.

This is correct for `position: fixed` (which is positioned relative to the viewport and has no scrollable DOM ancestors), but **incorrect** for `position: sticky`. Sticky elements remain part of the normal document flow and still scroll with their nearest scroll container. Treating them as fixed caused autoscroll to skip the actual scrollable ancestor (e.g. a scrollable table container) and use the document scroll element instead, breaking horizontal autoscroll in sticky table headers.

The fix removes `position: sticky` from the `isFixed` check so sticky elements are treated normally during scroll ancestor traversal.

## Test plan
- Set up a sortable list inside a `position: sticky` table header with a horizontally scrollable container
- Drag a column header toward the edge of the visible area
- Verify that the container scrolls horizontally as expected

---
*Automated fix by Claude Code*