### PR TITLE
SEO: deprioritize legacy docs with canonical URLs and sitemap priority

### DIFF
--- a/apps/docs/astro.config.mjs
+++ b/apps/docs/astro.config.mjs
@@ -9,7 +9,21 @@ import tailwindcss from '@tailwindcss/vite';
 
 export default defineConfig({
   site: 'https://dndkit.com',
-  integrations: [mintlify({ docsDir: './docs' }), react(), mdx(), sitemap()],
+  integrations: [
+    mintlify({ docsDir: './docs' }),
+    react(),
+    mdx(),
+    sitemap({
+      serialize(item) {
+        if (item.url.includes('/legacy/')) {
+          item.priority = 0.3;
+        } else {
+          item.priority = 0.7;
+        }
+        return item;
+      },
+    }),
+  ],
   markdown: {
     shikiConfig: {
       theme: 'monokai',

--- a/apps/docs/src/pages/[...slug].astro
+++ b/apps/docs/src/pages/[...slug].astro
@@ -156,9 +156,35 @@ const navbarConfig = {
         : link
     ),
 };
+
+// Canonical URL mapping: legacy pages point to their latest equivalents
+const legacyCanonicalMap: Record<string, string> = {
+  '/legacy/introduction/installation': '/quickstart',
+  '/legacy/introduction/getting-started': '/quickstart',
+  '/legacy/api-documentation/draggable': '/concepts/draggable',
+  '/legacy/api-documentation/draggable/use-draggable': '/react/hooks/use-draggable',
+  '/legacy/api-documentation/draggable/drag-overlay': '/react/components/drag-overlay',
+  '/legacy/api-documentation/droppable': '/concepts/droppable',
+  '/legacy/api-documentation/droppable/use-droppable': '/react/hooks/use-droppable',
+  '/legacy/api-documentation/context-provider/dnd-context': '/react/components/drag-drop-provider',
+  '/legacy/api-documentation/context-provider/use-dnd-context': '/concepts/drag-drop-manager',
+  '/legacy/api-documentation/context-provider/use-dnd-monitor': '/react/hooks/use-drag-drop-monitor',
+  '/legacy/api-documentation/context-provider/collision-detection-algorithms': '/concepts/droppable',
+  '/legacy/api-documentation/sensors': '/extend/sensors',
+  '/legacy/api-documentation/sensors/pointer': '/extend/sensors/pointer-sensor',
+  '/legacy/api-documentation/sensors/keyboard': '/extend/sensors/keyboard-sensor',
+  '/legacy/api-documentation/sensors/mouse': '/extend/sensors/pointer-sensor',
+  '/legacy/api-documentation/sensors/touch': '/extend/sensors/pointer-sensor',
+  '/legacy/api-documentation/modifiers': '/extend/modifiers',
+  '/legacy/presets/sortable/overview': '/concepts/sortable',
+  '/legacy/presets/sortable/sortable-context': '/concepts/sortable',
+  '/legacy/presets/sortable/use-sortable': '/react/hooks/use-sortable',
+  '/legacy/guides/accessibility': '/extend/plugins/accessibility',
+};
+const canonicalPath = (isLegacy && legacyCanonicalMap[currentPath]) || currentPath;
 ---
 
-<Layout title={doc.data.metaTitle || doc.data.seo?.title || `${doc.data.title || doc.id} - dnd kit`} description={doc.data.seo?.description || doc.data.description} path={currentPath}>
+<Layout title={doc.data.metaTitle || doc.data.seo?.title || `${doc.data.title || doc.id} - dnd kit`} description={doc.data.seo?.description || doc.data.description} path={canonicalPath}>
   <div>
     <Header
       pageTitle={doc.data.title || doc.id}


### PR DESCRIPTION
## Summary
- Set canonical URLs on legacy pages to point to their latest equivalents (e.g. `/legacy/presets/sortable/overview` → `/concepts/sortable`) so Google consolidates ranking signals onto the current documentation
- Lower sitemap priority for legacy pages to `0.3` (vs `0.7` for latest)

## Test plan
- [ ] Navigate to a legacy page (e.g. `/legacy/presets/sortable/overview`) and verify `<link rel="canonical">` points to `https://dndkit.com/concepts/sortable`
- [ ] Navigate to a latest page and verify canonical points to its own URL
- [ ] Build the site and verify sitemap has correct priority values

🤖 Generated with [Claude Code](https://claude.com/claude-code)