### PR TITLE
docs(svelte): use runes in sandbox snippets

### DIFF
--- a/apps/docs/docs/svelte/primitives/create-droppable.mdx
+++ b/apps/docs/docs/svelte/primitives/create-droppable.mdx
@@ -76,6 +76,7 @@ export const droppableCode = `
 <script>
   import {createDroppable} from '@dnd-kit/svelte';
 
+  let {children} = $props();
   const droppable = createDroppable({id: 'droppable'});
 </script>
 
@@ -84,7 +85,7 @@ export const droppableCode = `
   class="droppable"
   class:active={droppable.isDropTarget}
 >
-  <slot />
+  {@render children?.()}
 </div>
 `.trim();
 
@@ -95,7 +96,7 @@ export const appCode = `
   import Droppable from './Droppable.svelte';
   import './styles.css';
 
-  let parent = null;
+  let parent = $state(null);
 
   function onDragEnd(event) {
     if (event.canceled) return;

--- a/apps/docs/docs/svelte/primitives/create-sortable.mdx
+++ b/apps/docs/docs/svelte/primitives/create-sortable.mdx
@@ -182,7 +182,7 @@ export const appCode = `
   import {move} from '@dnd-kit/helpers';
   import './styles.css';
 
-  let items = [1, 2, 3, 4];
+  let items = $state([1, 2, 3, 4]);
   let snapshot = [];
 
   function onDragStart() {


### PR DESCRIPTION
## Summary
- The inline `<script>` example blocks in the Svelte docs already use `$state`, but the `appCode` template literals that power the embedded CodeSandbox (and that users copy from) did not. SvelteKit forces runes mode by default, so the unwrapped `let items = [...]` snippet was silently non-reactive when pasted into a SvelteKit project.
- Wrap `items` / `parent` in `$state(...)` in the `appCode` snippets for `createSortable` and `createDroppable`, and switch the shared `Droppable` snippet from legacy `<slot />` to `{@render children?.()}` so both work identically in the embedded sandbox and a runes-mode SvelteKit app.
- Closes #2032, closes #2034 — both reproductions copied from these snippets.

## Test plan
- [x] `bun run --cwd apps/docs build` — built successfully; verified `apps/docs/dist/svelte/primitives/create-sortable/index.html` ships `let items = $state([1, 2, 3, 4])`.
- [x] Reproduced the original bug in a SvelteKit `vite preview` build with the pre-fix snippet (no reorder); confirmed it works after wrapping in `$state`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)