### PR TITLE
Docs: add v0.4.0 changelog and improve responsive navigation

### DIFF
--- a/apps/docs/docs/changelog.mdx
+++ b/apps/docs/docs/changelog.mdx
@@ -6,6 +6,31 @@ icon: 'clock'
 hideContextMenu: true
 ---
 
+## v0.4.0
+
+<Update label="v0.4.0" description="April 2025" tags={["Minor"]}>
+  **Event type system redesign** — Replaced `DragDropEvents` with `DragDropEventMap` and `DragDropEventHandlers`, following the DOM `EventMap` pattern for improved type safety.
+
+  **Per-entity plugin configuration** — [Draggable](/concepts/draggable) entities now accept a `plugins` property for entity-specific plugin configuration. The `feedback` property has moved from the Draggable entity to the [Feedback plugin](/extend/plugins/feedback) configuration. [Sortable](/concepts/sortable) uses the same generic mechanism instead of custom registration.
+
+  **Virtualization improvements** — Entity identity changes are now batched and deferred to a microtask to prevent collision oscillation during virtualized sorting.
+
+  **[Feedback plugin](/extend/plugins/feedback) enhancements** — Added `keyboardTransition` option to customize or disable CSS transitions on keyboard moves. The `feedback` option now supports a callback form for dynamically choosing the feedback type. `DropAnimationFunction` context now includes `source`.
+
+  **[AutoScroller](/extend/plugins/auto-scroller) updates** — Added `acceleration` (default: `25`) and `threshold` (default: `0.2`) options to control scroll speed and activation zone, with per-axis configuration via `{x, y}`.
+
+  **[Sortable](/concepts/sortable) plugin improvements** — `plugins` now accepts `Customizable<Plugins>`, a function form that extends defaults without losing built-in Sortable plugins.
+
+  **Bug fixes:**
+  - Fixed `onDragStart` firing before `onDragOver` for elements that are both [draggable](/concepts/draggable) and [droppable](/concepts/droppable)
+  - Resolved DTS build errors with TypeScript 5.9 on Node 20
+  - Fixed [plugin](/extend/plugins) registration order when deduplicating configured plugins
+  - Fixed `useDeepSignal` calling `flushSync` from a React lifecycle method
+  - Svelte: Removed `OptimisticSortingPlugin` from defaults to prevent conflicts with Svelte 5 reconciliation
+  - Vue: Fixed [sortable](/concepts/sortable) type narrowing and re-exported drag event type aliases
+  - Added LICENSE file to all published packages
+</Update>
+
 ## v0.3.2
 
 <Update label="v0.3.2" description="March 2025" tags={["Patch"]}>

--- a/apps/docs/docs/index.mdx
+++ b/apps/docs/docs/index.mdx
@@ -6,7 +6,7 @@ ogTitle: "The modern toolkit for building\ndrag & drop interfaces"
 ogDescription: ''
 seo:
   title: 'dnd kit – The toolkit for building drag and drop interfaces'
-  description: 'A lightweight, performant, accessible and extensible drag and drop toolkit for React, Vue, Svelte, SolidJS, and vanilla JavaScript.'
+  description: 'A lightweight, modular drag and drop toolkit built with TypeScript. Works without a framework, with first-class support for React, Vue, Svelte, and SolidJS.'
 ---
 
 {/* Hero SVG is inlined by the page template for faster LCP */}

--- a/apps/docs/docs/index.mdx
+++ b/apps/docs/docs/index.mdx
@@ -5,8 +5,8 @@ hideContextMenu: true
 ogTitle: "The modern toolkit for building\ndrag & drop interfaces"
 ogDescription: ''
 seo:
-  title: 'dnd kit – The toolkit for building drag and drop interfaces'
-  description: 'A lightweight, modular drag and drop toolkit built with TypeScript. Works without a framework, with first-class support for React, Vue, Svelte, and SolidJS.'
+  title: 'dnd kit – The modern toolkit for building drag and drop interfaces'
+  description: 'A lightweight, extensible drag and drop toolkit written in TypeScript. Framework-agnostic core with first-class integrations for React, Vue, Svelte, and SolidJS.'
 ---
 
 {/* Hero SVG is inlined by the page template for faster LCP */}

--- a/apps/docs/src/components/Header.astro
+++ b/apps/docs/src/components/Header.astro
@@ -1,6 +1,6 @@
 ---
 import { SearchBar } from './SearchBar';
