### PR TITLE
fix(react): deep-compare sensors prop in useDraggable and useSortable

### DIFF
--- a/.changeset/fix-draggable-sensors-deep-equal.md
+++ b/.changeset/fix-draggable-sensors-deep-equal.md
@@ -1,0 +1,5 @@
+---
+'@dnd-kit/react': patch
+---
+
+Fixed `useDraggable` reassigning `draggable.sensors` on every render when `sensors` was passed as an inline array. The `sensors` prop is now compared with `deepEqual` (matching the existing behavior of `modifiers`, `plugins`, and `DragDropProvider`), preventing unnecessary mutations to the plugin registry that could disrupt in-progress sensor activation.

--- a/.changeset/fix-draggable-sensors-deep-equal.md
+++ b/.changeset/fix-draggable-sensors-deep-equal.md
@@ -2,4 +2,4 @@
 '@dnd-kit/react': patch
 ---
 
-Fixed `useDraggable` reassigning `draggable.sensors` on every render when `sensors` was passed as an inline array. The `sensors` prop is now compared with `deepEqual` (matching the existing behavior of `modifiers`, `plugins`, and `DragDropProvider`), preventing unnecessary mutations to the plugin registry that could disrupt in-progress sensor activation.
+Fixed `useDraggable` and `useSortable` reassigning the underlying entity's `sensors` on every render when `sensors` was passed as an inline array. The `sensors` prop is now compared with `deepEqual` (matching the existing behavior of `modifiers`, `plugins`, and `DragDropProvider`), preventing unnecessary mutations to the plugin registry that could disrupt in-progress sensor activation.

--- a/packages/react/src/core/draggable/useDraggable.ts
+++ b/packages/react/src/core/draggable/useDraggable.ts
@@ -42,14 +42,24 @@ export function useDraggable<T extends Data = Data>(
   useOnElementChange(element, (element) => (draggable.element = element));
   useOnValueChange(data, () => data && (draggable.data = data));
   useOnValueChange(disabled, () => (draggable.disabled = disabled === true));
-  useOnValueChange(sensors, () => (draggable.sensors = sensors));
+  useOnValueChange(
+    sensors,
+    () => (draggable.sensors = sensors),
+    undefined,
+    deepEqual
+  );
   useOnValueChange(
     modifiers,
     () => (draggable.modifiers = modifiers),
     undefined,
     deepEqual
   );
-  useOnValueChange(plugins, () => (draggable.plugins = plugins), undefined, deepEqual);
+  useOnValueChange(
+    plugins,
+    () => (draggable.plugins = plugins),
+    undefined,
+    deepEqual
+  );
   useOnValueChange(
     input.alignment,
     () => (draggable.alignment = input.alignment)

--- a/packages/react/src/sortable/useSortable.ts
+++ b/packages/react/src/sortable/useSortable.ts
@@ -85,7 +85,12 @@ export function useSortable<T extends Data = Data>(input: UseSortableInput<T>) {
   useOnElementChange(element, (element) => (sortable.element = element));
   useOnElementChange(target, (target) => (sortable.target = target));
   useOnValueChange(disabled, () => (sortable.disabled = disabled === true));
-  useOnValueChange(sensors, () => (sortable.sensors = sensors));
+  useOnValueChange(
+    sensors,
+    () => (sortable.sensors = sensors),
+    undefined,
+    deepEqual
+  );
   useOnValueChange(
     collisionDetector,
     () => (sortable.collisionDetector = collisionDetector)
@@ -94,7 +99,12 @@ export function useSortable<T extends Data = Data>(input: UseSortableInput<T>) {
     collisionPriority,
     () => (sortable.collisionPriority = collisionPriority)
   );
-  useOnValueChange(plugins, () => (sortable.plugins = plugins), undefined, deepEqual);
+  useOnValueChange(
+    plugins,
+    () => (sortable.plugins = plugins),
+    undefined,
+    deepEqual
+  );
   useOnValueChange(
     transition,
     () => (sortable.transition = transition),


### PR DESCRIPTION
## Summary

- Both `useDraggable` and `useSortable` were tracking the `sensors` prop with `useOnValueChange`'s default `Object.is` comparator, while the adjacent `modifiers` and `plugins` props (and all three props in `DragDropProvider`) use `deepEqual`.
- An inline `sensors={[PointerSensor.configure({...}), KeyboardSensor]}` array therefore reassigned `draggable.sensors` / `sortable.sensors` on every render, mutating the `PluginRegistry` and risking disruption to in-progress sensor activation.
- Switched both `sensors` lines to pass `deepEqual`, matching the existing pattern.

## Test plan

- [ ] Re-render a `<Draggable />` / `<Sortable />` with a structurally-equal but referentially-new `sensors` array and confirm the registry is not rewritten and active sensors are preserved.
- [ ] Verify drag interactions using inline `sensors` props are not interrupted across parent re-renders.

## Notes for reviewers

- `useDraggable`'s `data` prop (line 43) and `useSortable`'s `data` prop (line 74) are also commonly inlined and currently use `Object.is`. Behavior impact differs from sensors (no registry side effect, but downstream signal subscribers re-fire). Not changed here pending guidance.
- `@dnd-kit/react` has no test infrastructure (no `test` script, no Vitest/RTL devDeps, no `*.test.*` files), so no unit test is included. Standing up a React testing harness is out of scope for this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)