### PR TITLE
Fix mobile docs UX and CodeGroup tab switching

### DIFF
--- a/apps/docs/src/components/Assistant/AssistantSheet.tsx
+++ b/apps/docs/src/components/Assistant/AssistantSheet.tsx
@@ -123,7 +123,7 @@ function AssistantSheetClient() {
   return (
     <div
       className={cn(
-        'fixed bottom-6 left-1/2 -translate-x-1/2 z-[100] w-[calc(100%-2rem)] max-w-lg print:hidden',
+        'fixed bottom-6 left-1/2 -translate-x-1/2 z-50 w-[calc(100%-2rem)] max-w-lg print:hidden',
         'transition-all duration-300 ease-in-out',
       )}
     >

--- a/apps/docs/src/components/Assistant/LazyAssistant.tsx
+++ b/apps/docs/src/components/Assistant/LazyAssistant.tsx
@@ -96,7 +96,7 @@ export function LazyAssistant() {
 
 function Placeholder({ onActivate, loading }: { onActivate: () => void; loading: boolean }) {
   return (
-    <div className="fixed bottom-6 left-1/2 -translate-x-1/2 z-[100] w-[calc(100%-2rem)] max-w-lg print:hidden">
+    <div className="fixed bottom-6 left-1/2 -translate-x-1/2 z-50 w-[calc(100%-2rem)] max-w-lg print:hidden">
       <div
         className="rounded-2xl overflow-hidden bg-white/80 dark:bg-[#0b0b10]/80 backdrop-blur-xl backdrop-saturate-[180%] border border-gray-300/60 dark:border-white/15 shadow-[0_8px_32px_rgba(0,0,0,0.12)] dark:shadow-[0_8px_32px_rgba(0,0,0,0.4)]"
       >

--- a/apps/docs/src/components/CodeBlock.tsx
+++ b/apps/docs/src/components/CodeBlock.tsx
@@ -1,11 +1,10 @@
 /**
  * Custom CodeBlock component.
  *
- * Highlighting is done at build time (SSR only) via Shiki. The client
- * only hydrates the interactive copy/Ask AI buttons — zero highlighter
- * JS is shipped to the browser.
+ * Highlighting runs at build time (SSR) via Shiki. The client only
+ * hydrates the copy/Ask AI buttons — no highlighter JS shipped.
  */
-import { useState, type ReactNode } from 'react';
+import { useState, useMemo, type ReactNode } from 'react';
 import { openAssistant } from './Assistant/events';
 
 const SUPPORTED_LANGS = new Set([
@@ -35,81 +34,74 @@ function extractLanguage(className?: string): string {
 }
 
 /**
- * SSR-only: highlight code with Shiki. This function is only called
- * during build (typeof window === 'undefined'). Vite will include the
- * Shiki imports in the SSR bundle but tree-shake them from the client.
+ * SSR-only Shiki highlighter. Initialized once at build time via
+ * top-level await. On the client, highlightCode is undefined.
  */
 let highlightCode: ((code: string, lang: string, highlight?: string) => string) | undefined;
 
 if (typeof window === 'undefined') {
-  // Server-side only — these imports end up in the SSR bundle, not the client
-  const initHighlighter = async () => {
-    const { createHighlighterCoreSync } = await import('shiki/core');
-    const { createJavaScriptRegexEngine } = await import('shiki/engine/javascript');
-    const { transformerNotationDiff, transformerNotationHighlight } = await import('@shikijs/transformers');
-    const monokai = (await import('shiki/themes/monokai.mjs')).default;
+  const { createHighlighterCoreSync } = await import('shiki/core');
+  const { createJavaScriptRegexEngine } = await import('shiki/engine/javascript');
+  const { transformerNotationDiff, transformerNotationHighlight } = await import('@shikijs/transformers');
+  const monokai = (await import('shiki/themes/monokai.mjs')).default;
 
-    const langs = await Promise.all([
-      import('shiki/langs/tsx.mjs'),
-      import('shiki/langs/typescript.mjs'),
-      import('shiki/langs/javascript.mjs'),
-      import('shiki/langs/json.mjs'),
-      import('shiki/langs/jsonc.mjs'),
-      import('shiki/langs/bash.mjs'),
-      import('shiki/langs/css.mjs'),
-      import('shiki/langs/html.mjs'),
-      import('shiki/langs/vue.mjs'),
-      import('shiki/langs/svelte.mjs'),
-    ]);
+  const langs = await Promise.all([
+    import('shiki/langs/tsx.mjs'),
+    import('shiki/langs/typescript.mjs'),
+    import('shiki/langs/javascript.mjs'),
+    import('shiki/langs/json.mjs'),
+    import('shiki/langs/jsonc.mjs'),
+    import('shiki/langs/bash.mjs'),
+    import('shiki/langs/css.mjs'),
+    import('shiki/langs/html.mjs'),
+    import('shiki/langs/vue.mjs'),
+    import('shiki/langs/svelte.mjs'),
+  ]);
 
-    const highlighter = createHighlighterCoreSync({
-      themes: [monokai],
-      langs: langs.map(l => l.default),
-      engine: createJavaScriptRegexEngine(),
+  const highlighter = createHighlighterCoreSync({
+    themes: [monokai],
+    langs: langs.map(l => l.default),
+    engine: createJavaScriptRegexEngine(),
+  });
+
+  highlightCode = (code: string, lang: string, highlight?: string) => {
+    const transformers: any[] = [
+      transformerNotationDiff({
+        classLineAdd: 'line-diff line-add',
+        classLineRemove: 'line-diff line-remove',
+      }),
+      transformerNotationHighlight({
+        classActiveLine: 'line-highlight',
+      }),
+    ];
+
+    if (highlight) {
+      try {
+        const lines = JSON.parse(highlight) as number[];
+        if (lines.length) {
+          transformers.push({
+            name: 'line-highlight-prop',
+            line(node: any, line: number) {
+              if (lines.includes(line)) {
+                (this as any).addClassToHast(node, 'line-highlight');
+              }
+            },
+          });
+        }
+      } catch {}
+    }
+
+    let effectiveLang = lang === 'text' ? 'javascript' : lang;
+    if (effectiveLang === 'json' && code.includes('[!code')) {
+      effectiveLang = 'jsonc';
+    }
+
+    return highlighter.codeToHtml(code, {
+      lang: effectiveLang,
+      theme: 'monokai',
+      transformers,
     });
-
-    return (code: string, lang: string, highlight?: string) => {
-      const transformers: any[] = [
-        transformerNotationDiff({
-          classLineAdd: 'line-diff line-add',
-          classLineRemove: 'line-diff line-remove',
-        }),
-        transformerNotationHighlight({
-          classActiveLine: 'line-highlight',
-        }),
-      ];
-
-      if (highlight) {
-        try {
-          const lines = JSON.parse(highlight) as number[];
-          if (lines.length) {
-            transformers.push({
-              name: 'line-highlight-prop',
-              line(node: any, line: number) {
-                if (lines.includes(line)) {
-                  (this as any).addClassToHast(node, 'line-highlight');
-                }
-              },
-            });
-          }
-        } catch {}
-      }
-
-      let effectiveLang = lang === 'text' ? 'javascript' : lang;
-      if (effectiveLang === 'json' && code.includes('[!code')) {
-        effectiveLang = 'jsonc';
-      }
-
-      return highlighter.codeToHtml(code, {
-        lang: effectiveLang,
-        theme: 'monokai',
-        transformers,
-      });
-    };
   };
-
-  // Top-level await in SSR module
-  highlightCode = await initHighlighter();
 }
 
 interface CodeBlockProps {
@@ -130,7 +122,7 @@ export function CodeBlock({
   const code = extractCode(children).replace(/\n$/, '');
   const lang = extractLanguage(className);
 
-  // SSR: highlight with Shiki. Client: HTML is already in the DOM.
+  // SSR: highlight with Shiki. Client: empty (HTML preserved by CodeGroup).
   const html = highlightCode ? highlightCode(code, lang, highlight) : '';
 
   const [copied, setCopied] = useState(false);
@@ -142,17 +134,12 @@ export function CodeBlock({
     });
   };
 
-  // On the server, render highlighted HTML. On the client, the HTML is
-  // already in the DOM from SSR — pass dangerouslySetInnerHTML only during
-  // SSR so React doesn't overwrite the existing content during hydration.
-  const isServer = typeof window === 'undefined';
-
   const codeContent = (
     <div className="relative group">
       <div
         className={`overflow-auto text-sm leading-6 bg-[#1e1e1e] ${isGrouped ? '' : 'rounded-2xl'}`}
         style={{ fontVariantLigatures: 'none' }}
-        {...(isServer ? { dangerouslySetInnerHTML: { __html: html } } : {})}
+        dangerouslySetInnerHTML={{ __html: html }}
         suppressHydrationWarning
       />
       <div className="absolute top-3 right-3 flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity">

--- a/apps/docs/src/components/CodeBlock.tsx
+++ b/apps/docs/src/components/CodeBlock.tsx
@@ -142,12 +142,17 @@ export function CodeBlock({
     });
   };
 
+  // On the server, render highlighted HTML. On the client, the HTML is
+  // already in the DOM from SSR — pass dangerouslySetInnerHTML only during
+  // SSR so React doesn't overwrite the existing content during hydration.
+  const isServer = typeof window === 'undefined';
+
   const codeContent = (
     <div className="relative group">
       <div
         className={`overflow-auto text-sm leading-6 bg-[#1e1e1e] ${isGrouped ? '' : 'rounded-2xl'}`}
         style={{ fontVariantLigatures: 'none' }}
-        dangerouslySetInnerHTML={{ __html: html }}
+        {...(isServer ? { dangerouslySetInnerHTML: { __html: html } } : {})}
         suppressHydrationWarning
       />
       <div className="absolute top-3 right-3 flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity">

--- a/apps/docs/src/components/CodeGroup.tsx
+++ b/apps/docs/src/components/CodeGroup.tsx
@@ -1,10 +1,12 @@
 /**
  * Custom CodeGroup component — tabbed code blocks.
  *
- * All CodeBlock children are pre-rendered at build time (SSR).
- * Tab switching just toggles visibility — no client-side highlighting needed.
+ * All CodeBlock children are rendered at build time (SSR) with Shiki
+ * highlighting. On the client, tab switching uses DOM manipulation to
+ * toggle visibility — React never re-renders the code content, so the
+ * SSR HTML is preserved.
  */
-import { useState, Children, isValidElement, type ReactElement } from 'react';
+import { useState, useRef, useEffect, Children, isValidElement, type ReactElement } from 'react';
 import { CodeBlock } from './CodeBlock';
 
 interface CodeGroupProps {
@@ -14,13 +16,25 @@ interface CodeGroupProps {
 export function CodeGroup({ children }: CodeGroupProps) {
   const blocks = Children.toArray(children).filter(isValidElement) as ReactElement[];
   const [selected, setSelected] = useState(0);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const tabs = blocks.map((block, i) => ({
+    label: block.props?.filename || `Tab ${i + 1}`,
+    index: i,
+  }));
+
+  // Toggle visibility via DOM instead of React re-render
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+
+    const panels = container.querySelectorAll<HTMLElement>('[data-code-panel]');
+    panels.forEach((panel, i) => {
+      panel.style.display = i === selected ? '' : 'none';
+    });
+  }, [selected]);
 
   if (blocks.length === 0) return null;
-
-  const tabs = blocks.map((block, i) => {
-    const filename = block.props?.filename || `Tab ${i + 1}`;
-    return { label: filename, index: i };
-  });
 
   return (
     <div className="not-prose code-group my-5 rounded-2xl overflow-hidden border border-white/5">
@@ -40,16 +54,21 @@ export function CodeGroup({ children }: CodeGroupProps) {
           </button>
         ))}
       </div>
-      {/* Render ALL blocks at build time, toggle visibility on the client */}
-      {blocks.map((block, i) => (
-        <div key={i} className={i === selected ? '' : 'hidden'}>
-          <CodeBlock
-            {...block.props}
-            filename={undefined}
-            isGrouped
-          />
-        </div>
-      ))}
+      <div ref={containerRef}>
+        {blocks.map((block, i) => (
+          <div
+            key={i}
+            data-code-panel
+            style={{ display: i === selected ? undefined : 'none' }}
+          >
+            <CodeBlock
+              {...block.props}
+              filename={undefined}
+              isGrouped
+            />
+          </div>
+        ))}
+      </div>
     </div>
   );
 }

--- a/apps/docs/src/components/CodeGroup.tsx
+++ b/apps/docs/src/components/CodeGroup.tsx
@@ -2,11 +2,12 @@
  * Custom CodeGroup component — tabbed code blocks.
  *
  * All CodeBlock children are rendered at build time (SSR) with Shiki
- * highlighting. On the client, tab switching uses DOM manipulation to
- * toggle visibility — React never re-renders the code content, so the
- * SSR HTML is preserved.
+ * highlighting. Tab switching is pure CSS — zero JavaScript.
+ *
+ * DOM order: radios → tab labels → panels
+ * CSS uses :has() on .code-group to match checked radio → style tabs + panels.
  */
-import { useState, useRef, useEffect, Children, isValidElement, type ReactElement } from 'react';
+import { useId, Children, isValidElement, type ReactElement } from 'react';
 import { CodeBlock } from './CodeBlock';
 
 interface CodeGroupProps {
@@ -14,61 +15,49 @@ interface CodeGroupProps {
 }
 
 export function CodeGroup({ children }: CodeGroupProps) {
+  const id = useId();
   const blocks = Children.toArray(children).filter(isValidElement) as ReactElement[];
-  const [selected, setSelected] = useState(0);
-  const containerRef = useRef<HTMLDivElement>(null);
-
-  const tabs = blocks.map((block, i) => ({
-    label: block.props?.filename || `Tab ${i + 1}`,
-    index: i,
-  }));
-
-  // Toggle visibility via DOM instead of React re-render
-  useEffect(() => {
-    const container = containerRef.current;
-    if (!container) return;
-
-    const panels = container.querySelectorAll<HTMLElement>('[data-code-panel]');
-    panels.forEach((panel, i) => {
-      panel.style.display = i === selected ? '' : 'none';
-    });
-  }, [selected]);
 
   if (blocks.length === 0) return null;
 
   return (
     <div className="not-prose code-group my-5 rounded-2xl overflow-hidden border border-white/5">
-      <div className="flex items-center gap-0 bg-[#1e1e1e] border-b border-white/5 overflow-x-auto">
-        {tabs.map((tab) => (
-          <button
-            key={tab.index}
-            type="button"
-            onClick={() => setSelected(tab.index)}
-            className={`px-4 py-2.5 text-xs font-medium whitespace-nowrap transition-colors cursor-pointer border-b-2 ${
-              tab.index === selected
-                ? 'text-white/90 border-primary'
-                : 'text-white/40 border-transparent hover:text-white/60'
-            }`}
-          >
-            {tab.label}
-          </button>
-        ))}
-      </div>
-      <div ref={containerRef}>
+      {/* Hidden radios at the top — CSS uses .code-group:has(#id:checked) */}
+      {blocks.map((_, i) => (
+        <input
+          key={`r${i}`}
+          type="radio"
+          name={id}
+          id={`${id}-${i}`}
+          defaultChecked={i === 0}
+          className="sr-only"
+          data-tab-index={i}
+        />
+      ))}
+
+      {/* Tab bar */}
+      <div className="code-tabs flex items-center gap-0 bg-[#1e1e1e] border-b border-white/5 overflow-x-auto">
         {blocks.map((block, i) => (
-          <div
+          <label
             key={i}
-            data-code-panel
-            style={{ display: i === selected ? undefined : 'none' }}
+            htmlFor={`${id}-${i}`}
+            className="code-tab px-4 py-2.5 text-xs font-medium whitespace-nowrap transition-colors cursor-pointer border-b-2 text-white/40 border-transparent hover:text-white/60"
           >
-            <CodeBlock
-              {...block.props}
-              filename={undefined}
-              isGrouped
-            />
-          </div>
+            {block.props?.filename || `Tab ${i + 1}`}
+          </label>
         ))}
       </div>
+
+      {/* Panels — all hidden by default, shown via CSS :has(:checked) */}
+      {blocks.map((block, i) => (
+        <div key={i} className="code-panel" data-panel-index={i}>
+          <CodeBlock
+            {...block.props}
+            filename={undefined}
+            isGrouped
+          />
+        </div>
+      ))}
     </div>
   );
 }

--- a/apps/docs/src/components/Header.astro
+++ b/apps/docs/src/components/Header.astro
@@ -24,7 +24,7 @@ const activeVersion = versionTabs.find((v) => v.isActive);
 const hasVersions = versionTabs.length > 1;
 ---
 
-<header class="sticky top-0 w-full px-8 z-50">
+<header class="sticky top-0 w-full px-4 lg:px-8 z-50">
   <div
     class="absolute left-1/2 -translate-x-1/2 w-screen h-full backdrop-blur flex-none transition-colors duration-500 border-b border-gray-500/5 bg-white/95 supports-backdrop-blur:bg-white/60 dark:bg-background-dark/95 dark:supports-backdrop-blur:bg-background-dark/60 dark:border-white/5"
   >

--- a/apps/docs/src/components/Header.astro
+++ b/apps/docs/src/components/Header.astro
@@ -94,8 +94,8 @@ const hasVersions = versionTabs.length > 1;
               )}
             </div>
 
-            {/* Center: search */}
-            <div class="flex-1 hidden lg:flex items-center justify-center min-w-0">
+            {/* Center: search (desktop) */}
+            <div class="hidden lg:flex flex-1 items-center justify-center min-w-0">
               <div class="w-full max-w-sm">
                 <SearchBar client:load />
               </div>

--- a/apps/docs/src/components/Header.astro
+++ b/apps/docs/src/components/Header.astro
@@ -36,8 +36,18 @@ const hasVersions = versionTabs.length > 1;
           <div
             class="h-full relative flex-1 flex items-center justify-between gap-x-4 min-w-0 lg:border-none"
           >
-            {/* Left: logo + version */}
+            {/* Left: hamburger (mobile) + logo + version */}
             <div class="flex items-center gap-3 shrink-0">
+              <button
+                type="button"
+                class="lg:hidden flex items-center justify-center w-8 h-8 text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200"
+                aria-label="Open navigation"
+                data-mobile-nav-toggle
+              >
+                <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                  <line x1="4" x2="20" y1="12" y2="12" /><line x1="4" x2="20" y1="6" y2="6" /><line x1="4" x2="20" y1="18" y2="18" />
+                </svg>
+              </button>
               <a href="/" class="flex items-center shrink-0" data-logo-link>
                 <svg width="135" height="45" viewBox="0 0 474 158" fill="none" xmlns="http://www.w3.org/2000/svg" class="h-[45px] w-auto" role="img" aria-label="dnd kit">
                   <rect x="4.5" y="4.5" width="465" height="149" rx="14.5" fill="black" stroke="url(#logo-grad)" stroke-width="9"/>
@@ -125,15 +135,6 @@ const hasVersions = versionTabs.length > 1;
             </div>
           </div>
         </div>
-        {
-          pageTitle && (
-            <MobileNavToggle
-              pageTitle={pageTitle}
-              groupName={groupName}
-              client:load
-            />
-          )
-        }
       </div>
     </div>
   </div>
@@ -141,6 +142,13 @@ const hasVersions = versionTabs.length > 1;
 
 <script>
   document.addEventListener('astro:page-load', () => {
+    // Wire hamburger button to mobile sidebar
+    document.querySelectorAll('[data-mobile-nav-toggle]').forEach((btn) => {
+      btn.addEventListener('click', () => {
+        window.dispatchEvent(new CustomEvent('toggle-mobile-sidebar'));
+      });
+    });
+
     const dropdowns = document.querySelectorAll('[data-version-dropdown]');
     dropdowns.forEach((dropdown) => {
       const toggle = dropdown.querySelector('[data-version-toggle]');

--- a/apps/docs/src/components/MobileHeaderActions.tsx
+++ b/apps/docs/src/components/MobileHeaderActions.tsx
@@ -13,6 +13,15 @@ export function MobileActionButtons() {
       >
         <Icon icon="search" iconLibrary="lucide" size={16} color="dimgray" />
       </button>
+      <a
+        href="https://github.com/clauderic/dnd-kit"
+        target="_blank"
+        rel="noopener noreferrer"
+        className="text-gray-500 dark:text-gray-400 w-8 h-8 flex items-center justify-center hover:text-gray-600 dark:hover:text-gray-200"
+        aria-label="GitHub"
+      >
+        <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0 0 24 12c0-6.63-5.37-12-12-12z"/></svg>
+      </a>
       <ThemeToggle />
     </div>
   );

--- a/apps/docs/src/components/SearchBar.tsx
+++ b/apps/docs/src/components/SearchBar.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
+import { createPortal } from 'react-dom';
 import { navigate } from 'astro:transitions/client';
 import { useDebouncedCallback } from 'use-debounce';
 import { type DecoratedNavigationPage } from '@mintlify/models';
@@ -238,13 +239,9 @@ export function SearchBar() {
   const showEmpty = !hasQuery || isLoading || results.length > 0 ? false : true;
   const showDropdown = isOpen && (hasResults || showEmpty || hasQuery);
 
-  // On mobile, render as a fixed overlay; on desktop, render inline
-  const isMobile = typeof window !== 'undefined' && window.innerWidth < 1024;
-  const isMobileOverlay = isOpen && isMobile;
-
   return (
     <>
-      {/* Desktop: inline search input */}
+      {/* Inline search input (visible on desktop via parent CSS) */}
       <div className="relative">
         <div className="relative">
           <input
@@ -275,9 +272,9 @@ export function SearchBar() {
           )}
         </div>
 
-        {/* Desktop: click-away + dropdown */}
-        {isOpen && !isMobileOverlay && <div className="fixed inset-0 z-[199]" onClick={() => setIsOpen(false)} />}
-        {showDropdown && !isMobileOverlay && (
+        {/* Desktop: inline click-away + dropdown (hidden on mobile since parent is hidden) */}
+        {isOpen && <div className="fixed inset-0 z-[199]" onClick={() => setIsOpen(false)} />}
+        {showDropdown && (
           <div className="absolute top-full left-0 right-0 mt-2 z-[200] rounded-xl border border-stone-200 dark:border-white/10 bg-white dark:bg-gray-900 shadow-xl overflow-hidden">
           {hasResults && (
             <div ref={listRef} className="max-h-[min(400px,60vh)] overflow-y-auto p-1.5">
@@ -355,11 +352,11 @@ export function SearchBar() {
       )}
     </div>
 
-    {/* Mobile: fixed overlay with search input + results */}
-    {isMobileOverlay && (
+    {/* Search overlay — portaled to body for mobile (escapes hidden parent) and ⌘K trigger */}
+    {isOpen && createPortal(
       <>
-        <div className="fixed inset-0 z-[199] bg-black/20 backdrop-blur-sm" onClick={() => setIsOpen(false)} />
-        <div className="fixed top-0 left-0 right-0 z-[200] p-4 bg-white dark:bg-gray-900 border-b border-stone-200 dark:border-white/10 shadow-lg">
+        <div className="lg:hidden fixed inset-0 z-[199] bg-black/20 backdrop-blur-sm" onClick={() => setIsOpen(false)} />
+        <div className="lg:hidden fixed top-0 left-0 right-0 z-[200] p-4 bg-white dark:bg-gray-900 border-b border-stone-200 dark:border-white/10 shadow-lg">
           <div className="relative">
             <input
               ref={inputRef}
@@ -423,7 +420,8 @@ export function SearchBar() {
             </div>
           )}
         </div>
-      </>
+      </>,
+      document.body
     )}
     </>
   );

--- a/apps/docs/src/components/SearchBar.tsx
+++ b/apps/docs/src/components/SearchBar.tsx
@@ -238,44 +238,47 @@ export function SearchBar() {
   const showEmpty = !hasQuery || isLoading || results.length > 0 ? false : true;
   const showDropdown = isOpen && (hasResults || showEmpty || hasQuery);
 
+  // On mobile, render as a fixed overlay; on desktop, render inline
+  const isMobile = typeof window !== 'undefined' && window.innerWidth < 1024;
+  const isMobileOverlay = isOpen && isMobile;
+
   return (
-    <div className="relative">
-      {/* Search input — always visible */}
+    <>
+      {/* Desktop: inline search input */}
       <div className="relative">
-        <input
-          ref={inputRef}
-          type="search"
-          placeholder="Search..."
-          value={query}
-          onChange={(e) => handleInputChange(e.target.value)}
-          onKeyDown={handleKeyDown}
-          onFocus={() => setIsOpen(true)}
-          className="w-full h-9 rounded-xl bg-transparent pl-9 pr-14 text-sm text-stone-950 dark:text-white outline-none border border-stone-200 dark:border-white/10 hover:border-stone-300 dark:hover:border-white/20 focus:border-stone-300 dark:focus:border-white/20 focus:shadow-[0_1px_3px_rgba(0,0,0,0.08),0_0_0_1px_rgba(0,0,0,0.04)] dark:focus:shadow-[0_1px_3px_rgba(0,0,0,0.3),0_0_0_1px_rgba(255,255,255,0.06)] transition placeholder:text-stone-400 dark:placeholder:text-white/50 [&::-webkit-search-cancel-button]:appearance-none"
-          autoComplete="off"
-        />
-        <svg
-          width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"
-          className="absolute top-1/2 left-3 -translate-y-1/2 text-stone-400 dark:text-white/40 pointer-events-none peer-focus:text-[var(--primary)] transition-colors"
-        >
-          <circle cx="11" cy="11" r="8" /><path d="m21 21-4.3-4.3" />
-        </svg>
-        <kbd className="absolute top-1/2 right-3 -translate-y-1/2 hidden sm:inline-flex text-xs text-stone-400 dark:text-white/30 pointer-events-none">⌘K</kbd>
-        {isLoading && (
+        <div className="relative">
+          <input
+            ref={isMobileOverlay ? undefined : inputRef}
+            type="search"
+            placeholder="Search..."
+            value={query}
+            onChange={(e) => handleInputChange(e.target.value)}
+            onKeyDown={handleKeyDown}
+            onFocus={() => setIsOpen(true)}
+            className="w-full h-9 rounded-xl bg-transparent pl-9 pr-14 text-sm text-stone-950 dark:text-white outline-none border border-stone-200 dark:border-white/10 hover:border-stone-300 dark:hover:border-white/20 focus:border-stone-300 dark:focus:border-white/20 focus:shadow-[0_1px_3px_rgba(0,0,0,0.08),0_0_0_1px_rgba(0,0,0,0.04)] dark:focus:shadow-[0_1px_3px_rgba(0,0,0,0.3),0_0_0_1px_rgba(255,255,255,0.06)] transition placeholder:text-stone-400 dark:placeholder:text-white/50 [&::-webkit-search-cancel-button]:appearance-none"
+            autoComplete="off"
+          />
           <svg
-            width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"
-            className="absolute top-1/2 right-3 -translate-y-1/2 text-stone-400 animate-spin"
+            width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"
+            className="absolute top-1/2 left-3 -translate-y-1/2 text-stone-400 dark:text-white/40 pointer-events-none peer-focus:text-[var(--primary)] transition-colors"
           >
-            <path d="M21 12a9 9 0 1 1-6.219-8.56" />
+            <circle cx="11" cy="11" r="8" /><path d="m21 21-4.3-4.3" />
           </svg>
-        )}
-      </div>
+          <kbd className="absolute top-1/2 right-3 -translate-y-1/2 hidden sm:inline-flex text-xs text-stone-400 dark:text-white/30 pointer-events-none">⌘K</kbd>
+          {isLoading && (
+            <svg
+              width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"
+              className="absolute top-1/2 right-3 -translate-y-1/2 text-stone-400 animate-spin"
+            >
+              <path d="M21 12a9 9 0 1 1-6.219-8.56" />
+            </svg>
+          )}
+        </div>
 
-      {/* Click-away overlay */}
-      {isOpen && <div className="fixed inset-0 z-[199]" onClick={() => setIsOpen(false)} />}
-
-      {/* Dropdown results */}
-      {showDropdown && (
-        <div className="absolute top-full left-0 right-0 mt-2 z-[200] rounded-xl border border-stone-200 dark:border-white/10 bg-white dark:bg-gray-900 shadow-xl overflow-hidden">
+        {/* Desktop: click-away + dropdown */}
+        {isOpen && !isMobileOverlay && <div className="fixed inset-0 z-[199]" onClick={() => setIsOpen(false)} />}
+        {showDropdown && !isMobileOverlay && (
+          <div className="absolute top-full left-0 right-0 mt-2 z-[200] rounded-xl border border-stone-200 dark:border-white/10 bg-white dark:bg-gray-900 shadow-xl overflow-hidden">
           {hasResults && (
             <div ref={listRef} className="max-h-[min(400px,60vh)] overflow-y-auto p-1.5">
               {!query.trim() && recentSearches.length > 0 && (
@@ -351,6 +354,78 @@ export function SearchBar() {
         </div>
       )}
     </div>
+
+    {/* Mobile: fixed overlay with search input + results */}
+    {isMobileOverlay && (
+      <>
+        <div className="fixed inset-0 z-[199] bg-black/20 backdrop-blur-sm" onClick={() => setIsOpen(false)} />
+        <div className="fixed top-0 left-0 right-0 z-[200] p-4 bg-white dark:bg-gray-900 border-b border-stone-200 dark:border-white/10 shadow-lg">
+          <div className="relative">
+            <input
+              ref={inputRef}
+              type="search"
+              placeholder="Search..."
+              value={query}
+              onChange={(e) => handleInputChange(e.target.value)}
+              onKeyDown={handleKeyDown}
+              autoFocus
+              className="w-full h-10 rounded-xl bg-stone-50 dark:bg-white/5 pl-9 pr-10 text-sm text-stone-950 dark:text-white outline-none border border-stone-200 dark:border-white/10 focus:border-stone-300 dark:focus:border-white/20 placeholder:text-stone-400 dark:placeholder:text-white/50 [&::-webkit-search-cancel-button]:appearance-none"
+              autoComplete="off"
+            />
+            <svg
+              width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"
+              className="absolute top-1/2 left-3 -translate-y-1/2 text-stone-400 dark:text-white/40 pointer-events-none"
+            >
+              <circle cx="11" cy="11" r="8" /><path d="m21 21-4.3-4.3" />
+            </svg>
+            <button type="button" onClick={() => setIsOpen(false)} className="absolute top-1/2 right-3 -translate-y-1/2 text-stone-400 hover:text-stone-600 dark:hover:text-white/70">
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <path d="M18 6 6 18" /><path d="m6 6 12 12" />
+              </svg>
+            </button>
+          </div>
+          {(hasResults || showEmpty) && (
+            <div className="mt-2 max-h-[60vh] overflow-y-auto">
+              {hasResults && (
+                <div ref={listRef} className="p-1.5">
+                  {!query.trim() && recentSearches.length > 0 && (
+                    <div className="px-3 py-1.5 text-xs font-medium text-stone-400 dark:text-stone-500">Recent</div>
+                  )}
+                  {displayItems.map((item, i) => (
+                    <button
+                      key={item.id}
+                      type="button"
+                      className={`flex w-full cursor-pointer items-start gap-3 rounded-lg px-3 py-2 text-left transition-colors ${
+                        i === activeIndex
+                          ? 'bg-stone-100 dark:bg-white/5'
+                          : 'hover:bg-stone-50 dark:hover:bg-white/[0.02]'
+                      }`}
+                      onClick={() => selectResult(item)}
+                    >
+                      <div className="flex flex-1 flex-col gap-0.5 min-w-0">
+                        <div className="truncate text-sm font-medium text-stone-900 dark:text-white">{item.title}</div>
+                        {item.content && (
+                          <div
+                            className="line-clamp-1 text-xs text-stone-500 dark:text-stone-400 search-highlight"
+                            dangerouslySetInnerHTML={{ __html: item.content }}
+                          />
+                        )}
+                      </div>
+                    </button>
+                  ))}
+                </div>
+              )}
+              {showEmpty && (
+                <div className="px-4 py-6 text-center text-sm text-stone-500 dark:text-stone-400">
+                  No results found
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+      </>
+    )}
+    </>
   );
 }
 

--- a/apps/docs/src/components/SearchBar.tsx
+++ b/apps/docs/src/components/SearchBar.tsx
@@ -51,6 +51,7 @@ export function SearchBar() {
   const [activeIndex, setActiveIndex] = useState(0);
   const [recentSearches, setRecentSearches] = useState<SearchItem[]>([]);
   const inputRef = useRef<HTMLInputElement>(null);
+  const mobileInputRef = useRef<HTMLInputElement>(null);
   const listRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -80,10 +81,12 @@ export function SearchBar() {
     return () => document.removeEventListener('keydown', handleKeyDown);
   }, []);
 
-  // Focus input when opened
+  // Focus input when opened — try mobile input first, then desktop
   useEffect(() => {
     if (isOpen) {
-      setTimeout(() => inputRef.current?.focus(), 50);
+      setTimeout(() => {
+        mobileInputRef.current?.focus() || inputRef.current?.focus();
+      }, 50);
     } else {
       setQuery('');
       setResults([]);
@@ -245,7 +248,7 @@ export function SearchBar() {
       <div className="relative">
         <div className="relative">
           <input
-            ref={isMobileOverlay ? undefined : inputRef}
+            ref={inputRef}
             type="search"
             placeholder="Search..."
             value={query}
@@ -359,7 +362,7 @@ export function SearchBar() {
         <div className="lg:hidden fixed top-0 left-0 right-0 z-[200] p-4 bg-white dark:bg-gray-900 border-b border-stone-200 dark:border-white/10 shadow-lg">
           <div className="relative">
             <input
-              ref={inputRef}
+              ref={mobileInputRef}
               type="search"
               placeholder="Search..."
               value={query}

--- a/apps/docs/src/components/Sidebar/MobileSidebar.tsx
+++ b/apps/docs/src/components/Sidebar/MobileSidebar.tsx
@@ -59,17 +59,6 @@ export function MobileSidebar({
         />
       )}
 
-      {isOpen && (
-        <button
-          type="button"
-          onClick={() => setIsOpen(false)}
-          className="fixed bg-white dark:bg-gray-900 rounded-full top-4 right-4 w-8 h-8 flex items-center justify-center text-gray-500 hover:text-gray-600 dark:text-gray-400 dark:hover:text-gray-300 shadow-md z-80 lg:hidden"
-          aria-label="Close navigation"
-        >
-          <Icon icon="x" iconLibrary="lucide" size={18} />
-        </button>
-      )}
-
       <div
         className={cn(
           'fixed top-0 left-0 bottom-0 w-[20rem] bg-white dark:bg-background-dark z-70 transition-transform duration-300 ease-in-out lg:hidden',
@@ -77,14 +66,26 @@ export function MobileSidebar({
         )}
       >
         <div className="flex flex-col h-full">
-          <div className="flex items-center justify-between px-4 pt-6 pb-4">
-            <img
-              src="/images/logo/logo.svg"
-              alt="dnd kit"
-              width="84"
-              height="28"
-              className="h-7 w-auto"
-            />
+          <div className="flex items-center justify-between px-4 pt-5 pb-4">
+            <a href="/">
+              <img
+                src="/images/logo/logo.svg"
+                alt="dnd kit"
+                width="135"
+                height="45"
+                className="h-[38px] w-auto"
+              />
+            </a>
+            <button
+              type="button"
+              onClick={() => setIsOpen(false)}
+              className="w-8 h-8 flex items-center justify-center text-gray-400 hover:text-gray-600 dark:text-gray-500 dark:hover:text-gray-300 rounded-md hover:bg-gray-100 dark:hover:bg-white/5"
+              aria-label="Close navigation"
+            >
+              <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <path d="M18 6 6 18" /><path d="m6 6 12 12" />
+              </svg>
+            </button>
           </div>
 
           <nav className="flex-1 overflow-y-auto pt-4 pb-8">

--- a/apps/docs/src/styles/prose.css
+++ b/apps/docs/src/styles/prose.css
@@ -78,6 +78,30 @@
   padding-left: calc(1rem - 2px);
 }
 
+/* CodeGroup: pure CSS tab switching via radio inputs + :has() */
+.code-group .code-panel { display: none; }
+
+/* Show the panel whose index matches the checked radio */
+.code-group:has([data-tab-index="0"]:checked) [data-panel-index="0"],
+.code-group:has([data-tab-index="1"]:checked) [data-panel-index="1"],
+.code-group:has([data-tab-index="2"]:checked) [data-panel-index="2"],
+.code-group:has([data-tab-index="3"]:checked) [data-panel-index="3"],
+.code-group:has([data-tab-index="4"]:checked) [data-panel-index="4"],
+.code-group:has([data-tab-index="5"]:checked) [data-panel-index="5"] {
+  display: block;
+}
+
+/* Highlight the active tab label */
+.code-group:has([data-tab-index="0"]:checked) .code-tab:nth-child(1),
+.code-group:has([data-tab-index="1"]:checked) .code-tab:nth-child(2),
+.code-group:has([data-tab-index="2"]:checked) .code-tab:nth-child(3),
+.code-group:has([data-tab-index="3"]:checked) .code-tab:nth-child(4),
+.code-group:has([data-tab-index="4"]:checked) .code-tab:nth-child(5),
+.code-group:has([data-tab-index="5"]:checked) .code-tab:nth-child(6) {
+  color: rgba(255, 255, 255, 0.9);
+  border-color: var(--primary);
+}
+
 .line.line-diff.line-remove {
   background-color: rgba(248, 81, 73, 0.15) !important;
   border-left: 2px solid rgba(248, 81, 73, 0.5);


### PR DESCRIPTION
## Summary
- Add hamburger menu icon to mobile header bar (was missing)
- Remove page title row that wrapped below header on mobile
- Enlarge mobile sidebar logo (28px → 38px) with home link
- Replace floating X close button with subtle inline close
- Lower assistant z-index so mobile sidebar overlay covers it
- Reduce mobile header padding (px-8 → px-4)
- Fix mobile search: portal overlay to document.body so it works from hidden parent
- Fix CodeGroup tabs: pure CSS switching with radio inputs + :has() selectors (zero JS)
- Fix SSR-only Shiki: code content preserved across tab switches
- Add GitHub icon to mobile header

## Test plan
- [ ] Mobile: hamburger opens sidebar, close button works
- [ ] Mobile: search icon opens overlay with input + results
- [ ] Mobile: assistant bar hidden behind sidebar overlay
- [ ] Desktop: search bar and CodeGroup tabs work as before
- [ ] CodeGroup: switching tabs preserves syntax-highlighted code
- [ ] Build: all 16 monorepo tasks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)