### PR TITLE
docs: update use-droppable.mdx accept parameter typo

### DIFF
--- a/apps/docs/react/hooks/use-droppable.mdx
+++ b/apps/docs/react/hooks/use-droppable.mdx
@@ -52,7 +52,7 @@ The `useDroppable` hook accepts the following arguments:
   If you already have a reference to the element, you can pass it to the `element` option instead of using the `ref` that is returned by the `useDraggable` hook to connect the draggable source element.
 </ParamField>
 
-<ParamField path="accepts" type="string | number | Symbol | (type: string | number | Symbol) => boolean">
+<ParamField path="accept" type="string | number | Symbol | (type: string | number | Symbol) => boolean">
   Optionally supply a type of draggable element to only allow it to be dropped over certain droppable targets that [accept](#) this `type`.
 </ParamField>
 


### PR DESCRIPTION
param path changed from `accepts` to `accept`

`accepts` is the Droppable property, but the useDroppable hook takes `accept`.

this was making the links to `accept` elsewhere in the doc go straight to the top