### PR TITLE
Track docs.assistant.completed for answered/unanswered stats

### DIFF
--- a/apps/docs/src/hooks/useAssistant.ts
+++ b/apps/docs/src/hooks/useAssistant.ts
@@ -2,12 +2,14 @@ import { useChat } from '@ai-sdk/react';
 import { DefaultChatTransport } from 'ai';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import useMessagesStore from './useMessagesStore';
+import { trackEvent } from '../lib/analytics';
 
 const SUBDOMAIN = import.meta.env.PUBLIC_MINTLIFY_SUBDOMAIN;
 const API_KEY = import.meta.env.PUBLIC_MINTLIFY_ASSISTANT_KEY;
 
 export const useAssistant = () => {
   const isClearedRef = useRef(false);
+  const lastQueryRef = useRef('');
   const [input, setInput] = useState('');
 
   const { threadId, setThreadId, threadKey, setThreadKey } = useMessagesStore();
@@ -21,6 +23,21 @@ export const useAssistant = () => {
 
   const { messages, sendMessage, status, setMessages, stop } = useChat({
     id: `assistant-${SUBDOMAIN}`,
+    onFinish: (message) => {
+      if (isClearedRef.current) return;
+
+      const content = message.parts
+        ?.filter((p) => p.type === 'text')
+        .map((p) => ('text' in p ? p.text : ''))
+        .join('') ?? '';
+
+      trackEvent('docs.assistant.completed', {
+        query: lastQueryRef.current,
+        content: content.slice(0, 500),
+        sessionId: message.id,
+        subdomain: SUBDOMAIN,
+      });
+    },
     transport: new DefaultChatTransport({
       api: `https://api.mintlify.com/discovery/v2/assistant/${SUBDOMAIN}/message`,
       headers: {
@@ -86,6 +103,7 @@ export const useAssistant = () => {
   const handleSubmit = useCallback(() => {
     if (!input.trim() || status !== 'ready') return;
     isClearedRef.current = false;
+    lastQueryRef.current = input.trim();
     sendMessage({ text: input });
     setInput('');
   }, [input, status, sendMessage]);


### PR DESCRIPTION
## Summary

- Fires `docs.assistant.completed` when the assistant finishes streaming a response, matching the standard Mintlify platform behavior
- This is the event that drives the answered/unanswered stats in the Mintlify dashboard
- Includes `query`, `content`, `sessionId`, and `subdomain` properties

## Test plan

- [ ] Ask the assistant a question and verify `docs.assistant.completed` event is sent after the response finishes streaming
- [ ] Check Mintlify dashboard for answered/unanswered assistant stats

🤖 Generated with [Claude Code](https://claude.com/claude-code)