-import { MobileActionButtons, MobileNavToggle } from './MobileHeaderActions';
+import { MobileActionButtons, MobileNavToggle, TabletSearchButton } from './MobileHeaderActions';
 import { ThemeToggle } from './ThemeToggle';
 
 type VersionInfo = { name: string; href: string; isActive: boolean };
@@ -103,8 +103,8 @@ const hasVersions = versionTabs.length > 1;
 
             <MobileActionButtons client:load />
 
-            {/* Right: links + icons */}
-            <div class="hidden lg:flex items-center gap-4 shrink-0">
+            {/* Right: navbar links (tablet+) + icons */}
+            <div class="hidden md:flex items-center gap-4 shrink-0">
               {navbarConfig?.links?.map((link) => {
                 const isExternal = link.href.startsWith('http');
                 return (
@@ -118,6 +118,9 @@ const hasVersions = versionTabs.length > 1;
                   </a>
                 );
               })}
+              <div class="lg:hidden">
+                <TabletSearchButton client:load />
+              </div>
               {navbarConfig?.github && (
                 <a
                   href={navbarConfig.github}

--- a/apps/docs/src/components/MobileHeaderActions.tsx
+++ b/apps/docs/src/components/MobileHeaderActions.tsx
@@ -4,7 +4,7 @@ import { ThemeToggle } from './ThemeToggle';
 
 export function MobileActionButtons() {
   return (
-    <div className="flex lg:hidden items-center gap-2">
+    <div className="flex md:hidden items-center gap-2">
       <button
         type="button"
         className="text-gray-500 dark:text-gray-400 w-8 h-8 flex items-center justify-center hover:text-gray-600 dark:hover:text-gray-200"
@@ -24,6 +24,21 @@ export function MobileActionButtons() {
       </a>
       <ThemeToggle />
     </div>
+  );
+}
+
+export function TabletSearchButton() {
+  return (
+    <button
+      type="button"
+      className="p-1.5 rounded-md text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 hover:bg-gray-100 dark:hover:bg-white/5 transition-colors"
+      onClick={openSearch}
+      aria-label="Search"
+    >
+      <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+        <circle cx="11" cy="11" r="8" /><path d="m21 21-4.3-4.3" />
+      </svg>
+    </button>
   );
 }
 

--- a/apps/docs/src/components/Sidebar/MobileSidebar.tsx
+++ b/apps/docs/src/components/Sidebar/MobileSidebar.tsx
@@ -8,11 +8,14 @@ import { SidebarEntries } from './SidebarEntries';
 import { Anchors } from './Anchors';
 import { TabsDropdown } from './TabsDropdown';
 
+type NavbarLink = { label: string; href: string };
+
 interface MobileSidebarProps {
   navigation: NavNode;
   currentPath: string;
   tabs?: TabInfo[];
   anchors?: AnchorItem[];
+  navbarLinks?: NavbarLink[];
   sidebarItemStyle?: SidebarItemStyle;
   showDivider?: boolean;
 }
@@ -22,6 +25,7 @@ export function MobileSidebar({
   currentPath,
   tabs = [],
   anchors = [],
+  navbarLinks = [],
   sidebarItemStyle = 'container',
   showDivider = false,
 }: MobileSidebarProps) {
@@ -89,7 +93,7 @@ export function MobileSidebar({
           </div>
 
           <nav className="flex-1 overflow-y-auto pt-4 pb-8">
-            {tabs.length > 0 && (
+            {tabs.length > 1 && (
               <div className="px-4 mb-4">
                 <TabsDropdown tabs={tabs} />
               </div>
@@ -109,6 +113,30 @@ export function MobileSidebar({
                 showDivider={showDivider}
               />
             </div>
+
+            {navbarLinks.length > 0 && (
+              <div className="mt-6 border-t border-gray-200 dark:border-white/10 px-4 pt-4 flex flex-col gap-2">
+                {navbarLinks.map((link) => {
+                  const isExternal = link.href.startsWith('http');
+                  return (
+                    <a
+                      key={link.label}
+                      href={link.href}
+                      target={isExternal ? '_blank' : undefined}
+                      rel={isExternal ? 'noopener noreferrer' : undefined}
+                      className="flex items-center gap-2 text-sm font-medium text-gray-600 hover:text-gray-800 dark:text-gray-400 dark:hover:text-gray-200 py-1.5"
+                    >
+                      {link.label}
+                      {isExternal && (
+                        <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="text-gray-400 dark:text-gray-500">
+                          <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" /><polyline points="15 3 21 3 21 9" /><line x1="10" y1="14" x2="21" y2="3" />
+                        </svg>
+                      )}
+                    </a>
+                  );
+                })}
+              </div>
+            )}
           </nav>
         </div>
       </div>

--- a/apps/docs/src/pages/[...slug].astro
+++ b/apps/docs/src/pages/[...slug].astro
@@ -143,8 +143,17 @@ const anchors = anchorTabs.map((a) => ({
   isActive: a.isActive,
 }));
 
-// Navbar config
-const navbarConfig = (docsConfig as any).navbar;
+// Navbar config — override Examples link for Legacy version
+const baseNavbarConfig = (docsConfig as any).navbar;
+const isLegacy = activeVersion?.version === 'Legacy';
+const navbarConfig = {
+  ...baseNavbarConfig,
+  links: baseNavbarConfig?.links?.map((link: any) =>
+    link.label === 'Examples' && isLegacy
+      ? { ...link, href: 'https://master--5fc05e08a4a65d0021ae0bf2.chromatic.com' }
+      : link
+  ),
+};
 ---
 
 <Layout title={doc.data.metaTitle || doc.data.seo?.title || `${doc.data.title || doc.id} - dnd kit`} description={doc.data.seo?.description || doc.data.description} path={currentPath}>
@@ -159,8 +168,9 @@ const navbarConfig = (docsConfig as any).navbar;
     <MobileSidebar
       navigation={page.navigation}
       currentPath={currentPath}
-      tabs={tabs || []}
+      tabs={versionTabs}
       anchors={anchors}
+      navbarLinks={navbarConfig?.links || []}
       client:load
     />
 

--- a/apps/docs/src/pages/[...slug].astro
+++ b/apps/docs/src/pages/[...slug].astro
@@ -148,11 +148,13 @@ const baseNavbarConfig = (docsConfig as any).navbar;
 const isLegacy = activeVersion?.version === 'Legacy';
 const navbarConfig = {
   ...baseNavbarConfig,
-  links: baseNavbarConfig?.links?.map((link: any) =>
-    link.label === 'Examples' && isLegacy
-      ? { ...link, href: 'https://master--5fc05e08a4a65d0021ae0bf2.chromatic.com' }
-      : link
-  ),
+  links: baseNavbarConfig?.links
+    ?.filter((link: any) => !(link.label === 'Changelog' && isLegacy))
+    .map((link: any) =>
+      link.label === 'Examples' && isLegacy
+        ? { ...link, href: 'https://master--5fc05e08a4a65d0021ae0bf2.chromatic.com' }
+        : link
+    ),
 };
 ---
 


### PR DESCRIPTION
## Summary
- Add **v0.4.0 changelog entry** covering all features and bug fixes from the release (event type redesign, per-entity plugin config, virtualization improvements, feedback/autoscroller/sortable enhancements, and 7 bug fixes)
- **Show navbar links at tablet breakpoint** — Examples, Changelog, and Community links now appear at `md` (768px+) instead of only at `lg` (1024px+), with search/GitHub/theme icons grouped on the right
- **Add navbar links to mobile sidebar** — Examples, Changelog, and Community appear at the bottom of the mobile nav with external link indicators
- **Fix mobile sidebar version dropdown** — now shows Latest/Legacy switcher instead of duplicating the framework anchor tabs already listed below
- **Version-aware Examples link** — points to `examples.dndkit.com` for Latest docs and the Chromatic storybook for Legacy docs

## Test plan
- [ ] Verify changelog page renders v0.4.0 entry correctly
- [ ] Check header at desktop (1024px+): full search bar + navbar links + icons
- [ ] Check header at tablet (768px–1023px): hamburger + logo + navbar links + search/GitHub/theme icons
- [ ] Check header at mobile (<768px): hamburger + logo + search/GitHub/theme icons only
- [ ] Open mobile sidebar and verify Examples/Changelog/Community links at bottom
- [ ] Open mobile sidebar and verify Latest/Legacy dropdown (not framework tabs)
- [ ] Navigate to a Legacy page and verify Examples link points to Chromatic storybook
- [ ] Navigate to a Latest page and verify Examples link points to examples.dndkit.com

🤖 Generated with [Claude Code](https://claude.com/claude-code)