### PR TITLE
Improve docs based on AI assistant chat analysis

### DIFF
--- a/apps/docs/docs/concepts/draggable.mdx
+++ b/apps/docs/docs/concepts/draggable.mdx
@@ -128,6 +128,10 @@ The `Draggable` class accepts the following arguments:
   An array of [sensors](/extend/sensors) to detect drag interactions.
 </ParamField>
 
+<ParamField path="alignment" type="{ x: 'start' | 'center' | 'end'; y: 'start' | 'center' | 'end' }">
+  How the draggable's position should be aligned relative to its source element during drag operations. Used by the [Feedback plugin](/extend/plugins/feedback) when computing overlay placement. Defaults are inferred from the element's geometry.
+</ParamField>
+
 <ParamField path="data" type="{[key: string]: any}">
   Optional data to associate with this draggable element, available in event handlers.
 </ParamField>

--- a/apps/docs/docs/concepts/droppable.mdx
+++ b/apps/docs/docs/concepts/droppable.mdx
@@ -126,8 +126,12 @@ The `Droppable` class accepts the following arguments:
   The DOM element to make droppable. While not required in the constructor, it must be set to enable dropping.
 </ParamField>
 
-<ParamField path="accepts" type="string | number | Symbol | ((draggable: Draggable) => boolean)">
-  Specify which draggable elements can be dropped on this target. See [accepting specific types](#accepting-specific-types) for more details.
+<ParamField path="accept" type="Type | Type[] | ((source: Draggable) => boolean)">
+  Restrict which draggables can be dropped on this target. Pass a single [`type`](#param-type), an array of types, or a predicate that receives the draggable and returns `true` to accept it. If omitted, every draggable is accepted. See [accepting specific types](#accepting-specific-types) for more details.
+</ParamField>
+
+<ParamField path="type" type="string | number | Symbol">
+  An identifier used by other droppables' `accept` rules to decide whether this droppable can be a target for a given draggable.
 </ParamField>
 
 <ParamField path="collisionDetector" type="CollisionDetector">

--- a/apps/docs/docs/concepts/sortable.mdx
+++ b/apps/docs/docs/concepts/sortable.mdx
@@ -330,8 +330,8 @@ The `Sortable` class accepts the following arguments:
   Optionally restrict which types of items can be sorted together.
 </ParamField>
 
-<ParamField path="accepts" type="string | number | Symbol | ((type) => boolean)">
-  Optionally restrict which types of items can be dropped on this item.
+<ParamField path="accept" type="Type | Type[] | ((source: Draggable) => boolean)">
+  Restrict which draggables can be dropped on this sortable item. Pass a single [`type`](#param-type), an array of types, or a predicate that receives the draggable and returns `true` to accept it.
 </ParamField>
 
 <ParamField path="modifiers" type="Modifier[]">

--- a/apps/docs/docs/docs.json
+++ b/apps/docs/docs/docs.json
@@ -98,6 +98,7 @@
                   "react/guides/migration",
                   "react/guides/multiple-sortable-lists",
                   "react/guides/sortable-state-management",
+                  "react/guides/collision-detection",
                   "react/guides/modifiers",
                   "react/guides/feedback"
                 ]

--- a/apps/docs/docs/docs.json
+++ b/apps/docs/docs/docs.json
@@ -97,7 +97,9 @@
                 "pages": [
                   "react/guides/migration",
                   "react/guides/multiple-sortable-lists",
-                  "react/guides/sortable-state-management"
+                  "react/guides/sortable-state-management",
+                  "react/guides/modifiers",
+                  "react/guides/feedback"
                 ]
               }
             ]

--- a/apps/docs/docs/docs.json
+++ b/apps/docs/docs/docs.json
@@ -99,6 +99,7 @@
                   "react/guides/multiple-sortable-lists",
                   "react/guides/sortable-state-management",
                   "react/guides/collision-detection",
+                  "react/guides/sensors",
                   "react/guides/modifiers",
                   "react/guides/feedback"
                 ]

--- a/apps/docs/docs/docs.json
+++ b/apps/docs/docs/docs.json
@@ -89,7 +89,9 @@
                   "react/hooks/use-draggable",
                   "react/hooks/use-droppable",
                   "react/hooks/use-sortable",
