### PR TITLE
fix: (legacy version) fix utils used for calculating scroll offsets inside of iframes

### DIFF
--- a/.changeset/smooth-tips-sell.md
+++ b/.changeset/smooth-tips-sell.md
@@ -1,0 +1,6 @@
+---
+'@dnd-kit/core': patch
+'@dnd-kit/utilities': patch
+---
+
+Fix scroll calculations for draggable elements in a different frame context than the execution context

--- a/packages/core/src/utilities/scroll/getScrollableElement.ts
+++ b/packages/core/src/utilities/scroll/getScrollableElement.ts
@@ -20,11 +20,12 @@ export function getScrollableElement(element: EventTarget | null) {
     return null;
   }
 
-  if (
-    isDocument(element) ||
-    element === getOwnerDocument(element).scrollingElement
-  ) {
-    return window;
+  if (isDocument(element)) {
+    return element.defaultView ?? window;
+  }
+
+  if (element === getOwnerDocument(element).scrollingElement) {
+    return getOwnerDocument(element)?.defaultView ?? window;
   }
 
   if (isHTMLElement(element)) {

--- a/packages/utilities/src/execution-context/getWindow.ts
+++ b/packages/utilities/src/execution-context/getWindow.ts
@@ -14,5 +14,9 @@ export function getWindow(target: Event['target']): typeof window {
     return window;
   }
 
-  return target.ownerDocument?.defaultView ?? window;
+  let ownerDoc = target.ownerDocument;
+  if (!ownerDoc) {
+    ownerDoc = 'documentElement' in target ? target : null;
+  }
+  return ownerDoc?.defaultView ?? window;
 }


### PR DESCRIPTION
This PR is for the legacy version of the library - i'm not sure if you're still accepting patches for the @dnd-kit/core and @dnd-kit/utilities libraries, but these were blocking bugs for me

I noticed that scroll offsets are not calculated correctly when the draggable nodes are in a different frame than the execution context.

`getScrollableElement` was returning `window` directly instead of fetching the correct window object off of the `element` argument
and `getWindow` was not properly handling the case where the given `target` element was a Document object from inside of an iframe, which can be the case if the iframe document has no scrollable element beyond the `html` node