### PR TITLE
fix: add svelte.config.js to fix stories-svelte CI build

### DIFF
--- a/apps/stories-svelte/svelte.config.js
+++ b/apps/stories-svelte/svelte.config.js
@@ -1,0 +1,5 @@
+import {vitePreprocess} from '@sveltejs/vite-plugin-svelte';
+
+export default {
+  preprocess: vitePreprocess(),
+};


### PR DESCRIPTION
## Summary
- Adds missing `svelte.config.js` with `vitePreprocess()` to `apps/stories-svelte/`
- Fixes pre-existing CI build failure where `vite-plugin-svelte` fails to preprocess TypeScript in `<script lang="ts">` blocks, causing `js_parse_error`
- The build worked locally (macOS) but failed in CI (Ubuntu) due to platform-specific module resolution differences in how `@storybook/svelte-vite` configures the Svelte plugin

## Test plan
- [x] Verified `storybook build` succeeds locally with the fix
- [ ] CI Chromatic (Svelte) job should pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)