-                  "react/hooks/use-drag-drop-monitor"
+                  "react/hooks/use-drag-drop-monitor",
+                  "react/hooks/use-drag-operation",
+                  "react/hooks/use-drag-drop-manager"
                 ]
               },
               {

--- a/apps/docs/docs/docs.json
+++ b/apps/docs/docs/docs.json
@@ -89,9 +89,16 @@
                   "react/hooks/use-draggable",
                   "react/hooks/use-droppable",
                   "react/hooks/use-sortable",
-                  "react/hooks/use-drag-drop-monitor",
-                  "react/hooks/use-drag-operation",
-                  "react/hooks/use-drag-drop-manager"
+                  {
+                    "group": "Utilities",
+                    "icon": "wrench",
+                    "defaultOpen": true,
+                    "pages": [
+                      "react/hooks/use-drag-drop-monitor",
+                      "react/hooks/use-drag-operation",
+                      "react/hooks/use-drag-drop-manager"
+                    ]
+                  }
                 ]
               },
               {

--- a/apps/docs/docs/extend/sensors/keyboard-sensor.mdx
+++ b/apps/docs/docs/extend/sensors/keyboard-sensor.mdx
@@ -13,7 +13,7 @@ The Keyboard sensor enables keyboard-based drag and drop interactions. It is ena
 
 ```ts
 import {DragDropManager} from '@dnd-kit/dom';
-import {KeyboardSensor} from '@dnd-kit/dom/sensors';
+import {KeyboardSensor} from '@dnd-kit/dom';
 
 const manager = new DragDropManager({
   sensors: [

--- a/apps/docs/docs/extend/sensors/keyboard-sensor.mdx
+++ b/apps/docs/docs/extend/sensors/keyboard-sensor.mdx
@@ -38,13 +38,13 @@ The Keyboard sensor comes with these default key bindings:
 
 ```ts
 const defaultKeyboardCodes = {
-  start: ['Space', 'Enter'],    // Start dragging
-  cancel: ['Escape'],           // Cancel drag operation
-  end: ['Space', 'Enter'],      // End dragging
-  up: ['ArrowUp'],             // Move up
-  down: ['ArrowDown'],         // Move down
-  left: ['ArrowLeft'],         // Move left
-  right: ['ArrowRight'],       // Move right
+  start: ['Space', 'Enter'],          // Start dragging
+  cancel: ['Escape'],                 // Cancel drag operation
+  end: ['Space', 'Enter', 'Tab'],     // End dragging
+  up: ['ArrowUp'],                    // Move up
+  down: ['ArrowDown'],                // Move down
+  left: ['ArrowLeft'],                // Move left
+  right: ['ArrowRight'],              // Move right
 };
 ```
 
@@ -73,7 +73,7 @@ KeyboardSensor.configure({
 
 ## Default behavior
 
-By default, each key press moves the dragged item by 10 pixels. Hold <kbd>Shift</kbd> to move by 50 pixels instead.
+By default, each arrow key press moves the dragged item by 10 pixels. Hold <kbd>Shift</kbd> to multiply movement by 5 (so 50 pixels with the default offset).
 
 ## API Reference
 
@@ -94,6 +94,29 @@ By default, each key press moves the dragged item by 10 pixels. Hold <kbd>Shift<
   }
 
   type KeyCode = KeyboardEvent['code'];
+  ```
+</ParamField>
+
+<ParamField path="offset" type="number | {x: number; y: number}" default="10">
+  The number of pixels to move the dragged item per arrow key press. Pass a single number to apply equally to both axes, or an object to set per-axis values. Hold <kbd>Shift</kbd> while pressing an arrow key to multiply this offset by 5.
+
+  ```ts
+  KeyboardSensor.configure({
+    offset: {x: 20, y: 10}, // Move 20px horizontally, 10px vertically per key press
+  });
+  ```
+</ParamField>
+
+<ParamField path="preventActivation" type="(event: KeyboardEvent, source: Draggable) => boolean">
+  Return `true` to prevent the sensor from starting a drag for a given keydown event. By default, the sensor only activates when the keyboard event's target is the draggable's handle (or its element if no handle is set) — preventing accidental drags from focused descendants like buttons or inputs.
+
+  ```ts
+  KeyboardSensor.configure({
+    preventActivation: (event, source) => {
+      // Don't activate while a text input inside the draggable has focus
+      return event.target instanceof HTMLInputElement;
+    },
+  });
   ```
 </ParamField>
 

--- a/apps/docs/docs/extend/sensors/pointer-sensor.mdx
+++ b/apps/docs/docs/extend/sensors/pointer-sensor.mdx
@@ -201,6 +201,29 @@ The Pointer sensor handles these events:
 
 The sensor automatically binds listeners across all same-origin documents, enabling drag operations across same-origin iframes.
 
+## Touch and mobile
+
+The Pointer sensor handles touch input on mobile devices by default — no additional setup is required.
+
+On touch devices, dragging activates after a **250ms delay** with **5px movement tolerance**. This prevents accidental drags when scrolling. You can customize these constraints for your use case:
+
+```ts
+PointerSensor.configure({
+  activationConstraints(event) {
+    if (event.pointerType === 'touch') {
+      return [
+        new PointerActivationConstraints.Delay({
+          value: 150,    // Shorter delay for faster touch response
+          tolerance: 10, // More tolerance for finger movement
+        }),
+      ];
+    }
+
+    return undefined; // Use defaults for mouse/pen
+  },
+});
+```
+
 ### Best Practices
 
 1. Use appropriate constraints for different input types:

--- a/apps/docs/docs/extend/sensors/pointer-sensor.mdx
+++ b/apps/docs/docs/extend/sensors/pointer-sensor.mdx
@@ -131,7 +131,7 @@ PointerSensor.configure({
 
 ### Options
 
-<ParamField path="activationConstraints" type="ActivationConstraints&lt;PointerEvent&gt; | (event: PointerEvent, source: Draggable) =&gt; ActivationConstraints&lt;PointerEvent&gt;">
+<ParamField path="activationConstraints" type="ActivationConstraints<PointerEvent> | (event: PointerEvent, source: Draggable) => ActivationConstraints<PointerEvent> | undefined">
   Configure when dragging should start using an array of constraint instances:
 
   ```ts
@@ -156,7 +156,32 @@ PointerSensor.configure({
   });
   ```
 
-  Can be a fixed array of constraints or a function that returns constraints based on the event and source.
+  Can be a fixed array of constraints, a function that returns constraints based on the event and source, or `undefined` to fall back to the [defaults](#default-behavior).
+</ParamField>
+
+<ParamField path="activatorElements" type="(Element | undefined)[] | (source: Draggable) => (Element | undefined)[]">
+  The elements that should listen for `pointerdown` events to initiate a drag. By default, the sensor binds to the draggable's `handle` if set, otherwise to its `element`. Use this to designate one or more alternative elements (or compute them from the source) — for example, a separate "drag" button rendered outside the draggable element.
+
+  ```ts
+  PointerSensor.configure({
+    activatorElements: (source) => [source.element?.querySelector('[data-drag-handle]')],
+  });
+  ```
+</ParamField>
+
+<ParamField path="preventActivation" type="(event: PointerEvent, source: Draggable) => boolean">
+  Return `true` to prevent the sensor from activating for a given pointer event. Useful when you want to allow native interactions (text selection, button clicks, form input) inside a draggable element without starting a drag.
+
+  By default, the sensor prevents activation when the pointer target is an [interactive element](https://developer.mozilla.org/en-US/docs/Web/HTML/Content_categories#interactive_content) (like `<button>`, `<input>`, `<a>`) that isn't the draggable's handle or contained by it.
+
+  ```ts
+  PointerSensor.configure({
+    preventActivation: (event, source) => {
+      // Allow drags from anywhere except elements with [data-no-drag]
+      return event.target instanceof Element && event.target.closest('[data-no-drag]') !== null;
+    },
+  });
+  ```
 </ParamField>
 
 ### Built-in constraints

--- a/apps/docs/docs/react/components/drag-drop-provider.mdx
+++ b/apps/docs/docs/react/components/drag-drop-provider.mdx
@@ -178,6 +178,40 @@ function App() {
   Called when collisions are detected. Call `event.preventDefault()` to prevent automatic target selection.
 </ParamField>
 
+#### Event object structure
+
+All event handlers receive an event object and the `manager` instance. The most commonly used event, `onDragEnd`, has this shape:
+
+```ts
+onDragEnd={(event, manager) => {
+  event.operation.source   // The dragged element (Draggable), or null
+  event.operation.target   // The drop target (Droppable), or null
+  event.operation.source.id     // Unique identifier of the dragged element
+  event.operation.target?.id    // Unique identifier of the drop target
+  event.operation.position      // { current: {x, y}, initial: {x, y} }
+  event.operation.status        // Status of the drag operation
+  event.canceled                // true if the drag was cancelled (e.g. Escape key)
+  event.nativeEvent             // The underlying browser event, if available
+}}
+```
+
+For sortable elements, use the [`isSortable`](/react/guides/sortable-state-management#type-guards) type guard to access sortable-specific properties:
+
+```tsx
+import {isSortable} from '@dnd-kit/react/sortable';
+
+onDragEnd={(event) => {
+  const {source} = event.operation;
+
+  if (isSortable(source)) {
+    source.index         // Current position
+    source.initialIndex  // Position when the drag started
+    source.group         // Current group (for multi-list)
+    source.initialGroup  // Group when the drag started
+  }
+}}
+```
+
 ### Configuration
 
 <ParamField path="sensors" type="Sensor[] | (defaults: Sensor[]) => Sensor[]">

--- a/apps/docs/docs/react/guides/collision-detection.mdx
+++ b/apps/docs/docs/react/guides/collision-detection.mdx
@@ -29,13 +29,25 @@ High precision — a collision is only detected when the pointer is **inside** t
 
 Returns the droppable with the **greatest overlap area** with the dragged element's shape. Good for large containers where any visual overlap should count as a collision. Ties are broken by distance to the pointer.
 
+<Frame>
+  <img src="/images/droppable/shape-intersection.svg" alt="Shape intersection: the dragged element overlaps droppable rectangles and the one with the greatest overlap area is selected" />
+</Frame>
+
 ### `closestCenter`
 
 Picks the droppable whose **center point** is closest to the dragged element's center. Ideal for card stacking or grids where items snap to the nearest slot.
 
+<Frame>
+  <img src="/images/droppable/closest-center.svg" alt="Closest center: a line from the dragged element's center to the closest droppable's center" />
+</Frame>
+
 ### `closestCorners`
 
 Picks the droppable with the smallest **average corner-to-corner distance**. More forgiving than `closestCenter` at the edges of a list — useful for vertical sortable lists where you want items to pick up a neighbor as soon as the corners approach.
+
+<Frame>
+  <img src="/images/legacy/closest-corners.png" alt="Closest corners: lines drawn between the four corners of the dragged element and the corresponding corners of each droppable" />
+</Frame>
 
 ### `pointerDistance`
 
@@ -133,13 +145,4 @@ useDroppable({id, collisionDetector: myDetector});
 
 For reference implementations, read the source of the built-in detectors in [`@dnd-kit/collision`](https://github.com/clauderic/dnd-kit/tree/main/packages/collision/src/algorithms).
 
-## Migrating from legacy `collisionDetection`
-
-In `@dnd-kit/core`, `collisionDetection` was a single prop on `DndContext` that applied globally. The new API flips this: each droppable declares its own detector, which is more flexible and composable.
-
-| Legacy | New |
-| --- | --- |
-| `<DndContext collisionDetection={closestCenter}>` | `useDroppable({id, collisionDetector: closestCenter})` |
-| `pointerWithin` | `pointerIntersection` |
-
-See the [Migration guide](/react/guides/migration#collision-detection) for the full mapping table.
+If you're coming from `@dnd-kit/core`, see the [Migration guide](/react/guides/migration#collision-detection) for legacy API mappings.

--- a/apps/docs/docs/react/guides/collision-detection.mdx
+++ b/apps/docs/docs/react/guides/collision-detection.mdx
@@ -1,0 +1,145 @@
+---
+title: 'Collision detection'
+metaTitle: 'Collision Detection - React | dnd kit'
+description: 'Customize how draggable elements detect collisions with droppable targets in React. Includes closestCenter, closestCorners, pointerIntersection, and custom detectors.'
+icon: 'arrows-to-circle'
+---
+
+## Overview
+
+When you drag something over a droppable target, dnd kit runs a **collision detection algorithm** to decide which target is currently being hovered. The default works well for most lists, but you can customize it per droppable when you need different behavior — for example, card stacks, grids, or nested containers.
+
+Built-in detectors are exported from the `@dnd-kit/collision` package. You don't need to install it explicitly — it's already a transitive dependency of `@dnd-kit/react`.
+
+## Built-in detectors
+
+<Note>
+  All built-in detectors are exported from `@dnd-kit/collision`. If you don't pass a `collisionDetector`, dnd kit uses [`defaultCollisionDetection`](#default) automatically — you only need this guide when you want to override it.
+</Note>
+
+### `defaultCollisionDetection`
+
+The default. Runs `pointerIntersection` first, and falls back to `shapeIntersection` when the pointer isn't inside any droppable.
+
+### `pointerIntersection`
+
+High precision — a collision is only detected when the pointer is **inside** the droppable's bounding rectangle. Good for precise drop zones where you want the user to clearly be "over" a target.
+
+### `shapeIntersection`
+
+Returns the droppable with the **greatest overlap area** with the dragged element's shape. Good for large containers where any visual overlap should count as a collision. Ties are broken by distance to the pointer.
+
+### `closestCenter`
+
+Picks the droppable whose **center point** is closest to the dragged element's center. Ideal for card stacking or grids where items snap to the nearest slot.
+
+### `closestCorners`
+
+Picks the droppable with the smallest **average corner-to-corner distance**. More forgiving than `closestCenter` at the edges of a list — useful for vertical sortable lists where you want items to pick up a neighbor as soon as the corners approach.
+
+### `pointerDistance`
+
+Returns the droppable whose center is closest to the **pointer coordinates** (not the dragged element). Useful when you want drop detection to follow the cursor rather than the dragged element.
+
+### `directionBiased`
+
+Only detects collisions in the **direction the user is dragging** (up, down, left, right). Useful when you want items to only be swapped when the user drags *toward* them — prevents jitter when hovering near the edge between two targets.
+
+## Configuring a detector
+
+The `collisionDetector` option is set **per droppable**. Pass any built-in detector (or a custom one) to [`useDroppable`](/react/hooks/use-droppable) or [`useSortable`](/react/hooks/use-sortable):
+
+```tsx
+import {useDroppable} from '@dnd-kit/react';
+import {closestCenter} from '@dnd-kit/collision';
+
+function DropTarget({id}) {
+  const {ref, isDropTarget} = useDroppable({
+    id,
+    collisionDetector: closestCenter,
+  });
+
+  return <div ref={ref}>{isDropTarget ? 'Drop here' : 'Empty'}</div>;
+}
+```
+
+The same option works on `useSortable`:
+
+```tsx
+import {useSortable} from '@dnd-kit/react/sortable';
+import {closestCorners} from '@dnd-kit/collision';
+
+function SortableItem({id, index}) {
+  const sortable = useSortable({
+    id,
+    index,
+    collisionDetector: closestCorners,
+  });
+
+  return <div ref={sortable.ref}>Item {id}</div>;
+}
+```
+
+<Tip>
+  Because `collisionDetector` is configured per droppable rather than globally, different targets on the same page can use different algorithms. For example, a free-form canvas area might use `pointerIntersection` while a sortable list next to it uses `closestCenter`.
+</Tip>
+
+## Collision priority
+
+When multiple droppables overlap — for example, a sortable card inside a droppable column — you can bias which one "wins" using `collisionPriority`. Higher values take precedence.
+
+```tsx
+import {useDroppable} from '@dnd-kit/react';
+import {CollisionPriority} from '@dnd-kit/abstract';
+
+function Column({id, children}) {
+  const {ref} = useDroppable({
+    id,
+    collisionPriority: CollisionPriority.Low, // Cards inside will win by default
+  });
+
+  return <div ref={ref}>{children}</div>;
+}
+```
+
+The `CollisionPriority` enum is exported from `@dnd-kit/abstract` and provides named levels: `Lowest`, `Low`, `Normal`, `High`, `Highest`. You can also pass a plain number.
+
+## Writing a custom detector
+
+A collision detector is a function that receives the drag operation and a droppable, and returns a collision (or `null` if there's no collision). The return `value` is a score — higher scores win when multiple droppables collide.
+
+```tsx
+import type {CollisionDetector} from '@dnd-kit/abstract';
+import {CollisionPriority, CollisionType} from '@dnd-kit/abstract';
+
+const myDetector: CollisionDetector = ({dragOperation, droppable}) => {
+  if (!droppable.shape) return null;
+
+  // Your logic here — return null for no collision, or an object:
+  return {
+    id: droppable.id,
+    value: 1, // Higher values win
+    type: CollisionType.Collision,
+    priority: CollisionPriority.Normal,
+  };
+};
+```
+
+Pass it to any droppable:
+
+```tsx
+useDroppable({id, collisionDetector: myDetector});
+```
+
+For reference implementations, read the source of the built-in detectors in [`@dnd-kit/collision`](https://github.com/clauderic/dnd-kit/tree/main/packages/collision/src/algorithms).
+
+## Migrating from legacy `collisionDetection`
+
+In `@dnd-kit/core`, `collisionDetection` was a single prop on `DndContext` that applied globally. The new API flips this: each droppable declares its own detector, which is more flexible and composable.
+
+| Legacy | New |
+| --- | --- |
+| `<DndContext collisionDetection={closestCenter}>` | `useDroppable({id, collisionDetector: closestCenter})` |
+| `pointerWithin` | `pointerIntersection` |
+
+See the [Migration guide](/react/guides/migration#collision-detection) for the full mapping table.

--- a/apps/docs/docs/react/guides/collision-detection.mdx
+++ b/apps/docs/docs/react/guides/collision-detection.mdx
@@ -1,5 +1,6 @@
 ---
-title: 'Collision detection'
+title: 'Detecting collisions'
+sidebarTitle: 'Detecting collisions'
 metaTitle: 'Collision Detection - React | dnd kit'
 description: 'Customize how draggable elements detect collisions with droppable targets in React. Includes closestCenter, closestCorners, pointerIntersection, and custom detectors.'
 icon: 'arrows-to-circle'

--- a/apps/docs/docs/react/guides/feedback.mdx
+++ b/apps/docs/docs/react/guides/feedback.mdx
@@ -1,0 +1,129 @@
+---
+title: 'Feedback'
+metaTitle: 'Feedback Plugin - React | dnd kit'
+description: 'Configure drag feedback, clone overlays, drop animations, and troubleshoot common issues like duplicate items in React.'
+icon: 'clone'
+---
+
+## Overview
+
+The [Feedback](/extend/plugins/feedback) plugin manages visual feedback during drag operations. It is included by default and handles element promotion to the browser's top layer and drop animations.
+
+This guide covers common React patterns and troubleshooting.
+
+## Configuring feedback globally
+
+To configure feedback for all draggable elements, pass a `plugins` function to [`DragDropProvider`](/react/components/drag-drop-provider):
+
+```tsx
+import {DragDropProvider} from '@dnd-kit/react';
+import {Feedback} from '@dnd-kit/dom';
+
+function App() {
+  return (
+    <DragDropProvider
+      plugins={(defaults) => [
+        ...defaults,
+        Feedback.configure({dropAnimation: null}),
+      ]}
+    >
+      {/* All draggable elements will have no drop animation */}
+    </DragDropProvider>
+  );
+}
+```
+
+<Warning>
+  Use the function form `(defaults) => [...]` to extend the default plugins rather than replacing them. Passing a plain array replaces all default plugins, which may disable expected behavior like auto-scrolling and accessibility.
+</Warning>
+
+## Per-draggable feedback
+
+Configure feedback on individual elements via the `plugins` option in [`useDraggable`](/react/hooks/use-draggable) or [`useSortable`](/react/hooks/use-sortable):
+
+```tsx
+import {useDraggable} from '@dnd-kit/react';
+import {Feedback} from '@dnd-kit/dom';
+
+function CloneDraggable({id}: {id: string}) {
+  const {ref} = useDraggable({
+    id,
+    plugins: [
+      Feedback.configure({
+        feedback: 'clone',
+      }),
+    ],
+  });
+
+  return <div ref={ref}>Drag me (clone stays behind)</div>;
+}
+```
+
+## Feedback modes
+
+The `feedback` option controls how the element behaves during drag:
+
+| Mode | Behavior |
+|------|----------|
+| `'default'` | The element is promoted to the top layer and moves with the pointer |
+| `'clone'` | A clone of the element stays in its original position while the original moves |
+| `'move'` | The element moves without top layer promotion or a placeholder |
+| `'none'` | No visual feedback from the Feedback plugin. Use this when rendering a custom [`DragOverlay`](/react/components/drag-overlay) |
+
+## Drop animations
+
+### Disabling the drop animation
+
+```tsx
+Feedback.configure({dropAnimation: null})
+```
+
+### Customizing the drop animation
+
+```tsx
+Feedback.configure({
+  dropAnimation: {
+    duration: 300,   // milliseconds (default: 250)
+    easing: 'ease',  // CSS easing (default: 'ease')
+  },
+})
+```
+
+### Custom animation function
+
+For full control, provide a function that returns a `Promise`:
+
+```tsx
+Feedback.configure({
+  dropAnimation: async ({element, translate}) => {
+    await element.animate(
+      [{transform: `translate3d(${translate.x}px, ${translate.y}px, 0)`}, {transform: 'translate3d(0, 0, 0)'}],
+      {duration: 200, easing: 'ease-out'}
+    ).finished;
+  },
+})
+```
+
+## Troubleshooting
+
+### Duplicate items after data refetch
+
+When using sortable lists with React Query or other data fetching libraries, you may see duplicate items after a refetch. This happens because the [OptimisticSortingPlugin](/concepts/sortable#optimistic-sorting) has moved DOM elements during the drag, and the refetched data renders new elements in the updated positions.
+
+See [Integration with external state](/react/guides/sortable-state-management#integration-with-external-state) for how to solve this by deferring state sync until the drag is complete.
+
+### Double animation or snap on drop
+
+If items snap into position twice after dropping, your state update is likely conflicting with the drop animation. The Feedback plugin animates the element back, then your state update triggers a re-render that moves it again.
+
+To fix this, disable the drop animation:
+
+```tsx
+Feedback.configure({dropAnimation: null})
+```
+
+Or ensure your state update matches the final position by using the [`move`](/react/guides/sortable-state-management) helper from `@dnd-kit/helpers` in `onDragEnd`, which correctly reconciles the optimistic position with your state.
+
+<Info>
+  For the complete API reference including `rootElement` and `keyboardTransition` options, see the [core Feedback plugin documentation](/extend/plugins/feedback).
+</Info>

--- a/apps/docs/docs/react/guides/feedback.mdx
+++ b/apps/docs/docs/react/guides/feedback.mdx
@@ -1,5 +1,6 @@
 ---
-title: 'Feedback'
+title: 'Customizing feedback'
+sidebarTitle: 'Customizing feedback'
 metaTitle: 'Feedback Plugin - React | dnd kit'
 description: 'Configure drag feedback, clone overlays, drop animations, and troubleshoot common issues like duplicate items in React.'
 icon: 'clone'

--- a/apps/docs/docs/react/guides/migration.mdx
+++ b/apps/docs/docs/react/guides/migration.mdx
@@ -289,65 +289,63 @@ mode: 'wide'
 
 ## API reference
 
-A quick lookup for common legacy APIs and their new equivalents. Organized by category so you can jump to what you need.
+A quick lookup for common legacy APIs and their new equivalents, organized by category.
 
-<AccordionGroup>
-  <Accordion title="Context & Provider" icon="square-dashed">
-    | Legacy (`@dnd-kit/core`) | New (`@dnd-kit/react`) |
-    | --- | --- |
-    | `DndContext` | [`DragDropProvider`](/react/components/drag-drop-provider) |
-    | `SortableContext` | No longer needed |
-  </Accordion>
+### Context & Provider
 
-  <Accordion title="Events" icon="bolt">
-    | Legacy | New |
-    | --- | --- |
-    | `active` | `event.operation.source` |
-    | `over` | `event.operation.target` |
-    | `active.id` | `event.operation.source.id` |
-    | `onDragCancel` | Check `event.canceled` inside `onDragEnd` |
-  </Accordion>
+| Legacy (`@dnd-kit/core`) | New (`@dnd-kit/react`) |
+| --- | --- |
+| `DndContext` | [`DragDropProvider`](/react/components/drag-drop-provider) |
+| `SortableContext` | No longer needed |
 
-  <Accordion title="Sensors" icon="monitor-waveform">
-    | Legacy | New |
-    | --- | --- |
-    | `useSensor` / `useSensors` | Built-in by default. Customize via the `sensors` prop on [`DragDropProvider`](/react/components/drag-drop-provider) |
-    | `PointerSensor` | [`PointerSensor`](/extend/sensors/pointer-sensor) from `@dnd-kit/dom/sensors` |
-    | `KeyboardSensor` | [`KeyboardSensor`](/extend/sensors/keyboard-sensor) from `@dnd-kit/dom/sensors` |
-  </Accordion>
+### Events
 
-  <Accordion title="Collision detection" icon="arrows-to-circle">
-    | Legacy | New |
-    | --- | --- |
-    | `collisionDetection` prop on `DndContext` | `collisionDetector` option on [`useDroppable`](/react/hooks/use-droppable) / [`useSortable`](/react/hooks/use-sortable) |
-    | `pointerWithin` | `pointerIntersection` from `@dnd-kit/collision` |
-    | `closestCenter` | `closestCenter` from `@dnd-kit/collision` |
-    | `closestCorners` | `closestCorners` from `@dnd-kit/collision` |
-  </Accordion>
+| Legacy | New |
+| --- | --- |
+| `active` | `event.operation.source` |
+| `over` | `event.operation.target` |
+| `active.id` | `event.operation.source.id` |
+| `onDragCancel` | Check `event.canceled` inside `onDragEnd` |
 
-  <Accordion title="Modifiers" icon="arrows-to-dot">
-    See the [React modifiers guide](/react/guides/modifiers) for usage examples.
+### Sensors
 
-    | Legacy | New |
-    | --- | --- |
-    | `restrictToParentElement` | `RestrictToElement` from `@dnd-kit/dom/modifiers` |
-    | `restrictToWindowEdges` | `RestrictToWindow` from `@dnd-kit/dom/modifiers` |
-    | `restrictToVerticalAxis` | `RestrictToVerticalAxis` from `@dnd-kit/abstract/modifiers` |
-    | `restrictToHorizontalAxis` | `RestrictToHorizontalAxis` from `@dnd-kit/abstract/modifiers` |
-    | `createSnapModifier` | `SnapModifier` from `@dnd-kit/abstract/modifiers` |
-  </Accordion>
+| Legacy | New |
+| --- | --- |
+| `useSensor` / `useSensors` | Built-in by default. Customize via the `sensors` prop on [`DragDropProvider`](/react/components/drag-drop-provider) |
+| `PointerSensor` | [`PointerSensor`](/extend/sensors/pointer-sensor) from `@dnd-kit/dom/sensors` |
+| `KeyboardSensor` | [`KeyboardSensor`](/extend/sensors/keyboard-sensor) from `@dnd-kit/dom/sensors` |
 
-  <Accordion title="Sortable" icon="arrows-up-down">
-    See the [sortable state management guide](/react/guides/sortable-state-management) for usage examples.
+### Collision detection
 
-    | Legacy | New |
-    | --- | --- |
-    | `arrayMove` | `move` from `@dnd-kit/helpers` |
-    | `verticalListSortingStrategy` | Not needed — handled automatically |
-    | `horizontalListSortingStrategy` | Not needed — handled automatically |
-    | `rectSortingStrategy` | Not needed — handled automatically |
-  </Accordion>
-</AccordionGroup>
+| Legacy | New |
+| --- | --- |
+| `collisionDetection` prop on `DndContext` | `collisionDetector` option on [`useDroppable`](/react/hooks/use-droppable) / [`useSortable`](/react/hooks/use-sortable) |
+| `pointerWithin` | `pointerIntersection` from `@dnd-kit/collision` |
+| `closestCenter` | `closestCenter` from `@dnd-kit/collision` |
+| `closestCorners` | `closestCorners` from `@dnd-kit/collision` |
+
+### Modifiers
+
+See the [React modifiers guide](/react/guides/modifiers) for usage examples.
+
+| Legacy | New |
+| --- | --- |
+| `restrictToParentElement` | `RestrictToElement` from `@dnd-kit/dom/modifiers` |
+| `restrictToWindowEdges` | `RestrictToWindow` from `@dnd-kit/dom/modifiers` |
+| `restrictToVerticalAxis` | `RestrictToVerticalAxis` from `@dnd-kit/abstract/modifiers` |
+| `restrictToHorizontalAxis` | `RestrictToHorizontalAxis` from `@dnd-kit/abstract/modifiers` |
+| `createSnapModifier` | `SnapModifier` from `@dnd-kit/abstract/modifiers` |
+
+### Sortable
+
+See the [sortable state management guide](/react/guides/sortable-state-management) for usage examples.
+
+| Legacy | New |
+| --- | --- |
+| `arrayMove` | `move` from `@dnd-kit/helpers` |
+| `verticalListSortingStrategy` | Not needed — handled automatically |
+| `horizontalListSortingStrategy` | Not needed — handled automatically |
+| `rectSortingStrategy` | Not needed — handled automatically |
 
 ## Next steps
 

--- a/apps/docs/docs/react/guides/migration.mdx
+++ b/apps/docs/docs/react/guides/migration.mdx
@@ -296,7 +296,6 @@ A quick lookup for common legacy APIs and their new equivalents, organized by ca
 | Legacy (`@dnd-kit/core`) | New (`@dnd-kit/react`) |
 | --- | --- |
 | `DndContext` | [`DragDropProvider`](/react/components/drag-drop-provider) |
-| `SortableContext` | No longer needed |
 
 ### Events
 
@@ -338,10 +337,15 @@ See the [React modifiers guide](/react/guides/modifiers) for usage examples.
 
 ### Sortable
 
+<Note>
+  `SortableContext` is no longer needed. Sortable items register and coordinate with the [`DragDropProvider`](/react/components/drag-drop-provider) automatically when you use [`useSortable`](/react/hooks/use-sortable) — there's no wrapping context to configure. Use the `type` and `accept` options on `useSortable` to control which items can be sorted together.
+</Note>
+
 See the [sortable state management guide](/react/guides/sortable-state-management) for usage examples.
 
 | Legacy | New |
 | --- | --- |
+| `SortableContext` | No longer needed — see note above |
 | `arrayMove` | `move` from `@dnd-kit/helpers` |
 | `verticalListSortingStrategy` | Not needed — handled automatically |
 | `horizontalListSortingStrategy` | Not needed — handled automatically |

--- a/apps/docs/docs/react/guides/migration.mdx
+++ b/apps/docs/docs/react/guides/migration.mdx
@@ -6,29 +6,6 @@ icon: 'swap-arrows'
 mode: 'wide'
 ---
 
-## API mapping reference
-
-Use this table as a quick reference when migrating from `@dnd-kit/core` and `@dnd-kit/sortable` to the new `@dnd-kit/react` API.
-
-| Legacy | New equivalent |
-|---|---|
-| `DndContext` | [`DragDropProvider`](/react/components/drag-drop-provider) |
-| `SortableContext` | No longer needed |
-| `useSensor` / `useSensors` | Built-in by default. Customize via the `sensors` prop on [`DragDropProvider`](/react/components/drag-drop-provider) |
-| `arrayMove` | [`move`](/react/guides/sortable-state-management) from `@dnd-kit/helpers` |
-| `active` / `over` | `event.operation.source` / `event.operation.target` |
-| `active.id` | `event.operation.source.id` |
-| `onDragCancel` | Check `event.canceled` in `onDragEnd` |
-| `collisionDetection` prop | `collisionDetector` per-droppable via [`useDroppable`](/react/hooks/use-droppable) |
-| `pointerWithin` | `pointerIntersection` from `@dnd-kit/collision` |
-| `closestCenter` | `closestCenter` from `@dnd-kit/collision` |
-| `restrictToParentElement` | [`RestrictToElement`](/react/guides/modifiers) modifier from `@dnd-kit/dom/modifiers` |
-| `restrictToVerticalAxis` | `RestrictToVerticalAxis` modifier from `@dnd-kit/abstract/modifiers` |
-| `verticalListSortingStrategy` | No longer needed — handled automatically |
-| `horizontalListSortingStrategy` | No longer needed — handled automatically |
-
-## Step-by-step migration
-
 <Steps>
   <Step title="Update dependencies">
     Update your `package.json` and install the new packages:
@@ -309,6 +286,68 @@ Use this table as a quick reference when migrating from `@dnd-kit/core` and `@dn
     Use the array manipulation helpers from `@dnd-kit/helpers` to handle reordering.
   </Step>
 </Steps>
+
+## API reference
+
+A quick lookup for common legacy APIs and their new equivalents. Organized by category so you can jump to what you need.
+
+<AccordionGroup>
+  <Accordion title="Context & Provider" icon="square-dashed">
+    | Legacy (`@dnd-kit/core`) | New (`@dnd-kit/react`) |
+    | --- | --- |
+    | `DndContext` | [`DragDropProvider`](/react/components/drag-drop-provider) |
+    | `SortableContext` | No longer needed |
+  </Accordion>
+
+  <Accordion title="Events" icon="bolt">
+    | Legacy | New |
+    | --- | --- |
+    | `active` | `event.operation.source` |
+    | `over` | `event.operation.target` |
+    | `active.id` | `event.operation.source.id` |
+    | `onDragCancel` | Check `event.canceled` inside `onDragEnd` |
+  </Accordion>
+
+  <Accordion title="Sensors" icon="monitor-waveform">
+    | Legacy | New |
+    | --- | --- |
+    | `useSensor` / `useSensors` | Built-in by default. Customize via the `sensors` prop on [`DragDropProvider`](/react/components/drag-drop-provider) |
+    | `PointerSensor` | [`PointerSensor`](/extend/sensors/pointer-sensor) from `@dnd-kit/dom/sensors` |
+    | `KeyboardSensor` | [`KeyboardSensor`](/extend/sensors/keyboard-sensor) from `@dnd-kit/dom/sensors` |
+  </Accordion>
+
+  <Accordion title="Collision detection" icon="arrows-to-circle">
+    | Legacy | New |
+    | --- | --- |
+    | `collisionDetection` prop on `DndContext` | `collisionDetector` option on [`useDroppable`](/react/hooks/use-droppable) / [`useSortable`](/react/hooks/use-sortable) |
+    | `pointerWithin` | `pointerIntersection` from `@dnd-kit/collision` |
+    | `closestCenter` | `closestCenter` from `@dnd-kit/collision` |
+    | `closestCorners` | `closestCorners` from `@dnd-kit/collision` |
+  </Accordion>
+
+  <Accordion title="Modifiers" icon="arrows-to-dot">
+    See the [React modifiers guide](/react/guides/modifiers) for usage examples.
+
+    | Legacy | New |
+    | --- | --- |
+    | `restrictToParentElement` | `RestrictToElement` from `@dnd-kit/dom/modifiers` |
+    | `restrictToWindowEdges` | `RestrictToWindow` from `@dnd-kit/dom/modifiers` |
+    | `restrictToVerticalAxis` | `RestrictToVerticalAxis` from `@dnd-kit/abstract/modifiers` |
+    | `restrictToHorizontalAxis` | `RestrictToHorizontalAxis` from `@dnd-kit/abstract/modifiers` |
+    | `createSnapModifier` | `SnapModifier` from `@dnd-kit/abstract/modifiers` |
+  </Accordion>
+
+  <Accordion title="Sortable" icon="arrows-up-down">
+    See the [sortable state management guide](/react/guides/sortable-state-management) for usage examples.
+
+    | Legacy | New |
+    | --- | --- |
+    | `arrayMove` | `move` from `@dnd-kit/helpers` |
+    | `verticalListSortingStrategy` | Not needed — handled automatically |
+    | `horizontalListSortingStrategy` | Not needed — handled automatically |
+    | `rectSortingStrategy` | Not needed — handled automatically |
+  </Accordion>
+</AccordionGroup>
 
 ## Next steps
 

--- a/apps/docs/docs/react/guides/migration.mdx
+++ b/apps/docs/docs/react/guides/migration.mdx
@@ -394,7 +394,7 @@ See the [sortable state management guide](/react/guides/sortable-state-managemen
   </Card>
   <Card
     title="Managing sortable state"
-    icon="sliders"
+    icon="list-ol"
     href="/react/guides/sortable-state-management"
   >
     Use the `move` helper from `@dnd-kit/helpers` or manage state manually

--- a/apps/docs/docs/react/guides/migration.mdx
+++ b/apps/docs/docs/react/guides/migration.mdx
@@ -401,7 +401,7 @@ See the [sortable state management guide](/react/guides/sortable-state-managemen
   </Card>
   <Card
     title="Modifiers"
-    icon="arrows-to-dot"
+    icon="sliders"
     href="/react/guides/modifiers"
   >
     Restrict movement to an element, axis, or snap to a grid in React

--- a/apps/docs/docs/react/guides/migration.mdx
+++ b/apps/docs/docs/react/guides/migration.mdx
@@ -6,6 +6,29 @@ icon: 'swap-arrows'
 mode: 'wide'
 ---
 
+## API mapping reference
+
+Use this table as a quick reference when migrating from `@dnd-kit/core` and `@dnd-kit/sortable` to the new `@dnd-kit/react` API.
+
+| Legacy | New equivalent |
+|---|---|
+| `DndContext` | [`DragDropProvider`](/react/components/drag-drop-provider) |
+| `SortableContext` | No longer needed |
+| `useSensor` / `useSensors` | Built-in by default. Customize via the `sensors` prop on [`DragDropProvider`](/react/components/drag-drop-provider) |
+| `arrayMove` | [`move`](/react/guides/sortable-state-management) from `@dnd-kit/helpers` |
+| `active` / `over` | `event.operation.source` / `event.operation.target` |
+| `active.id` | `event.operation.source.id` |
+| `onDragCancel` | Check `event.canceled` in `onDragEnd` |
+| `collisionDetection` prop | `collisionDetector` per-droppable via [`useDroppable`](/react/hooks/use-droppable) |
+| `pointerWithin` | `pointerIntersection` from `@dnd-kit/collision` |
+| `closestCenter` | `closestCenter` from `@dnd-kit/collision` |
+| `restrictToParentElement` | [`RestrictToElement`](/react/guides/modifiers) modifier from `@dnd-kit/dom/modifiers` |
+| `restrictToVerticalAxis` | `RestrictToVerticalAxis` modifier from `@dnd-kit/abstract/modifiers` |
+| `verticalListSortingStrategy` | No longer needed — handled automatically |
+| `horizontalListSortingStrategy` | No longer needed — handled automatically |
+
+## Step-by-step migration
+
 <Steps>
   <Step title="Update dependencies">
     Update your `package.json` and install the new packages:
@@ -298,24 +321,24 @@ mode: 'wide'
     Build beautiful drag and drop interfaces in minutes with the new dnd kit
   </Card>
   <Card
-    title="Draggable elements"
-    icon="bullseye-pointer"
-    href="/concepts/draggable"
+    title="Managing sortable state"
+    icon="sliders"
+    href="/react/guides/sortable-state-management"
   >
-    Learn how to make elements draggable with the new API
+    Use the `move` helper from `@dnd-kit/helpers` or manage state manually
   </Card>
   <Card
-    title="Droppable targets"
-    icon="expand"
-    href="/concepts/droppable"
+    title="Modifiers"
+    icon="arrows-to-dot"
+    href="/react/guides/modifiers"
   >
-    Create drop zones and handle collision detection
+    Restrict movement to an element, axis, or snap to a grid in React
   </Card>
   <Card
-    title="Sortable lists"
-    icon="layer-group"
-    href="/concepts/sortable"
+    title="Feedback"
+    icon="clone"
+    href="/react/guides/feedback"
   >
-    Build sortable interfaces with array manipulation helpers
+    Configure drag feedback, clone overlays, and drop animations in React
   </Card>
 </CardGroup>

--- a/apps/docs/docs/react/guides/migration.mdx
+++ b/apps/docs/docs/react/guides/migration.mdx
@@ -308,11 +308,42 @@ A quick lookup for common legacy APIs and their new equivalents, organized by ca
 
 ### Sensors
 
-| Legacy | New |
+<Note>
+  The legacy `MouseSensor` and `TouchSensor` have been merged into a single [`PointerSensor`](/extend/sensors/pointer-sensor) that handles mouse, touch, and pen input via the native Pointer Events API. You can still apply different behavior per input type by passing a function to `activationConstraints` and branching on `event.pointerType` (`'mouse'`, `'touch'`, or `'pen'`):
+
+  ```tsx
+  import {DragDropProvider} from '@dnd-kit/react';
+  import {PointerSensor, PointerActivationConstraints} from '@dnd-kit/dom';
+
+  <DragDropProvider
+    sensors={(defaults) => [
+      ...defaults.filter((sensor) => sensor !== PointerSensor),
+      PointerSensor.configure({
+        activationConstraints(event, source) {
+          if (event.pointerType === 'touch') {
+            return [
+              new PointerActivationConstraints.Delay({value: 500, tolerance: {x: 5, y: 5}}),
+            ];
+          }
+          return [new PointerActivationConstraints.Distance({value: 8})];
+        },
+      }),
+    ]}
+  >
+    {/* ... */}
+  </DragDropProvider>
+  ```
+
+  If you don't configure it, the default already differentiates pointer types — see the [PointerSensor docs](/extend/sensors/pointer-sensor) for the full default behavior.
+</Note>
+
+| Legacy (`@dnd-kit/core`) | New (`@dnd-kit/dom`) |
 | --- | --- |
 | `useSensor` / `useSensors` | Built-in by default. Customize via the `sensors` prop on [`DragDropProvider`](/react/components/drag-drop-provider) |
-| `PointerSensor` | [`PointerSensor`](/extend/sensors/pointer-sensor) from `@dnd-kit/dom/sensors` |
-| `KeyboardSensor` | [`KeyboardSensor`](/extend/sensors/keyboard-sensor) from `@dnd-kit/dom/sensors` |
+| `MouseSensor` | [`PointerSensor`](/extend/sensors/pointer-sensor) from `@dnd-kit/dom` |
+| `TouchSensor` | [`PointerSensor`](/extend/sensors/pointer-sensor) from `@dnd-kit/dom` |
+| `PointerSensor` | [`PointerSensor`](/extend/sensors/pointer-sensor) from `@dnd-kit/dom` |
+| `KeyboardSensor` | [`KeyboardSensor`](/extend/sensors/keyboard-sensor) from `@dnd-kit/dom` |
 
 ### Collision detection
 

--- a/apps/docs/docs/react/guides/migration.mdx
+++ b/apps/docs/docs/react/guides/migration.mdx
@@ -407,7 +407,7 @@ See the [sortable state management guide](/react/guides/sortable-state-managemen
     Restrict movement to an element, axis, or snap to a grid in React
   </Card>
   <Card
-    title="Feedback"
+    title="Customizing feedback"
     icon="clone"
     href="/react/guides/feedback"
   >

--- a/apps/docs/docs/react/guides/migration.mdx
+++ b/apps/docs/docs/react/guides/migration.mdx
@@ -334,7 +334,7 @@ A quick lookup for common legacy APIs and their new equivalents, organized by ca
   </DragDropProvider>
   ```
 
-  If you don't configure it, the default already differentiates pointer types — see the [PointerSensor docs](/extend/sensors/pointer-sensor) for the full default behavior.
+  If you don't configure it, the default already differentiates pointer types. See [Configuring sensors](/react/guides/sensors) for the React-specific guide and the [PointerSensor docs](/extend/sensors/pointer-sensor) for the full default behavior.
 </Note>
 
 | Legacy (`@dnd-kit/core`) | New (`@dnd-kit/dom`) |
@@ -400,7 +400,7 @@ See the [sortable state management guide](/react/guides/sortable-state-managemen
     Use the `move` helper from `@dnd-kit/helpers` or manage state manually
   </Card>
   <Card
-    title="Modifiers"
+    title="Using modifiers"
     icon="sliders"
     href="/react/guides/modifiers"
   >

--- a/apps/docs/docs/react/guides/modifiers.mdx
+++ b/apps/docs/docs/react/guides/modifiers.mdx
@@ -2,7 +2,7 @@
 title: 'Modifiers'
 metaTitle: 'Modifiers - React | dnd kit'
 description: 'Restrict drag movement to an element, axis, or snap to a grid in React.'
-icon: 'arrows-to-dot'
+icon: 'sliders'
 ---
 
 ## Overview

--- a/apps/docs/docs/react/guides/modifiers.mdx
+++ b/apps/docs/docs/react/guides/modifiers.mdx
@@ -1,0 +1,188 @@
+---
+title: 'Modifiers'
+metaTitle: 'Modifiers - React | dnd kit'
+description: 'Restrict drag movement to an element, axis, or snap to a grid in React.'
+icon: 'arrows-to-dot'
+---
+
+## Overview
+
+[Modifiers](/extend/modifiers) transform the movement of draggable elements during drag operations. They can restrict movement to axes or boundaries, adjust positioning, or implement custom movement logic.
+
+This guide covers how to use modifiers in React with hooks like [`useDraggable`](/react/hooks/use-draggable) and [`useSortable`](/react/hooks/use-sortable).
+
+## Restricting to a container element
+
+Use the `RestrictToElement` modifier from `@dnd-kit/dom/modifiers` to constrain dragging within a container. Pass the container's DOM element via a React ref:
+
+```tsx
+import {useRef} from 'react';
+import {DragDropProvider} from '@dnd-kit/react';
+import {useDraggable} from '@dnd-kit/react';
+import {RestrictToElement} from '@dnd-kit/dom/modifiers';
+
+function App() {
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  return (
+    <DragDropProvider>
+      <div ref={containerRef} style={{width: 400, height: 400, position: 'relative'}}>
+        <DraggableItem container={containerRef} />
+      </div>
+    </DragDropProvider>
+  );
+}
+
+function DraggableItem({container}: {container: React.RefObject<HTMLDivElement | null>}) {
+  const {ref} = useDraggable({
+    id: 'draggable-1',
+    modifiers: [
+      RestrictToElement.configure({
+        element: container.current,
+      }),
+    ],
+  });
+
+  return <div ref={ref}>Drag me</div>;
+}
+```
+
+<Tip>
+  The `element` option also accepts a function that receives the current drag operation and returns an element. This is useful when you need dynamic container references:
+
+  ```tsx
+  RestrictToElement.configure({
+    element: () => document.getElementById('my-container'),
+  })
+  ```
+</Tip>
+
+## Restricting to the window
+
+Use `RestrictToWindow` from `@dnd-kit/dom/modifiers` to prevent dragging outside the browser viewport:
+
+```tsx
+import {useDraggable} from '@dnd-kit/react';
+import {RestrictToWindow} from '@dnd-kit/dom/modifiers';
+
+function DraggableItem() {
+  const {ref} = useDraggable({
+    id: 'draggable-1',
+    modifiers: [RestrictToWindow],
+  });
+
+  return <div ref={ref}>Drag me</div>;
+}
+```
+
+## Restricting to an axis
+
+Use `RestrictToVerticalAxis` or `RestrictToHorizontalAxis` from `@dnd-kit/abstract/modifiers` to lock movement to a single axis:
+
+```tsx
+import {useSortable} from '@dnd-kit/react/sortable';
+import {RestrictToVerticalAxis} from '@dnd-kit/abstract/modifiers';
+
+function SortableItem({id, index}: {id: string; index: number}) {
+  const {ref} = useSortable({
+    id,
+    index,
+    modifiers: [RestrictToVerticalAxis],
+  });
+
+  return <div ref={ref}>Item {id}</div>;
+}
+```
+
+## Snapping to a grid
+
+Use the `SnapModifier` from `@dnd-kit/abstract/modifiers` to snap movement to a grid:
+
+```tsx
+import {useDraggable} from '@dnd-kit/react';
+import {SnapModifier} from '@dnd-kit/abstract/modifiers';
+
+function DraggableItem() {
+  const {ref} = useDraggable({
+    id: 'draggable-1',
+    modifiers: [
+      SnapModifier.configure({
+        size: 20, // Snap every 20px in both directions
+      }),
+    ],
+  });
+
+  return <div ref={ref}>Drag me</div>;
+}
+```
+
+The `size` option accepts a number for uniform snapping, or an object with separate `x` and `y` values:
+
+```tsx
+SnapModifier.configure({
+  size: {x: 50, y: 25}, // 50px horizontal, 25px vertical
+})
+```
+
+## Combining modifiers
+
+You can combine multiple modifiers. They are applied in order:
+
+```tsx
+import {useDraggable} from '@dnd-kit/react';
+import {RestrictToElement} from '@dnd-kit/dom/modifiers';
+import {SnapModifier} from '@dnd-kit/abstract/modifiers';
+
+function DraggableItem({container}: {container: React.RefObject<HTMLDivElement | null>}) {
+  const {ref} = useDraggable({
+    id: 'draggable-1',
+    modifiers: [
+      RestrictToElement.configure({element: container.current}),
+      SnapModifier.configure({size: 20}),
+    ],
+  });
+
+  return <div ref={ref}>Drag me</div>;
+}
+```
+
+## Global vs. per-draggable modifiers
+
+Modifiers can be set globally on the [`DragDropProvider`](/react/components/drag-drop-provider) to apply to all draggable elements, or on individual hooks for per-element control.
+
+### Global modifiers
+
+```tsx
+import {DragDropProvider} from '@dnd-kit/react';
+import {RestrictToWindow} from '@dnd-kit/dom/modifiers';
+
+function App() {
+  return (
+    <DragDropProvider modifiers={[RestrictToWindow]}>
+      {/* All draggable elements are restricted to the window */}
+    </DragDropProvider>
+  );
+}
+```
+
+### Per-draggable modifiers
+
+Per-draggable modifiers take precedence over global modifiers:
+
+```tsx
+import {useDraggable} from '@dnd-kit/react';
+import {RestrictToVerticalAxis} from '@dnd-kit/abstract/modifiers';
+
+function VerticalOnlyDraggable() {
+  const {ref} = useDraggable({
+    id: 'vertical-only',
+    modifiers: [RestrictToVerticalAxis],
+  });
+
+  return <div ref={ref}>I can only move vertically</div>;
+}
+```
+
+<Info>
+  For the full list of built-in modifiers and how to create custom modifiers, see the [core Modifiers documentation](/extend/modifiers).
+</Info>

--- a/apps/docs/docs/react/guides/modifiers.mdx
+++ b/apps/docs/docs/react/guides/modifiers.mdx
@@ -1,5 +1,6 @@
 ---
-title: 'Modifiers'
+title: 'Using modifiers'
+sidebarTitle: 'Using modifiers'
 metaTitle: 'Modifiers - React | dnd kit'
 description: 'Restrict drag movement to an element, axis, or snap to a grid in React.'
 icon: 'sliders'

--- a/apps/docs/docs/react/guides/multiple-sortable-lists.mdx
+++ b/apps/docs/docs/react/guides/multiple-sortable-lists.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Multiple sortable lists'
 metaTitle: 'Multiple Sortable Lists - React | dnd kit'
-description: 'Learn how to reorder sortable elements across multiple lists.'
+description: 'Learn how to build kanban boards, trello-like interfaces, and multi-column layouts with sortable drag and drop across multiple lists.'
 icon: 'columns-3'
 mode: "wide"
 ---
@@ -13,7 +13,7 @@ import {CodeSandbox} from '/snippets/sandbox.mdx';
 
 ## Overview
 
-In this guide, you'll learn how to reorder sortable elements across multiple lists. This is useful when you have multiple lists and you want to move elements between them.
+In this guide, you'll learn how to reorder sortable elements across multiple lists. This pattern is commonly used to build **kanban boards**, **trello-like task managers**, and **multi-column layouts** where items can be reordered within and across columns.
 
 Before getting started, make sure you familiarize yourself with the [useSortable](/react/hooks/use-sortable) hook.
 

--- a/apps/docs/docs/react/guides/sensors.mdx
+++ b/apps/docs/docs/react/guides/sensors.mdx
@@ -1,0 +1,217 @@
+---
+title: 'Configuring sensors'
+sidebarTitle: 'Configuring sensors'
+metaTitle: 'Configuring Sensors - React | dnd kit'
+description: 'Customize how drag operations start in React: pointer activation constraints, keyboard codes, drag handles, and per-pointer-type behavior.'
+icon: 'monitor-waveform'
+---
+
+## Overview
+
+[Sensors](/extend/sensors) detect user input and translate it into drag and drop operations. The defaults work well out of the box — `PointerSensor` (mouse, touch, pen) and `KeyboardSensor` are both registered automatically on every [`DragDropProvider`](/react/components/drag-drop-provider). You only need this guide when you want to customize when and how drags activate.
+
+<Note>
+  Sensors are part of `@dnd-kit/dom` and are imported from there:
+
+  ```ts
+  import {PointerSensor, KeyboardSensor, PointerActivationConstraints} from '@dnd-kit/dom';
+  ```
+</Note>
+
+## Where to configure sensors
+
+Sensors can be configured at three different levels:
+
+| Level | How | When to use |
+| --- | --- | --- |
+| **Global (provider)** | `sensors` prop on `DragDropProvider` | Apply behavior across every draggable |
+| **Per-draggable** | `sensors` option on `useDraggable` / `useSortable` | Override behavior for a specific element |
+| **Per-instance** | `Sensor.configure({...})` | Build a configured sensor descriptor that you pass to one of the above |
+
+Per-draggable sensors take precedence over global sensors.
+
+## Customizing PointerSensor
+
+`PointerSensor` handles **mouse, touch, and pen** input via the native [Pointer Events API](https://developer.mozilla.org/en-US/docs/Web/API/Pointer_events). It exposes three options: `activationConstraints`, `activatorElements`, and `preventActivation`.
+
+### Activation constraints
+
+Activation constraints control when a drag starts. Provide either an array of constraint instances, or a function that returns constraints based on the event.
+
+```tsx
+import {DragDropProvider} from '@dnd-kit/react';
+import {PointerSensor, PointerActivationConstraints} from '@dnd-kit/dom';
+
+<DragDropProvider
+  sensors={(defaults) => [
+    ...defaults.filter((sensor) => sensor !== PointerSensor),
+    PointerSensor.configure({
+      activationConstraints: [
+        // Drag starts after the pointer moves 8px
+        new PointerActivationConstraints.Distance({value: 8}),
+        // ...or after holding for 200ms with up to 10px tolerance
+        new PointerActivationConstraints.Delay({value: 200, tolerance: 10}),
+      ],
+    }),
+  ]}
+>
+  {/* ... */}
+</DragDropProvider>
+```
+
+When multiple constraints are provided, the drag activates as soon as **any one** is satisfied.
+
+### Per-pointer-type behavior
+
+Pass a function to `activationConstraints` to branch on `event.pointerType` (`'mouse'`, `'touch'`, or `'pen'`). This is the recommended way to give touch and mouse different activation behavior:
+
+```tsx
+PointerSensor.configure({
+  activationConstraints(event, source) {
+    if (event.pointerType === 'touch') {
+      // Longer delay for touch to avoid hijacking scroll gestures
+      return [
+        new PointerActivationConstraints.Delay({value: 250, tolerance: 5}),
+      ];
+    }
+
+    // Mouse and pen: 5px movement threshold
+    return [new PointerActivationConstraints.Distance({value: 5})];
+  },
+});
+```
+
+Returning `undefined` from the function falls back to the [default behavior](/extend/sensors/pointer-sensor#default-behavior).
+
+### Drag handles via activator elements
+
+By default, the sensor binds `pointerdown` to the draggable's `handle` (if set on the hook) or its main `element`. Use `activatorElements` to designate a different element — useful when you want to render a separate "drag" affordance outside the draggable's DOM subtree.
+
+```tsx
+PointerSensor.configure({
+  activatorElements: (source) => [
+    source.element?.querySelector('[data-drag-handle]'),
+  ],
+});
+```
+
+<Tip>
+  For the common case — a drag handle inside the draggable element — pass a `handle` ref directly to `useDraggable` or `useSortable` instead. `activatorElements` is for the less common case where the activator lives outside the source element.
+</Tip>
+
+### Preventing accidental drags
+
+The `preventActivation` callback returns `true` to skip a `pointerdown` event. By default, it returns `true` when the target is an interactive element (`<button>`, `<input>`, `<a>`, etc.) that isn't part of the handle — so clicks on buttons inside a draggable card don't start a drag.
+
+```tsx
+PointerSensor.configure({
+  preventActivation: (event, source) => {
+    // Don't start a drag from anything inside [data-no-drag]
+    return (
+      event.target instanceof Element &&
+      event.target.closest('[data-no-drag]') !== null
+    );
+  },
+});
+```
+
+## Customizing KeyboardSensor
+
+`KeyboardSensor` enables keyboard-driven drag and drop for accessibility. It activates when a focused draggable receives a configured "start" keydown event.
+
+### Custom key bindings
+
+```tsx
+import {KeyboardSensor} from '@dnd-kit/dom';
+
+KeyboardSensor.configure({
+  keyboardCodes: {
+    start: ['Space', 'Enter'],
+    cancel: ['Escape'],
+    end: ['Space', 'Enter', 'Tab'],
+    up: ['ArrowUp', 'KeyW'],
+    down: ['ArrowDown', 'KeyS'],
+    left: ['ArrowLeft', 'KeyA'],
+    right: ['ArrowRight', 'KeyD'],
+  },
+});
+```
+
+Key codes follow [`KeyboardEvent.code`](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/code) values.
+
+### Keyboard movement offset
+
+The `offset` option controls how many pixels each arrow key press moves the dragged element. Hold <kbd>Shift</kbd> to multiply the offset by 5.
+
+```tsx
+KeyboardSensor.configure({
+  offset: 20,                  // 20px per key press, 100px with Shift
+  // or per-axis:
+  // offset: {x: 20, y: 10},
+});
+```
+
+### Preventing keyboard activation
+
+By default, the keyboard sensor only activates when the focused element is the draggable's handle (or its element if no handle is set). Override `preventActivation` to customize:
+
+```tsx
+KeyboardSensor.configure({
+  preventActivation: (event, source) => {
+    // Don't activate while a text input inside the draggable has focus
+    return event.target instanceof HTMLInputElement;
+  },
+});
+```
+
+## Per-draggable sensors
+
+Both [`useDraggable`](/react/hooks/use-draggable) and [`useSortable`](/react/hooks/use-sortable) accept a `sensors` option that applies only to that element. Per-draggable sensors override global ones.
+
+```tsx
+import {useDraggable} from '@dnd-kit/react';
+import {PointerSensor, PointerActivationConstraints} from '@dnd-kit/dom';
+
+function StrictDragHandle({id}) {
+  const {ref} = useDraggable({
+    id,
+    sensors: [
+      PointerSensor.configure({
+        activationConstraints: [
+          // This particular draggable requires a longer hold to start
+          new PointerActivationConstraints.Delay({value: 500, tolerance: 5}),
+        ],
+      }),
+    ],
+  });
+
+  return <div ref={ref}>Hold me for half a second</div>;
+}
+```
+
+## Replacing vs. extending defaults
+
+The `sensors` prop on `DragDropProvider` accepts either an array (replaces defaults entirely) or a function that receives the defaults (lets you extend them).
+
+```tsx
+// Extend — keeps KeyboardSensor and adds a configured PointerSensor
+<DragDropProvider
+  sensors={(defaults) => [
+    ...defaults.filter((sensor) => sensor !== PointerSensor),
+    PointerSensor.configure({/* ... */}),
+  ]}
+>
+
+// Replace — only the listed sensors are active
+<DragDropProvider
+  sensors={[PointerSensor, KeyboardSensor]}
+>
+```
+
+<Warning>
+  If you replace the defaults with an array, double-check you're including `KeyboardSensor` — leaving it out removes keyboard accessibility.
+</Warning>
+
+## Migrating from `MouseSensor` and `TouchSensor`
+
+The legacy `@dnd-kit/core` package had separate `MouseSensor` and `TouchSensor` classes. They're consolidated into one `PointerSensor` here. To replicate the old per-input-type behavior, branch on `event.pointerType` inside `activationConstraints` (see [Per-pointer-type behavior](#per-pointer-type-behavior) above), or read the [Migration guide](/react/guides/migration#sensors) for the full mapping.

--- a/apps/docs/docs/react/guides/sortable-state-management.mdx
+++ b/apps/docs/docs/react/guides/sortable-state-management.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Managing sortable state'
 metaTitle: 'Managing Sortable State - React | dnd kit'
-description: 'Learn how to manage sortable state with and without the move helper.'
+description: 'Learn how to manage sortable state using the move helper or manual state management, including integration with external state libraries like React Query, Zustand, or Redux.'
 icon: 'sliders'
 ---
 
@@ -217,3 +217,52 @@ if (isSortableOperation(operation)) {
   operation.target.index;        // typed
 }
 ```
+
+## Integration with external state
+
+When using sortable lists alongside data fetching libraries like React Query, TanStack Query, or SWR, you may encounter duplicate items after a refetch. This happens when optimistic sorting has moved DOM elements during the drag, and then a refetch replaces the data while the drag state is still active.
+
+To avoid this, only sync your local items state with fetched data when no drag is in progress:
+
+```tsx
+import {useState, useEffect, useRef} from 'react';
+import {DragDropProvider} from '@dnd-kit/react';
+
+function SortableList() {
+  const {data: fetchedItems} = useQuery({queryKey: ['items'], queryFn: fetchItems});
+  const [items, setItems] = useState(fetchedItems ?? []);
+  const isDragging = useRef(false);
+
+  useEffect(() => {
+    if (fetchedItems && !isDragging.current) {
+      setItems(fetchedItems);
+    }
+  }, [fetchedItems]);
+
+  return (
+    <DragDropProvider
+      onDragStart={() => { isDragging.current = true; }}
+      onDragEnd={(event) => {
+        isDragging.current = false;
+
+        if (event.canceled) {
+          // Reset to server state on cancel
+          setItems(fetchedItems ?? []);
+          return;
+        }
+
+        // Update local state, then sync with server
+        setItems((items) => move(items, event));
+      }}
+    >
+      {items.map((item, index) => (
+        <SortableItem key={item.id} id={item.id} index={index} />
+      ))}
+    </DragDropProvider>
+  );
+}
+```
+
+<Tip>
+  The key principle is maintaining a single source of truth: render from your local `items` state (not directly from the query data), and only update it from the query when no drag is active.
+</Tip>

--- a/apps/docs/docs/react/guides/sortable-state-management.mdx
+++ b/apps/docs/docs/react/guides/sortable-state-management.mdx
@@ -2,7 +2,7 @@
 title: 'Managing sortable state'
 metaTitle: 'Managing Sortable State - React | dnd kit'
 description: 'Learn how to manage sortable state using the move helper or manual state management, including integration with external state libraries like React Query, Zustand, or Redux.'
-icon: 'sliders'
+icon: 'list-ol'
 ---
 
 ## Overview

--- a/apps/docs/docs/react/hooks/use-drag-drop-manager.mdx
+++ b/apps/docs/docs/react/hooks/use-drag-drop-manager.mdx
@@ -3,7 +3,6 @@ title: 'useDragDropManager'
 sidebarTitle: 'useDragDropManager'
 metaTitle: 'useDragDropManager - React | dnd kit'
 description: 'Read the DragDropManager instance that the surrounding DragDropProvider created.'
-icon: 'gear'
 ---
 
 ## Overview

--- a/apps/docs/docs/react/hooks/use-drag-drop-manager.mdx
+++ b/apps/docs/docs/react/hooks/use-drag-drop-manager.mdx
@@ -1,0 +1,62 @@
+---
+title: 'useDragDropManager'
+sidebarTitle: 'useDragDropManager'
+metaTitle: 'useDragDropManager - React | dnd kit'
+description: 'Read the DragDropManager instance that the surrounding DragDropProvider created.'
+icon: 'gear'
+---
+
+## Overview
+
+`useDragDropManager` returns the [`DragDropManager`](/concepts/drag-drop-manager) instance that the surrounding [`DragDropProvider`](/react/components/drag-drop-provider) created. Use it for advanced cases that need direct access to the manager — registering custom event listeners on `manager.monitor`, looking up registered plugins via `manager.registry`, or imperatively dispatching actions.
+
+For most use cases — rendering UI based on drag state, reordering items in `onDragEnd`, etc. — prefer the higher-level hooks ([`useDragOperation`](/react/hooks/use-drag-operation), [`useDragDropMonitor`](/react/hooks/use-drag-drop-monitor)) or the event handlers on `DragDropProvider` itself.
+
+```tsx
+import {DragDropProvider} from '@dnd-kit/react';
+import {useDragDropManager} from '@dnd-kit/react';
+import {useEffect} from 'react';
+
+function DragLogger() {
+  const manager = useDragDropManager();
+
+  useEffect(() => {
+    if (!manager) return;
+
+    const cleanup = manager.monitor.addEventListener('dragstart', (event) => {
+      console.log('drag started for', event.operation.source.id);
+    });
+
+    return cleanup;
+  }, [manager]);
+
+  return null;
+}
+
+function App() {
+  return (
+    <DragDropProvider>
+      <DragLogger />
+      {/* ... */}
+    </DragDropProvider>
+  );
+}
+```
+
+<Warning>
+  The hook returns `null` when called outside of a `DragDropProvider`. Always guard against `null` before dereferencing the manager.
+</Warning>
+
+## API Reference
+
+### Output
+
+<ResponseField name="manager" type="DragDropManager | null">
+  The [`DragDropManager`](/concepts/drag-drop-manager) instance from the nearest ancestor `DragDropProvider`, or `null` if no provider is present.
+</ResponseField>
+
+## Related
+
+- [`useDragOperation`](/react/hooks/use-drag-operation) — reactive read of `source` and `target`
+- [`useDragDropMonitor`](/react/hooks/use-drag-drop-monitor) — subscribe to lifecycle events
+- [`DragDropManager`](/concepts/drag-drop-manager) — full reference for the manager API

--- a/apps/docs/docs/react/hooks/use-drag-drop-monitor.mdx
+++ b/apps/docs/docs/react/hooks/use-drag-drop-monitor.mdx
@@ -2,7 +2,6 @@
 title: 'useDragDropMonitor'
 metaTitle: 'useDragDropMonitor - React | dnd kit'
 description: 'Monitor drag and drop events in your React components.'
-icon: 'signal-stream'
 ---
 
 ## Usage

--- a/apps/docs/docs/react/hooks/use-drag-operation.mdx
+++ b/apps/docs/docs/react/hooks/use-drag-operation.mdx
@@ -3,7 +3,6 @@ title: 'useDragOperation'
 sidebarTitle: 'useDragOperation'
 metaTitle: 'useDragOperation - React | dnd kit'
 description: 'Reactively read the current drag source and target from any descendant of a DragDropProvider.'
-icon: 'eye'
 ---
 
 ## Overview

--- a/apps/docs/docs/react/hooks/use-drag-operation.mdx
+++ b/apps/docs/docs/react/hooks/use-drag-operation.mdx
@@ -1,0 +1,61 @@
+---
+title: 'useDragOperation'
+sidebarTitle: 'useDragOperation'
+metaTitle: 'useDragOperation - React | dnd kit'
+description: 'Reactively read the current drag source and target from any descendant of a DragDropProvider.'
+icon: 'eye'
+---
+
+## Overview
+
+`useDragOperation` returns a reactive snapshot of the current drag operation's `source` and `target`. Any component nested inside a [`DragDropProvider`](/react/components/drag-drop-provider) can call this hook to read live drag state and re-render whenever it changes — without subscribing to events manually.
+
+Use it when you need ambient awareness of a drag in progress (for example, to highlight a drop zone, render an overlay, or disable an unrelated UI affordance during a drag).
+
+```tsx
+import {DragDropProvider} from '@dnd-kit/react';
+import {useDragOperation} from '@dnd-kit/react';
+
+function DraggingIndicator() {
+  const {source, target} = useDragOperation();
+
+  if (!source) return null;
+
+  return (
+    <div role="status" aria-live="polite">
+      Dragging <strong>{String(source.id)}</strong>
+      {target ? <> over <strong>{String(target.id)}</strong></> : ' over no target'}
+    </div>
+  );
+}
+
+function App() {
+  return (
+    <DragDropProvider>
+      <DraggingIndicator />
+      {/* ...draggables and droppables... */}
+    </DragDropProvider>
+  );
+}
+```
+
+<Note>
+  The hook subscribes to changes via reactive computeds, so the calling component re-renders only when `source` or `target` actually changes — not on every pointer move. If you need pointer-level updates, use [`useDragDropMonitor`](/react/hooks/use-drag-drop-monitor) instead.
+</Note>
+
+## API Reference
+
+### Output
+
+<ResponseField name="source" type="Draggable | undefined">
+  The currently dragged [Draggable](/concepts/draggable) instance, or `undefined` when no drag is in progress.
+</ResponseField>
+
+<ResponseField name="target" type="Droppable | undefined">
+  The [Droppable](/concepts/droppable) instance the source is currently over, or `undefined` if the source is not over any drop target.
+</ResponseField>
+
+## Related
+
+- [`useDragDropMonitor`](/react/hooks/use-drag-drop-monitor) — subscribe to lifecycle events (`dragstart`, `dragmove`, `dragover`, `dragend`)
+- [`useDragDropManager`](/react/hooks/use-drag-drop-manager) — read the underlying manager for advanced use cases

--- a/apps/docs/docs/react/hooks/use-draggable.mdx
+++ b/apps/docs/docs/react/hooks/use-draggable.mdx
@@ -59,6 +59,10 @@ The `useDraggable` hook accepts the following arguments:
   An array of [sensors](/extend/sensors) that can be bound to the draggable element to detect drag interactions.
 </ParamField>
 
+<ParamField path="alignment" type="{ x: 'start' | 'center' | 'end'; y: 'start' | 'center' | 'end' }">
+  How the draggable's position should be aligned relative to its source element during drag operations. Used by the [Feedback plugin](/extend/plugins/feedback) when computing overlay placement.
+</ParamField>
+
 <ParamField path="data" type="{[key: string]: any}">
   The data argument is for advanced use-cases where you may need access to additional data about the draggable element in event handlers, modifiers, sensors or custom plugins.
 </ParamField>

--- a/apps/docs/docs/react/hooks/use-droppable.mdx
+++ b/apps/docs/docs/react/hooks/use-droppable.mdx
@@ -53,8 +53,12 @@ The `useDroppable` hook accepts the following arguments:
   If you already have a reference to the element, you can pass it to the `element` option instead of using the `ref` that is returned by the `useDraggable` hook to connect the draggable source element.
 </ParamField>
 
-<ParamField path="accepts" type="string | number | Symbol | (type: string | number | Symbol) => boolean">
-  Optionally supply a type of draggable element to only allow it to be dropped over certain droppable targets that [accept](#) this `type`.
+<ParamField path="accept" type="Type | Type[] | ((source: Draggable) => boolean)">
+  Restrict which draggables can be dropped on this target. Pass a single [`type`](#param-type), an array of types, or a predicate that receives the draggable and returns `true` to accept it. If omitted, the droppable accepts every draggable.
+</ParamField>
+
+<ParamField path="type" type="string | number | Symbol">
+  An identifier used by other droppables' `accept` rules to decide whether this droppable can be a target for a given draggable. Has no effect on its own — it pairs with `accept`.
 </ParamField>
 
 <ParamField path="collisionDetector" type="(input: CollisionDetectorInput) => Collision | null">

--- a/apps/docs/docs/react/hooks/use-sortable.mdx
+++ b/apps/docs/docs/react/hooks/use-sortable.mdx
@@ -100,8 +100,16 @@ The `useSortable` hook accepts all of the same arguments as the [useDraggable](/
   If you already have a reference to the element you want to use as the droppable target for this sortable element, you can pass it to the `target` option instead of using the `targetRef` that is returned by the `useSortable` hook.
 </ParamField>
 
-<ParamField path="accepts" type="string | number | Symbol | (type: string | number | Symbol) => boolean">
-  Optionally supply a type of draggable element to only allow it to be dropped over certain droppable targets that [accept](#) this `type`.
+<ParamField path="accept" type="Type | Type[] | ((source: Draggable) => boolean)">
+  Restrict which draggables can be dropped on this sortable item. Pass a single [`type`](#param-type), an array of types, or a predicate that receives the draggable and returns `true` to accept it. If omitted, every draggable is accepted.
+</ParamField>
+
+<ParamField path="type" type="string | number | Symbol">
+  An identifier used by other sortables' or droppables' `accept` rules to decide whether this item can be a drop target for a given draggable.
+</ParamField>
+
+<ParamField path="group" type="string | number | Symbol">
+  An optional identifier for grouping sortable items. Items with the same `group` can be sorted within the same list — useful for [multi-list sortable layouts](/react/guides/multiple-sortable-lists). Items without a `group` are treated as belonging to the same implicit group.
 </ParamField>
 
 <ParamField path="collisionDetector" type="(input: CollisionDetectorInput) => Collision | null">

--- a/apps/docs/docs/react/quickstart.mdx
+++ b/apps/docs/docs/react/quickstart.mdx
@@ -35,6 +35,15 @@ Before getting started, make sure you install `@dnd-kit/react` in your project:
   ```
 </CodeGroup>
 
+<Note>
+  `@dnd-kit/react` is the only required package. For sortable lists, you'll also want `@dnd-kit/helpers`
+  for the [`move`](/react/guides/sortable-state-management) utility. Packages like `@dnd-kit/dom` and `@dnd-kit/abstract` are installed
+  automatically as dependencies.
+
+  If you're migrating from the legacy `@dnd-kit/core`, `@dnd-kit/sortable`, or `@dnd-kit/utilities`
+  packages, see the [Migration guide](/react/guides/migration).
+</Note>
+
 ## Making elements draggable
 
 Let's get started by creating draggable elements that can be dropped over droppable targets. To do so, we'll be using the `useDraggable` hook.

--- a/apps/docs/src/components/ParamField.tsx
+++ b/apps/docs/src/components/ParamField.tsx
@@ -3,7 +3,13 @@
  */
 
 interface ParamFieldProps {
+  /**
+   * The parameter or property name. Mintlify's `<ParamField>` uses `path`,
+   * while `<ResponseField>` uses `name` — both are accepted here so the
+   * same component can render input arguments and output properties.
+   */
   path?: string;
+  name?: string;
   type?: string;
   required?: boolean;
   default?: string;
@@ -80,17 +86,20 @@ function ParamHead({
 
 export function ParamField({
   path,
+  name,
   type,
   required,
   deprecated,
   default: defaultValue,
   children,
 }: ParamFieldProps) {
+  const fieldName = path ?? name;
+
   return (
     <div className="field my-2.5 border-stone-50 border-b pt-2.5 pb-5 dark:border-stone-800/50">
-      {path && (
+      {fieldName && (
         <ParamHead
-          name={path}
+          name={fieldName}
           type={type}
           required={required != null ? true : undefined}
           requiredLabel="required"

--- a/apps/docs/src/components/Sidebar/SidebarGroupItem.tsx
+++ b/apps/docs/src/components/Sidebar/SidebarGroupItem.tsx
@@ -20,7 +20,13 @@ export function SidebarGroupItem({
   isNested = false,
 }: SidebarGroupItemProps) {
   const hasActiveChild = containsPath(group.pages, currentPath);
-  const [isOpen, setIsOpen] = useState(hasActiveChild || !isNested);
+  // Nav groups can opt in to being expanded by default via `"defaultOpen": true`
+  // in docs.json. The field is preserved through the Mintlify config parser
+  // even though it's not part of the official NavGroup type.
+  const defaultOpen = (group as { defaultOpen?: boolean }).defaultOpen === true;
+  const [isOpen, setIsOpen] = useState(
+    hasActiveChild || defaultOpen || !isNested,
+  );
 
   // Nested groups (sub-groups like "Plugins", "Sensors") are collapsible
   if (isNested) {


### PR DESCRIPTION
## Summary

Analyzed ~10K user interactions with the Mintlify AI assistant (Apr 7–14) to identify documentation gaps. The most common pain points were:

- **Migration confusion**: Users constantly ask "what's the equivalent of X?" (DndContext, SortableContext, arrayMove, active/over, collisionDetection, etc.)
- **Package confusion**: Users don't know which packages to install or that `@dnd-kit/helpers` exists
- **Missing keywords**: Users search for "kanban" but the multi-list guide never uses that word
- **Event types undocumented**: Users can't figure out the shape of `onDragEnd` event objects
- **React-specific modifier/feedback examples missing**: Core docs show vanilla JS only
- **Touch/mobile questions**: Users ask if it works on mobile, docs don't make it obvious
- **Duplicate items after refetch**: Very common React Query integration issue with no guidance

### Changes

- Add API mapping table to React migration guide (14 legacy → new equivalents)
- Add packages overview note to React quickstart
- Add "kanban", "trello", "multi-column" keywords to multiple sortable lists guide
- Add "Integration with external state" section covering React Query duplicate items fix
- **New page**: React Modifiers guide (`/react/guides/modifiers`) with ref-based examples
- **New page**: React Feedback plugin guide (`/react/guides/feedback`) with troubleshooting
- Document event object structure on DragDropProvider page
- Add "Touch and mobile" section to pointer sensor docs
- Update `docs.json` navigation with new guide pages

All import paths, API names, option types, and default values were cross-referenced against the actual package source code.

## Test plan

- [ ] Verify docs dev server renders all modified and new pages
- [ ] Check internal links resolve correctly
- [ ] Review new pages for consistency with existing docs style

🤖 Generated with [Claude Code](https://claude.com/claude-code)