### PR TITLE
fix(solid): avoid double-evaluating children in DragDropProvider

### DIFF
--- a/.changeset/fix-solid-children-double-eval.md
+++ b/.changeset/fix-solid-children-double-eval.md
@@ -1,0 +1,5 @@
+---
+'@dnd-kit/solid': patch
+---
+
+Fixed `DragDropProvider` evaluating its `children` JSX twice on initial mount in `@dnd-kit/solid`. The provider now strips `children` from the props it forwards to `DragDropManager`, preventing the manager constructor's spread (`{...input}`) from invoking Solid's `children` getter and synthesizing an orphan component subtree whose reactive scope was never disposed.

--- a/packages/solid/src/core/context/DragDropProvider.tsx
+++ b/packages/solid/src/core/context/DragDropProvider.tsx
@@ -1,4 +1,4 @@
-import {createEffect, createMemo, onCleanup} from 'solid-js';
+import {createEffect, createMemo, onCleanup, splitProps} from 'solid-js';
 import {DragDropManager, defaultPreset, resolveCustomizable} from '@dnd-kit/dom';
 import {isSortable} from '@dnd-kit/dom/sortable';
 
@@ -27,8 +27,13 @@ export interface DragDropProviderProps
 export function DragDropProvider(props: DragDropProviderProps) {
   const {savePosition, restorePosition, clearPosition} = createSaveElementPosition();
   const {renderer, trackRendering} = useRenderer();
+  // Strip `children` before forwarding props to `DragDropManager`. The manager
+  // constructor spreads its input (`{...input}`) which would otherwise invoke
+  // Solid's `children` getter and synthesize an orphan component subtree on
+  // every memo recomputation. See #2015.
+  const [, managerProps] = splitProps(props, ['children']);
   const manager = createMemo(
-    () => props.manager ?? new DragDropManager(props)
+    () => props.manager ?? new DragDropManager(managerProps)
   );
 
   onCleanup(() => {


### PR DESCRIPTION
Fixes #2015

## Summary

`@dnd-kit/solid`'s `DragDropProvider` evaluates its children JSX twice on initial mount, leaking an orphaned reactive scope (signals, memos, and `useInstance` registration effects) for the provider's lifetime.

The trigger is `new DragDropManager(props)` inside the manager memo. `DragDropManager`'s constructor spreads its input (`{...input}`), which reads every own enumerable property of the Solid props object. Solid's JSX compiler installs `children` as a getter on the props object, so the spread invokes that getter and synthesizes a component subtree that is never owned or disposed. `DragDropProvider` then reads `props.children` again to render the inner `DragDropContext.Provider`, producing the actual mounted subtree.

The reporter (@martinory) provided a thorough root-cause analysis in #2015 and verified the fix locally against the canonical `apps/stories-solid/stories/Sortable/SortableApp.tsx` story:

- Per-row `Sortable` body invocations drop from 2 → 1.
- The first `useDragDropManager()` call per row used to return `null` (orphan executing before the context was attached); now there is only one call, with the live manager.
- Drag-and-drop continues to work normally.

## Fix

Strip `children` from the props passed to `new DragDropManager(...)` using Solid's `splitProps`. This removes only the getter that triggers the spread hazard while preserving every other reactive prop the consumer passed (event handlers, plugins, sensors, modifiers, `manager` config). `splitProps` returns a reactive proxy, so the manager memo continues to react to changes in those props.

```ts
const [, managerProps] = splitProps(props, ['children']);
const manager = createMemo(
  () => props.manager ?? new DragDropManager(managerProps),
);
```

## Test plan

- [ ] `apps/stories-solid` Sortable story renders the same DOM as before.
- [ ] Console no longer shows the duplicate per-row evaluations described in #2015.
- [ ] Real-pointer drag-and-drop continues to reorder items.
- [ ] `useDragDropManager()` returns the live manager on every call site (no more `null` orphan reads).

## Out of scope

The reporter notes that `{...input}` in `DragDropManager`'s constructor is a latent hazard for any framework adapter whose props are getter-backed. The Vue and Svelte adapters may benefit from the same audit, but the Solid-side fix is the smallest change that resolves this issue and is the one verified by the reporter; broader adapter-side hardening (or destructuring the manager input in `@dnd-kit/dom`) is best handled separately.

---
*Automated fix by Claude Code, based on the diagnosis and verification by @martinory in #2015.*