### PR TITLE
fix(sortable): adding a guardrail to handle the null value that cause a TypeError in SortableContext

### DIFF
--- a/.changeset/tender-aliens-build.md
+++ b/.changeset/tender-aliens-build.md
@@ -1,0 +1,5 @@
+---
+'@dnd-kit/helpers': patch
+---
+
+fix a check for the 'id' in items that causing TypeError in SortableContext add the gaurdrail for chekcing the item is not null.

--- a/packages/helpers/src/move.ts
+++ b/packages/helpers/src/move.ts
@@ -84,7 +84,7 @@ function mutate<
   }
 
   const findIndex = (item: Items[0], id: UniqueIdentifier) =>
-    item === id || (typeof item === 'object' && 'id' in item && item.id === id);
+    item === id || ( item !== null && typeof item === 'object' && 'id' in item && item.id === id); // adding the fix/ guardrails for check the item is not null
 
   if (Array.isArray(items)) {
     const sourceIndex = items.findIndex((item) => findIndex(item, source.id));

--- a/packages/helpers/tests/move.test.ts
+++ b/packages/helpers/tests/move.test.ts
@@ -780,3 +780,72 @@ describe('move – edge cases', () => {
     expect(move(items, event)).toEqual(['a', 'c', 'd', 'b']);
   });
 });
+
+// ===========================================================================
+// move / swap – null items (regression: TypeError from `'id' in null`)
+// ===========================================================================
+
+describe('move / swap – null items in array', () => {
+  // `typeof null === 'object'` in JS, so without an explicit null guard the
+  // `'id' in item` check throws `TypeError: Cannot use 'in' operator to
+  // search for 'id' in null`. These tests lock in that null entries are
+  // silently skipped during the ID lookup.
+
+  it('move should not throw when flat array contains null entries', () => {
+    const items: any[] = [null, 'a', 'b'];
+    const event = dragOverEvent(mockSource('a'), mockTarget('b'));
+    expect(() => move(items, event)).not.toThrow();
+  });
+
+  it('move should correctly reorder a flat array containing null entries', () => {
+    const items: any[] = [null, 'a', 'b'];
+    const event = dragOverEvent(mockSource('a'), mockTarget('b'));
+    expect(move(items, event)).toEqual([null, 'b', 'a']);
+  });
+
+  it('move should treat a null source/target id as not found (no throw)', () => {
+    const items: any[] = [null, 'a', 'b'];
+    const event = dragOverEvent(mockSource('z'), mockTarget('a'));
+    const result = move(items, event);
+    expect(result).toBe(items);
+  });
+
+  it('swap should not throw when flat array contains null entries', () => {
+    const items: any[] = [null, 'a', 'b'];
+    const event = dragOverEvent(mockSource('a'), mockTarget('b'));
+    expect(() => swap(items, event)).not.toThrow();
+  });
+
+  it('swap should correctly swap items in a flat array containing null entries', () => {
+    const items: any[] = [null, 'a', 'b'];
+    const event = dragOverEvent(mockSource('a'), mockTarget('b'));
+    expect(swap(items, event)).toEqual([null, 'b', 'a']);
+  });
+
+  it('move should not throw when an {id} object array contains null entries', () => {
+    const items: any[] = [{id: 'a'}, null, {id: 'b'}];
+    const event = dragOverEvent(mockSource('a'), mockTarget('b'));
+    expect(() => move(items, event)).not.toThrow();
+    expect(move(items, event)).toEqual([null, {id: 'b'}, {id: 'a'}]);
+  });
+
+  it('move should not throw when a grouped record contains null entries', () => {
+    const items: Record<string, any[]> = {
+      A: [null, 'a1', 'a2'],
+      B: ['b1', null],
+    };
+    const source = mockSource('a1');
+    source.manager = {
+      dragOperation: {
+        position: {current: {x: 0, y: 0}},
+        shape: null,
+      },
+    };
+    const event = dragOverEvent(source, mockTarget('a2'));
+    expect(() => move(items, event)).not.toThrow();
+    expect(move(items, event)).toEqual({
+      A: [null, 'a2', 'a1'],
+      B: ['b1', null],
+    });
+  });
+});


### PR DESCRIPTION
## Problem
When the `items` array passed to `SortableContext` contains `null` values,
the component throws a TypeError because `typeof null === 'object'` in JS,
and `'id' in null` throws.

## Root Cause
typeof null returns "object" in JavaScript which causes the isObject()
check to pass, and then "id" in null throws a TypeError.

## Fix
Added a null check before the isObject() check to guard against this case.

## Reproduction
const items = [null, 'a', 'b'];
<SortableContext items={items}>...</SortableContext>
// TypeError: Cannot use 'in' operator to search for 'id' in null