### PR TITLE
fix(feedback): prevent DragOverlay flickering after drop

### DIFF
--- a/.changeset/fix-dragoverlay-flicker.md
+++ b/.changeset/fix-dragoverlay-flicker.md
@@ -1,0 +1,5 @@
+---
+"@dnd-kit/dom": patch
+---
+
+Fix DragOverlay flickering after drop

--- a/packages/dom/src/core/plugins/feedback/Feedback.ts
+++ b/packages/dom/src/core/plugins/feedback/Feedback.ts
@@ -89,9 +89,9 @@ export class Feedback extends Plugin<DragDropManager, FeedbackOptions> {
   constructor(manager: DragDropManager, options?: FeedbackOptions) {
     super(manager, options);
 
-    const styleInjector = manager.registry.plugins.get(
-      StyleInjector as any
-    ) as StyleInjector | undefined;
+    const styleInjector = manager.registry.plugins.get(StyleInjector as any) as
+      | StyleInjector
+      | undefined;
 
     const unregisterStyles = styleInjector?.register(CSS_RULES);
 
@@ -461,29 +461,37 @@ export class Feedback extends Plugin<DragDropManager, FeedbackOptions> {
       feedbackElement.removeAttribute(ATTRIBUTE);
       styles.reset();
 
-      if (savedCellWidths && isTableRow(element)) {
-        const cells = Array.from(element.cells);
+      const finalize = () => {
+        if (savedCellWidths && isTableRow(element)) {
+          const cells = Array.from(element.cells);
 
-        for (const [index, cell] of cells.entries()) {
-          cell.style.width = savedCellWidths[index] ?? '';
+          for (const [index, cell] of cells.entries()) {
+            cell.style.width = savedCellWidths[index] ?? '';
+          }
         }
+
+        source.status = 'idle';
+
+        const moved = state.current.translate != null;
+        const isDragging = dragOperation.status.dragging;
+
+        if (
+          placeholder &&
+          ((!isDragging && moved) ||
+            placeholder.parentElement !== feedbackElement.parentElement) &&
+          feedbackElement.isConnected
+        ) {
+          placeholder.replaceWith(feedbackElement);
+        }
+
+        placeholder?.remove();
+      };
+
+      if (feedbackElement === this.overlay) {
+        setTimeout(finalize, 0);
+      } else {
+        finalize();
       }
-
-      source.status = 'idle';
-
-      const moved = state.current.translate != null;
-      const isDragging = dragOperation.status.dragging;
-
-      if (
-        placeholder &&
-        ((!isDragging && moved) ||
-          placeholder.parentElement !== feedbackElement.parentElement) &&
-        feedbackElement.isConnected
-      ) {
-        placeholder.replaceWith(feedbackElement);
-      }
-
-      placeholder?.remove();
     };
 
     /* ---- Reactive effects ---- */
@@ -511,9 +519,7 @@ export class Feedback extends Plugin<DragDropManager, FeedbackOptions> {
           const currentShape = untracked(() => dragOperation.shape?.current);
           const keyboardTransition = options?.keyboardTransition;
           const translateTransition =
-            isKeyboardOperation &&
-            !reducedMotion &&
-            keyboardTransition !== null
+            isKeyboardOperation && !reducedMotion && keyboardTransition !== null
               ? `${keyboardTransition?.duration ?? 250}ms ${keyboardTransition?.easing ?? 'cubic-bezier(0.25, 1, 0.5, 1)'}`
               : '0ms linear';
 


### PR DESCRIPTION
Fixes #1996

## Problem

When using `DragOverlay`, a brief flicker occurs after dropping an item.
The overlay momentarily appears unstyled (at its natural/full size) before disappearing.

## Root Cause

The flicker is caused by a timing gap between style removal and React's re-render:

1. `cleanup()` calls `styles.reset()` — removes all CSS custom properties from the overlay element
2. `source.status = 'idle'` is set immediately after
3. This synchronously triggers `dragOperation.reset()` → `status = Idle`
4. `StyleInjector` reacts synchronously and removes the injected CSS rules from the document
   (including `[data-dnd-overlay]:not([data-dnd-dragging]) { display: none }`)
5. The browser paints at this point — the overlay has no inline styles and no CSS rules,
   but React hasn't re-rendered yet to remove the children
6. React re-renders on the next task and removes the children

The existing CSS rule `[data-dnd-overlay]:not([data-dnd-dragging]) { display: none }` was
intended to handle this, but it gets removed from the document in the same synchronous
execution before the browser has a chance to paint with it applied.

## Fix

Defer `source.status = 'idle'` (and subsequent finalization) to after the browser paint
by wrapping it in `setTimeout(fn, 0)` when operating in overlay mode.

This keeps the injected CSS rules — including
`[data-dnd-overlay]:not([data-dnd-dragging]) { display: none }` — alive in the document
at paint time, allowing the browser to apply them and hide the overlay before React
re-renders to remove the children.

`setTimeout` is the only deferral mechanism that executes after the browser paint;
microtasks and `requestAnimationFrame` both fire before paint.

Only applied when `feedbackElement === this.overlay` to avoid affecting non-overlay drag behavior.
No inline styles are used.

## Changes

`packages/dom/src/core/plugins/feedback/Feedback.ts`

- In `cleanup()`: extract finalization logic into a `finalize()` function; call it via
  `setTimeout(finalize, 0)` when in overlay mode, or call it directly otherwise

## Verification

1. Run storybook: `cd apps/stories && bun run dev`
2. Open: http://localhost:6006/?path=/story/react-draggable-drag-overlay--drag-overlay
3. Drag and drop the item — the overlay no longer flickers on drop

---

This is my first contribution to dnd-kit. Happy to make any changes if needed.