### PR TITLE
feat(dom): support callback form for feedback option

### DIFF
--- a/.changeset/feedback-callback-type.md
+++ b/.changeset/feedback-callback-type.md
@@ -1,0 +1,15 @@
+---
+'@dnd-kit/dom': minor
+---
+
+Support a callback form for the `feedback` option in the `Feedback` plugin, allowing the feedback type to be chosen dynamically based on the source and manager context (e.g. activator type).
+
+```ts
+Feedback.configure({
+  feedback: (source, manager) => {
+    return isKeyboardEvent(manager.dragOperation.activatorEvent)
+      ? 'clone'
+      : 'default';
+  },
+});
+```

--- a/apps/stories-solid/stories/Sortable/SortableDynamicFeedbackApp.tsx
+++ b/apps/stories-solid/stories/Sortable/SortableDynamicFeedbackApp.tsx
@@ -1,15 +1,19 @@
 import {createSignal, For} from 'solid-js';
 import {Feedback} from '@dnd-kit/dom';
+import type {Plugins} from '@dnd-kit/abstract';
 import {DragDropProvider} from '@dnd-kit/solid';
 import {useSortable} from '@dnd-kit/solid/sortable';
 import {move} from '@dnd-kit/helpers';
 
-const dynamicFeedbackPlugin = Feedback.configure({
-  feedback: (_source, manager) =>
-    manager.dragOperation.activatorEvent instanceof KeyboardEvent
-      ? 'clone'
-      : 'default',
-});
+const dynamicFeedbackPlugins = (defaults: Plugins) => [
+  ...defaults,
+  Feedback.configure({
+    feedback: (_source, manager) =>
+      manager.dragOperation.activatorEvent instanceof KeyboardEvent
+        ? 'clone'
+        : 'default',
+  }),
+];
 
 function Sortable(props: {id: number; index: number}) {
   const {isDragging, ref} = useSortable({
@@ -19,7 +23,7 @@ function Sortable(props: {id: number; index: number}) {
     get index() {
       return props.index;
     },
-    plugins: [dynamicFeedbackPlugin],
+    plugins: dynamicFeedbackPlugins,
   });
 
   return (

--- a/apps/stories-solid/stories/Sortable/SortableDynamicFeedbackApp.tsx
+++ b/apps/stories-solid/stories/Sortable/SortableDynamicFeedbackApp.tsx
@@ -1,0 +1,52 @@
+import {createSignal, For} from 'solid-js';
+import {Feedback} from '@dnd-kit/dom';
+import {DragDropProvider} from '@dnd-kit/solid';
+import {useSortable} from '@dnd-kit/solid/sortable';
+import {move} from '@dnd-kit/helpers';
+
+const dynamicFeedbackPlugin = Feedback.configure({
+  feedback: (_source, manager) =>
+    manager.dragOperation.activatorEvent instanceof KeyboardEvent
+      ? 'clone'
+      : 'default',
+});
+
+function Sortable(props: {id: number; index: number}) {
+  const {isDragging, ref} = useSortable({
+    get id() {
+      return props.id;
+    },
+    get index() {
+      return props.index;
+    },
+    plugins: [dynamicFeedbackPlugin],
+  });
+
+  return (
+    <li ref={ref} class="item" data-shadow={isDragging() ? '' : undefined}>
+      {props.id}
+    </li>
+  );
+}
+
+export default function App() {
+  const [items, setItems] = createSignal(createRange(100));
+
+  return (
+    <DragDropProvider
+      onDragEnd={(event) => {
+        setItems((items) => move(items, event));
+      }}
+    >
+      <ul class="list">
+        <For each={items()}>
+          {(id, index) => <Sortable id={id} index={index()} />}
+        </For>
+      </ul>
+    </DragDropProvider>
+  );
+}
+
+function createRange(length: number) {
+  return Array.from({length}, (_, i) => i + 1);
+}

--- a/apps/stories-solid/stories/Sortable/Vertical/Vertical.stories.tsx
+++ b/apps/stories-solid/stories/Sortable/Vertical/Vertical.stories.tsx
@@ -4,6 +4,8 @@ import App from '../SortableApp';
 import sortableSource from '../SortableApp.tsx?raw';
 import DragHandleApp from '../SortableDragHandleApp';
 import sortableDragHandleSource from '../SortableDragHandleApp.tsx?raw';
+import DynamicFeedbackApp from '../SortableDynamicFeedbackApp';
+import sortableDynamicFeedbackSource from '../SortableDynamicFeedbackApp.tsx?raw';
 import {
   baseStyles,
   handleStyles,
@@ -46,6 +48,19 @@ export const WithDragHandle: Story = {
       files: {
         'src/App.tsx': sortableDragHandleSource,
         'src/styles.css': [baseStyles, sortableStyles, handleStyles].join('\n\n'),
+      },
+    },
+  },
+};
+
+export const DynamicFeedback: Story = {
+  name: 'Dynamic feedback',
+  render: () => <DynamicFeedbackApp />,
+  parameters: {
+    codesandbox: {
+      files: {
+        'src/App.tsx': sortableDynamicFeedbackSource,
+        'src/styles.css': [baseStyles, sortableStyles].join('\n\n'),
       },
     },
   },

--- a/apps/stories-svelte/stories/Sortable/SortableDynamicFeedbackApp.svelte
+++ b/apps/stories-svelte/stories/Sortable/SortableDynamicFeedbackApp.svelte
@@ -1,0 +1,29 @@
+<script lang="ts">
+  import {Feedback} from '@dnd-kit/dom';
+  import {DragDropProvider} from '@dnd-kit/svelte';
+  import {move} from '@dnd-kit/helpers';
+  import SortableDynamicFeedbackItem from './SortableDynamicFeedbackItem.svelte';
+
+  let items = $state(Array.from({length: 100}, (_, i) => i + 1));
+  let snapshot: number[] = [];
+
+  function onDragStart() {
+    snapshot = items.slice();
+  }
+
+  function onDragOver(event: any) {
+    items = move(items, event);
+  }
+
+  function onDragEnd(event: any) {
+    if (event.canceled) items = snapshot;
+  }
+</script>
+
+<DragDropProvider {onDragStart} {onDragOver} {onDragEnd}>
+  <ul class="list">
+    {#each items as id, index (id)}
+      <SortableDynamicFeedbackItem {id} {index} />
+    {/each}
+  </ul>
+</DragDropProvider>

--- a/apps/stories-svelte/stories/Sortable/SortableDynamicFeedbackItem.svelte
+++ b/apps/stories-svelte/stories/Sortable/SortableDynamicFeedbackItem.svelte
@@ -1,0 +1,27 @@
+<script lang="ts">
+  import {Feedback} from '@dnd-kit/dom';
+  import {createSortable} from '@dnd-kit/svelte/sortable';
+
+  let {id, index}: {id: number; index: number} = $props();
+
+  const dynamicFeedbackPlugin = Feedback.configure({
+    feedback: (_source, manager) =>
+      manager.dragOperation.activatorEvent instanceof KeyboardEvent
+        ? 'clone'
+        : 'default',
+  });
+
+  const sortable = createSortable({
+    get id() { return id; },
+    get index() { return index; },
+    plugins: [dynamicFeedbackPlugin],
+  });
+</script>
+
+<li
+  {@attach sortable.attach}
+  class="item"
+  data-shadow={sortable.isDragging ? 'true' : undefined}
+>
+  {id}
+</li>

--- a/apps/stories-svelte/stories/Sortable/SortableDynamicFeedbackItem.svelte
+++ b/apps/stories-svelte/stories/Sortable/SortableDynamicFeedbackItem.svelte
@@ -1,20 +1,22 @@
 <script lang="ts">
   import {Feedback} from '@dnd-kit/dom';
+  import type {Plugins} from '@dnd-kit/abstract';
   import {createSortable} from '@dnd-kit/svelte/sortable';
 
   let {id, index}: {id: number; index: number} = $props();
 
-  const dynamicFeedbackPlugin = Feedback.configure({
-    feedback: (_source, manager) =>
-      manager.dragOperation.activatorEvent instanceof KeyboardEvent
-        ? 'clone'
-        : 'default',
-  });
-
   const sortable = createSortable({
     get id() { return id; },
     get index() { return index; },
-    plugins: [dynamicFeedbackPlugin],
+    plugins: (defaults: Plugins) => [
+      ...defaults,
+      Feedback.configure({
+        feedback: (_source, manager) =>
+          manager.dragOperation.activatorEvent instanceof KeyboardEvent
+            ? 'clone'
+            : 'default',
+      }),
+    ],
   });
 </script>
 

--- a/apps/stories-svelte/stories/Sortable/Vertical/Vertical.stories.ts
+++ b/apps/stories-svelte/stories/Sortable/Vertical/Vertical.stories.ts
@@ -6,6 +6,9 @@ import sortableItemSource from '../SortableItem.svelte?raw';
 import SortableDragHandleApp from '../SortableDragHandleApp.svelte';
 import sortableDragHandleSource from '../SortableDragHandleApp.svelte?raw';
 import sortableItemWithHandleSource from '../SortableItemWithHandle.svelte?raw';
+import SortableDynamicFeedbackApp from '../SortableDynamicFeedbackApp.svelte';
+import sortableDynamicFeedbackSource from '../SortableDynamicFeedbackApp.svelte?raw';
+import sortableDynamicFeedbackItemSource from '../SortableDynamicFeedbackItem.svelte?raw';
 import NestedScrollSortableApp from '../NestedScrollSortableApp.svelte';
 import {
   baseStyles,
@@ -45,6 +48,20 @@ export const WithDragHandle: Story = {
         'src/styles.css': [baseStyles, sortableStyles, handleStyles].join(
           '\n\n'
         ),
+      },
+    },
+  },
+};
+
+export const DynamicFeedback: Story = {
+  name: 'Dynamic feedback',
+  render: () => ({Component: SortableDynamicFeedbackApp}),
+  parameters: {
+    codesandbox: {
+      files: {
+        'src/App.svelte': sortableDynamicFeedbackSource,
+        'src/SortableDynamicFeedbackItem.svelte': sortableDynamicFeedbackItemSource,
+        'src/styles.css': [baseStyles, sortableStyles].join('\n\n'),
       },
     },
   },

--- a/apps/stories-vanilla/stories/Sortable/Sortable.stories.ts
+++ b/apps/stories-vanilla/stories/Sortable/Sortable.stories.ts
@@ -2,6 +2,8 @@ import type {Meta, StoryObj} from '@storybook/html-vite';
 
 import App from './SortableApp.ts';
 import sortableSource from './SortableApp.ts?raw';
+import DynamicFeedbackApp from './SortableDynamicFeedbackApp.ts';
+import sortableDynamicFeedbackSource from './SortableDynamicFeedbackApp.ts?raw';
 import {baseStyles, sortableStyles} from '@dnd-kit/stories-shared/styles/sandbox';
 
 const meta: Meta = {
@@ -18,6 +20,19 @@ export const BasicSetup: Story = {
     codesandbox: {
       files: {
         'src/App.ts': sortableSource,
+        'src/styles.css': [baseStyles, sortableStyles].join('\n\n'),
+      },
+    },
+  },
+};
+
+export const DynamicFeedback: Story = {
+  name: 'Dynamic feedback',
+  render: () => DynamicFeedbackApp(),
+  parameters: {
+    codesandbox: {
+      files: {
+        'src/App.ts': sortableDynamicFeedbackSource,
         'src/styles.css': [baseStyles, sortableStyles].join('\n\n'),
       },
     },

--- a/apps/stories-vanilla/stories/Sortable/SortableDynamicFeedbackApp.ts
+++ b/apps/stories-vanilla/stories/Sortable/SortableDynamicFeedbackApp.ts
@@ -1,0 +1,49 @@
+import {DragDropManager, Feedback} from '@dnd-kit/dom';
+import {Sortable} from '@dnd-kit/dom/sortable';
+
+const dynamicFeedbackPlugin = Feedback.configure({
+  feedback: (_source, manager) =>
+    manager.dragOperation.activatorEvent instanceof KeyboardEvent
+      ? 'clone'
+      : 'default',
+});
+
+export default function App() {
+  const list = document.createElement('ul');
+  list.className = 'list';
+
+  const manager = new DragDropManager();
+  const items = createRange(100);
+
+  for (const id of items) {
+    const li = document.createElement('li');
+    li.className = 'item';
+    li.textContent = String(id);
+
+    list.appendChild(li);
+
+    const sortable = new Sortable(
+      {
+        id,
+        element: li,
+        index: id - 1,
+        plugins: [dynamicFeedbackPlugin],
+        effects: () => [
+          () => {
+            if (sortable.isDragging) {
+              li.dataset.shadow = '';
+              return () => delete li.dataset.shadow;
+            }
+          },
+        ],
+      },
+      manager
+    );
+  }
+
+  return list;
+}
+
+function createRange(length: number) {
+  return Array.from({length}, (_, i) => i + 1);
+}

--- a/apps/stories-vanilla/stories/Sortable/SortableDynamicFeedbackApp.ts
+++ b/apps/stories-vanilla/stories/Sortable/SortableDynamicFeedbackApp.ts
@@ -1,12 +1,16 @@
 import {DragDropManager, Feedback} from '@dnd-kit/dom';
+import type {Plugins} from '@dnd-kit/abstract';
 import {Sortable} from '@dnd-kit/dom/sortable';
 
-const dynamicFeedbackPlugin = Feedback.configure({
-  feedback: (_source, manager) =>
-    manager.dragOperation.activatorEvent instanceof KeyboardEvent
-      ? 'clone'
-      : 'default',
-});
+const dynamicFeedbackPlugins = (defaults: Plugins) => [
+  ...defaults,
+  Feedback.configure({
+    feedback: (_source, manager) =>
+      manager.dragOperation.activatorEvent instanceof KeyboardEvent
+        ? 'clone'
+        : 'default',
+  }),
+];
 
 export default function App() {
   const list = document.createElement('ul');
@@ -27,7 +31,7 @@ export default function App() {
         id,
         element: li,
         index: id - 1,
-        plugins: [dynamicFeedbackPlugin],
+        plugins: dynamicFeedbackPlugins,
         effects: () => [
           () => {
             if (sortable.isDragging) {

--- a/apps/stories-vue/stories/Sortable/SortableDynamicFeedbackApp.vue
+++ b/apps/stories-vue/stories/Sortable/SortableDynamicFeedbackApp.vue
@@ -1,18 +1,22 @@
 <script setup lang="ts">
 import {ref, computed} from 'vue';
 import {Feedback} from '@dnd-kit/dom';
+import type {Plugins} from '@dnd-kit/abstract';
 import {DragDropProvider} from '@dnd-kit/vue';
 import {useSortable} from '@dnd-kit/vue/sortable';
 import {move} from '@dnd-kit/helpers';
 
 const items = ref(Array.from({length: 100}, (_, i) => i + 1));
 
-const dynamicFeedbackPlugin = Feedback.configure({
-  feedback: (_source, manager) =>
-    manager.dragOperation.activatorEvent instanceof KeyboardEvent
-      ? 'clone'
-      : 'default',
-});
+const plugins = (defaults: Plugins) => [
+  ...defaults,
+  Feedback.configure({
+    feedback: (_source, manager) =>
+      manager.dragOperation.activatorEvent instanceof KeyboardEvent
+        ? 'clone'
+        : 'default',
+  }),
+];
 
 function onDragEnd(event: any) {
   items.value = move(items.value, event);
@@ -26,7 +30,7 @@ const SortableItem = defineComponent({
   props: {
     id: {type: Number, required: true},
     index: {type: Number, required: true},
-    plugins: {type: Array, default: undefined},
+    plugins: {type: [Array, Function], default: undefined},
   },
   setup(props) {
     const element = ref<HTMLElement | null>(null);
@@ -56,7 +60,7 @@ export default defineComponent({components: {SortableItem}});
         :key="id"
         :id="id"
         :index="index"
-        :plugins="[dynamicFeedbackPlugin]"
+        :plugins="plugins"
       />
     </ul>
   </DragDropProvider>

--- a/apps/stories-vue/stories/Sortable/SortableDynamicFeedbackApp.vue
+++ b/apps/stories-vue/stories/Sortable/SortableDynamicFeedbackApp.vue
@@ -1,0 +1,63 @@
+<script setup lang="ts">
+import {ref, computed} from 'vue';
+import {Feedback} from '@dnd-kit/dom';
+import {DragDropProvider} from '@dnd-kit/vue';
+import {useSortable} from '@dnd-kit/vue/sortable';
+import {move} from '@dnd-kit/helpers';
+
+const items = ref(Array.from({length: 100}, (_, i) => i + 1));
+
+const dynamicFeedbackPlugin = Feedback.configure({
+  feedback: (_source, manager) =>
+    manager.dragOperation.activatorEvent instanceof KeyboardEvent
+      ? 'clone'
+      : 'default',
+});
+
+function onDragEnd(event: any) {
+  items.value = move(items.value, event);
+}
+</script>
+
+<script lang="ts">
+import {defineComponent} from 'vue';
+
+const SortableItem = defineComponent({
+  props: {
+    id: {type: Number, required: true},
+    index: {type: Number, required: true},
+    plugins: {type: Array, default: undefined},
+  },
+  setup(props) {
+    const element = ref<HTMLElement | null>(null);
+    const {isDragging} = useSortable({
+      id: computed(() => props.id),
+      index: computed(() => props.index),
+      element,
+      plugins: computed(() => props.plugins),
+    });
+    return {element, isDragging};
+  },
+  template: `
+    <li ref="element" class="item" :data-shadow="isDragging || undefined">
+      {{ id }}
+    </li>
+  `,
+});
+
+export default defineComponent({components: {SortableItem}});
+</script>
+
+<template>
+  <DragDropProvider @dragEnd="onDragEnd">
+    <ul class="list">
+      <SortableItem
+        v-for="(id, index) in items"
+        :key="id"
+        :id="id"
+        :index="index"
+        :plugins="[dynamicFeedbackPlugin]"
+      />
+    </ul>
+  </DragDropProvider>
+</template>

--- a/apps/stories-vue/stories/Sortable/Vertical/Vertical.stories.ts
+++ b/apps/stories-vue/stories/Sortable/Vertical/Vertical.stories.ts
@@ -4,6 +4,8 @@ import SortableApp from '../SortableApp.vue';
 import sortableSource from '../SortableApp.vue?raw';
 import SortableDragHandleApp from '../SortableDragHandleApp.vue';
 import sortableDragHandleSource from '../SortableDragHandleApp.vue?raw';
+import SortableDynamicFeedbackApp from '../SortableDynamicFeedbackApp.vue';
+import sortableDynamicFeedbackSource from '../SortableDynamicFeedbackApp.vue?raw';
 import {
   baseStyles,
   handleStyles,
@@ -38,6 +40,19 @@ export const WithDragHandle: Story = {
       files: {
         'src/App.vue': sortableDragHandleSource,
         'src/styles.css': [baseStyles, sortableStyles, handleStyles].join('\n\n'),
+      },
+    },
+  },
+};
+
+export const DynamicFeedback: Story = {
+  name: 'Dynamic feedback',
+  render: () => ({components: {SortableDynamicFeedbackApp}, template: '<SortableDynamicFeedbackApp />'}),
+  parameters: {
+    codesandbox: {
+      files: {
+        'src/App.vue': sortableDynamicFeedbackSource,
+        'src/styles.css': [baseStyles, sortableStyles].join('\n\n'),
       },
     },
   },

--- a/apps/stories/stories/react/Sortable/SortableExample.tsx
+++ b/apps/stories/stories/react/Sortable/SortableExample.tsx
@@ -2,6 +2,7 @@ import React, {useRef, useState, memo} from 'react';
 import type {CSSProperties, PropsWithChildren} from 'react';
 import type {
   CollisionDetector,
+  Customizable,
   Modifiers,
   Plugins,
   UniqueIdentifier,
@@ -20,7 +21,7 @@ interface Props {
   debug?: boolean;
   dragHandle?: boolean;
   disabled?: UniqueIdentifier[];
-  plugins?: Plugins;
+  plugins?: Customizable<Plugins>;
   modifiers?: Modifiers;
   layout?: 'vertical' | 'horizontal' | 'grid';
   transition?: SortableTransition;
@@ -84,7 +85,7 @@ interface SortableProps {
   collisionDetector?: CollisionDetector;
   disabled?: boolean;
   dragHandle?: boolean;
-  plugins?: Plugins;
+  plugins?: Customizable<Plugins>;
   optimistic?: boolean;
   transition?: SortableTransition;
   style?: React.CSSProperties;

--- a/apps/stories/stories/react/Sortable/Vertical/Vertical.stories.tsx
+++ b/apps/stories/stories/react/Sortable/Vertical/Vertical.stories.tsx
@@ -79,6 +79,21 @@ export const Clone: Story = {
   },
 };
 
+export const DynamicFeedback: Story = {
+  name: 'Dynamic feedback',
+  args: {
+    debug: false,
+    plugins: [
+      Feedback.configure({
+        feedback: (_source, manager) =>
+          manager.dragOperation.activatorEvent instanceof KeyboardEvent
+            ? 'clone'
+            : 'default',
+      }),
+    ],
+  },
+};
+
 export const RestrictAxis: Story = {
   name: 'Restrict axis',
   args: {

--- a/apps/stories/stories/react/Sortable/Vertical/Vertical.stories.tsx
+++ b/apps/stories/stories/react/Sortable/Vertical/Vertical.stories.tsx
@@ -83,7 +83,8 @@ export const DynamicFeedback: Story = {
   name: 'Dynamic feedback',
   args: {
     debug: false,
-    plugins: [
+    plugins: (defaults) => [
+      ...defaults,
       Feedback.configure({
         feedback: (_source, manager) =>
           manager.dragOperation.activatorEvent instanceof KeyboardEvent

--- a/packages/dom/src/core/index.ts
+++ b/packages/dom/src/core/index.ts
@@ -40,6 +40,7 @@ export {
 } from './plugins/index.ts';
 export type {
   FeedbackType,
+  FeedbackInput,
   FeedbackOptions,
   Transition,
   DropAnimation,

--- a/packages/dom/src/core/plugins/feedback/Feedback.ts
+++ b/packages/dom/src/core/plugins/feedback/Feedback.ts
@@ -38,13 +38,17 @@ import {runDropAnimation, type DropAnimation} from './dropAnimation.ts';
 
 export type FeedbackType = 'default' | 'move' | 'clone' | 'none';
 
+export type FeedbackInput =
+  | FeedbackType
+  | ((source: Draggable, manager: DragDropManager) => FeedbackType);
+
 export interface KeyboardTransition {
   duration?: number;
   easing?: string;
 }
 
 export interface FeedbackOptions {
-  feedback?: FeedbackType;
+  feedback?: FeedbackInput;
   rootElement?: Element | ((source: Draggable) => Element);
   dropAnimation?: DropAnimation | null;
   keyboardTransition?: KeyboardTransition | null;
@@ -130,8 +134,12 @@ export class Feedback extends Plugin<DragDropManager, FeedbackOptions> {
 
     const {element} = source;
     const entityOptions = source.pluginConfig(Feedback);
-    const feedback =
+    const feedbackOption =
       entityOptions?.feedback ?? options?.feedback ?? 'default';
+    const feedback =
+      typeof feedbackOption === 'function'
+        ? feedbackOption(source, manager)
+        : feedbackOption;
 
     if (
       !element ||

--- a/packages/dom/src/core/plugins/feedback/index.ts
+++ b/packages/dom/src/core/plugins/feedback/index.ts
@@ -1,5 +1,5 @@
 export {Feedback} from './Feedback.ts';
-export type {FeedbackType, FeedbackOptions, KeyboardTransition} from './Feedback.ts';
+export type {FeedbackType, FeedbackInput, FeedbackOptions, KeyboardTransition} from './Feedback.ts';
 export type {Transition} from './types.ts';
 export type {
   DropAnimation,

--- a/packages/dom/src/core/plugins/index.ts
+++ b/packages/dom/src/core/plugins/index.ts
@@ -6,6 +6,7 @@ export {Feedback} from './feedback/index.ts';
 export type {Transition} from './feedback/types.ts';
 export type {
   FeedbackType,
+  FeedbackInput,
   FeedbackOptions,
   DropAnimation,
   DropAnimationOptions,


### PR DESCRIPTION
## Summary
- Allow the `feedback` option in the `Feedback` plugin to accept a callback `(source, manager) => FeedbackType`, enabling dynamic feedback type selection based on context such as the activator event.
- Export the new `FeedbackInput` type from `@dnd-kit/dom`.

## Example

```ts
Feedback.configure({
  feedback: (source, manager) => {
    return isKeyboardEvent(manager.dragOperation.activatorEvent)
      ? 'clone'
      : 'default';
  },
});
```

## Test plan
- [x] Verify static string values (`'default'`, `'clone'`, `'move'`, `'none'`) continue to work unchanged
- [x] Verify callback form is invoked with correct `source` and `manager` arguments
- [x] Verify dynamic feedback selection based on activator event type

🤖 Generated with [Claude Code](https://claude.com/claude-code)