### PR TITLE
docs(svelte): per-item component for sortable list (fixes #2038)

### DIFF
--- a/apps/docs/docs/svelte/primitives/create-droppable.mdx
+++ b/apps/docs/docs/svelte/primitives/create-droppable.mdx
@@ -76,6 +76,7 @@ export const droppableCode = `
 <script>
   import {createDroppable} from '@dnd-kit/svelte';
 
+  let {children} = $props();
   const droppable = createDroppable({id: 'droppable'});
 </script>
 
@@ -84,7 +85,7 @@ export const droppableCode = `
   class="droppable"
   class:active={droppable.isDropTarget}
 >
-  <slot />
+  {@render children?.()}
 </div>
 `.trim();
 
@@ -95,7 +96,7 @@ export const appCode = `
   import Droppable from './Droppable.svelte';
   import './styles.css';
 
-  let parent = null;
+  let parent = $state(null);
 
   function onDragEnd(event) {
     if (event.canceled) return;

--- a/apps/docs/docs/svelte/primitives/create-sortable.mdx
+++ b/apps/docs/docs/svelte/primitives/create-sortable.mdx
@@ -182,7 +182,7 @@ export const appCode = `
   import {move} from '@dnd-kit/helpers';
   import './styles.css';
 
-  let items = [1, 2, 3, 4];
+  let items = $state([1, 2, 3, 4]);
   let snapshot = [];
 
   function onDragStart() {

--- a/apps/docs/docs/svelte/primitives/create-sortable.mdx
+++ b/apps/docs/docs/svelte/primitives/create-sortable.mdx
@@ -17,11 +17,16 @@ The `createSortable` primitive combines draggable and droppable behavior with so
 
 <CodeSandbox template="svelte" files={{
   '/src/App.svelte': {code: appCode, active: true},
+  '/src/SortableItem.svelte': {code: sortableItemCode},
   '/src/styles.css': {code: sortableStyles, hidden: true},
 }} height={560} previewHeight={180} />
 
+<Warning>
+  Each sortable item must live in its own component (`SortableItem.svelte` above), with `createSortable` called in that component's `<script>`. Calling `createSortable` inline in an `{#each}` block — for example via `{@const sortable = createSortable(...)}` — re-runs the call on every reorder, which creates a fresh `Sortable` instance per render and breaks sort transition animations. Wrapping each item in its own component is what gives `createSortable` a stable per-item identity across reorders.
+</Warning>
+
 <Note>
-  When using `createSortable` inside an `{#each}` block, pass reactive values like `index` as getter properties (e.g. `get index() { return index; }`) to maintain reactivity as items are reordered. Visual sorting during drag is driven by calling `move()` in `onDragOver`. The `onDragEnd` handler only needs to restore the snapshot when the drag is canceled.
+  Pass reactive values like `id` and `index` as **getter properties** (e.g. `get id() { return id; }`, `get index() { return index; }`) so the underlying sortable stays in sync as items are reordered. Visual sorting during drag is driven by calling `move()` in `onDragOver`; the `onDragEnd` handler only needs to restore the snapshot when the drag is canceled.
 </Note>
 
 ## Without the move helper
@@ -32,10 +37,28 @@ If you need more control over state updates, you can manage state manually using
 
 Call `move()` in `onDragOver` for live visual sorting, and restore the snapshot in `onDragEnd` only when the drag is canceled:
 
-```svelte
+```svelte SortableItem.svelte
+<script>
+  import {createSortable} from '@dnd-kit/svelte/sortable';
+
+  let {id, index} = $props();
+
+  const sortable = createSortable({
+    get id() { return id; },
+    get index() { return index; },
+  });
+</script>
+
+<li {@attach sortable.attach}>
+  Item {id}
+</li>
+```
+
+```svelte App.svelte
 <script>
   import {DragDropProvider} from '@dnd-kit/svelte';
-  import {createSortable, isSortable} from '@dnd-kit/svelte/sortable';
+  import {isSortable} from '@dnd-kit/svelte/sortable';
+  import SortableItem from './SortableItem.svelte';
 
   let items = $state([1, 2, 3, 4]);
   let snapshot = [];
@@ -68,10 +91,7 @@ Call `move()` in `onDragOver` for live visual sorting, and restore the snapshot 
 <DragDropProvider {onDragStart} {onDragOver} {onDragEnd}>
   <ul>
     {#each items as id, index (id)}
-      {@const sortable = createSortable({id, get index() { return index; }})}
-      <li {@attach sortable.attach}>
-        Item {id}
-      </li>
+      <SortableItem {id} {index} />
     {/each}
   </ul>
 </DragDropProvider>
@@ -175,11 +195,28 @@ All input properties accept plain values or getter functions for reactivity.
   Attachment function for the drop target element (when different from the sortable element).
 </ResponseField>
 
+export const sortableItemCode = `
+<script>
+  import {createSortable} from '@dnd-kit/svelte/sortable';
+
+  let {id, index} = $props();
+
+  const sortable = createSortable({
+    get id() { return id; },
+    get index() { return index; },
+  });
+</script>
+
+<li {@attach sortable.attach} class="item">
+  Item {id}
+</li>
+`.trim();
+
 export const appCode = `
 <script>
   import {DragDropProvider} from '@dnd-kit/svelte';
-  import {createSortable} from '@dnd-kit/svelte/sortable';
   import {move} from '@dnd-kit/helpers';
+  import SortableItem from './SortableItem.svelte';
   import './styles.css';
 
   let items = $state([1, 2, 3, 4]);
@@ -201,10 +238,7 @@ export const appCode = `
 <DragDropProvider {onDragStart} {onDragOver} {onDragEnd}>
   <ul class="list">
     {#each items as id, index (id)}
-      {@const sortable = createSortable({id, get index() { return index; }})}
-      <li {@attach sortable.attach} class="item">
-        Item {id}
-      </li>
+      <SortableItem {id} {index} />
     {/each}
   </ul>
 </DragDropProvider>

--- a/apps/templates/svelte-sortable/src/App.svelte
+++ b/apps/templates/svelte-sortable/src/App.svelte
@@ -1,7 +1,7 @@
 <script>
   import {DragDropProvider} from '@dnd-kit/svelte';
-  import {createSortable} from '@dnd-kit/svelte/sortable';
   import {move} from '@dnd-kit/helpers';
+  import SortableItem from './SortableItem.svelte';
 
   let items = $state([1, 2, 3, 4]);
   let snapshot = [];
@@ -22,10 +22,7 @@
 <DragDropProvider {onDragStart} {onDragOver} {onDragEnd}>
   <ul class="list">
     {#each items as id, index (id)}
-      {@const sortable = createSortable({id, get index() { return index; }})}
-      <li {@attach sortable.attach} class="item">
-        Item {id}
-      </li>
+      <SortableItem {id} {index} />
     {/each}
   </ul>
 </DragDropProvider>

--- a/apps/templates/svelte-sortable/src/SortableItem.svelte
+++ b/apps/templates/svelte-sortable/src/SortableItem.svelte
@@ -1,0 +1,14 @@
+<script>
+  import {createSortable} from '@dnd-kit/svelte/sortable';
+
+  let {id, index} = $props();
+
+  const sortable = createSortable({
+    get id() { return id; },
+    get index() { return index; },
+  });
+</script>
+
+<li {@attach sortable.attach} class="item">
+  Item {id}
+</li>


### PR DESCRIPTION
## Summary
- The `createSortable` example called the primitive inline via `{@const sortable = createSortable(...)}` inside an `{#each}` block. In Svelte 5 keyed each blocks, that `{@const}` re-evaluates on every reorder, calling `createSortable` again and registering a brand-new `Sortable` per render — fresh instance, no shape, `#previousIndex` already equal to the current index, so the sort-transition `animate()` either bails on missing shape or skips because the index didn't actually change yet. That's the "first move animates, every subsequent move teleports" behavior reported in #2038.
- Moved `createSortable` into a dedicated `SortableItem.svelte` component in both the docs sandbox example (and the manual `isSortable` example) and the `svelte-sortable` template. Component instances are preserved across keyed-each reorders, which is what gives `Sortable` a stable per-item identity.
- Added a `<Warning>` callout explaining the failure mode so users don't reintroduce the inline pattern.
- Closes #2038.

## Verification
Reproduced in a fresh SvelteKit project (Svelte 5.55, vite 8) with the docs example: items \"teleported\" on every swap after the first, and the droppable for an item was a different instance after each swap (`oldDrop === newDrop` → `false`). After moving `createSortable` into `SortableItem.svelte`:
- Droppable instance is preserved across swaps (`sameInstance: true`).
- `Element.prototype.animate` is called for each affected item on every swap (2 → 4 → 6 across three swaps), confirming the sort transition fires every time.

## Test plan
- [x] `bun run --cwd apps/docs build` — built successfully; verified the sandbox HTML now imports `SortableItem` and renders `<SortableItem />` inside the each.
- [x] Manual SvelteKit repro using the new component pattern — animations fire on every reorder, items don't teleport.

🤖 Generated with [Claude Code](https://claude.com/claude-code)