### PR TITLE
Include sourcemap files in published react/solid/vue packages

### DIFF
--- a/.changeset/include-sourcemap-files.md
+++ b/.changeset/include-sourcemap-files.md
@@ -1,0 +1,7 @@
+---
+'@dnd-kit/react': patch
+'@dnd-kit/solid': patch
+'@dnd-kit/vue': patch
+---
+
+Include sourcemap files in published packages. The build emits `.map` files alongside each entry point and writes `//# sourceMappingURL=...` comments into the bundles, but the `files` field in `package.json` did not list the maps, so they were excluded from the npm tarball. Bundlers attempting to load the referenced maps would fail with `ENOENT`, producing warnings (or build failures in strict CI setups).

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -11,17 +11,25 @@
     "LICENSE",
     "README.md",
     "index.js",
+    "index.js.map",
     "index.d.ts",
     "index.cjs",
+    "index.cjs.map",
     "hooks.js",
+    "hooks.js.map",
     "hooks.d.ts",
     "hooks.cjs",
+    "hooks.cjs.map",
     "sortable.js",
+    "sortable.js.map",
     "sortable.d.ts",
     "sortable.cjs",
+    "sortable.cjs.map",
     "utilities.js",
+    "utilities.js.map",
     "utilities.d.ts",
-    "utilities.cjs"
+    "utilities.cjs",
+    "utilities.cjs.map"
   ],
   "exports": {
     ".": {

--- a/packages/solid/package.json
+++ b/packages/solid/package.json
@@ -11,17 +11,25 @@
     "LICENSE",
     "README.md",
     "index.js",
+    "index.js.map",
     "index.d.ts",
     "index.cjs",
+    "index.cjs.map",
     "hooks.js",
+    "hooks.js.map",
     "hooks.d.ts",
     "hooks.cjs",
+    "hooks.cjs.map",
     "sortable.js",
+    "sortable.js.map",
     "sortable.d.ts",
     "sortable.cjs",
+    "sortable.cjs.map",
     "utilities.js",
+    "utilities.js.map",
     "utilities.d.ts",
-    "utilities.cjs"
+    "utilities.cjs",
+    "utilities.cjs.map"
   ],
   "exports": {
     ".": {

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -11,17 +11,25 @@
     "LICENSE",
     "README.md",
     "index.js",
+    "index.js.map",
     "index.d.ts",
     "index.cjs",
+    "index.cjs.map",
     "composables.js",
+    "composables.js.map",
     "composables.d.ts",
     "composables.cjs",
+    "composables.cjs.map",
     "sortable.js",
+    "sortable.js.map",
     "sortable.d.ts",
     "sortable.cjs",
+    "sortable.cjs.map",
     "utilities.js",
+    "utilities.js.map",
     "utilities.d.ts",
-    "utilities.cjs"
+    "utilities.cjs",
+    "utilities.cjs.map"
   ],
   "exports": {
     ".": {


### PR DESCRIPTION
## Summary

The build for `@dnd-kit/react`, `@dnd-kit/solid`, and `@dnd-kit/vue` emits `.map` files alongside each entry point (`tsup` runs with `sourcemap: true`) and writes `//# sourceMappingURL=...` comments into every bundle. But the `files` field in each `package.json` enumerates the JS/CJS/DTS outputs by name and omits the `.map` siblings, so they get stripped from the npm tarball.

Confirmed against the published artifact:

```
$ npm pack @dnd-kit/react@latest
$ tar tzf dnd-kit-react-*.tgz
package/index.js
package/index.cjs
package/hooks.js
...   # no .map files
$ tail -1 package/index.js
//# sourceMappingURL=index.js.map   # but the file isn't there
```

Downstream bundlers then try to fetch the referenced maps, hit `ENOENT`, and emit warnings — which can fail builds in strict CI setups (see #2029 for a real-world report).

## Fix

Add the `.js.map` and `.cjs.map` entries to the `files` array in each affected package. This brings them into line with `@dnd-kit/abstract` and `@dnd-kit/dom`, which already list their map files explicitly. Other packages (`collision`, `geometry`, `helpers`, `state`, `svelte`) use `dist/**` globs and were never affected.

Verified with `npm pack --dry-run` after the change — `.map` files now appear in the tarball contents.

## Supersedes #2029

That PR only patched `react` and bundled two unrelated changes:
- a 60-line custom Vite plugin in `apps/docs/astro.config.mjs` to work around the author's local pnpm/bun layout for `@mintlify/components`
- a tsup temp build artifact (`packages/solid/tsup.config.bundled_*.mjs`) with absolute paths from the author's machine

This PR is the minimal, complete fix across all three affected packages.

## Test plan

- [x] `npm pack --dry-run` in `packages/react` shows `*.map` files in the tarball contents
- [x] Local build still emits the expected `.js.map` / `.cjs.map` files at the names listed in `files`
- [ ] Changesets bot picks up `.changeset/include-sourcemap-files.md` and proposes patch bumps for all three packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)