### PR TITLE
fix(sortable): Add support for non-contiguous indexes in OptimisticSortingPlugin

### DIFF
--- a/.changeset/puny-fans-enjoy.md
+++ b/.changeset/puny-fans-enjoy.md
@@ -1,0 +1,5 @@
+---
+'@dnd-kit/dom': minor
+---
+
+Updated OptimisticSortingPlugin to support non-contiguous sortable indexes.

--- a/packages/dom/src/sortable/plugins/OptimisticSortingPlugin.helpers.ts
+++ b/packages/dom/src/sortable/plugins/OptimisticSortingPlugin.helpers.ts
@@ -1,0 +1,45 @@
+import type {UniqueIdentifier} from '@dnd-kit/abstract';
+
+import type {Sortable} from '../sortable.ts';
+
+export type SortableInstances = Map<
+  UniqueIdentifier | undefined,
+  Set<Sortable>
+>;
+export type SortableIndices = Map<UniqueIdentifier, number>;
+
+export function getSortableIndices(
+  instances: SortableInstances
+): SortableIndices {
+  const sortableIndices: SortableIndices = new Map();
+
+  for (const [, group] of instances) {
+    for (const sortable of group) {
+      sortableIndices.set(sortable.id, sortable.index);
+    }
+  }
+
+  return sortableIndices;
+}
+
+export function hasChanged(
+  snapshotIndices: SortableIndices,
+  instances: SortableInstances,
+  newInstances: SortableInstances
+): boolean {
+  for (const [group, sortables] of instances) {
+    for (const sortable of sortables) {
+      const index = snapshotIndices.get(sortable.id);
+
+      if (
+        sortable.index !== index ||
+        sortable.group !== group ||
+        !newInstances.get(group)?.has(sortable)
+      ) {
+        return true;
+      }
+    }
+  }
+
+  return false;
+}

--- a/packages/dom/src/sortable/plugins/OptimisticSortingPlugin.ts
+++ b/packages/dom/src/sortable/plugins/OptimisticSortingPlugin.ts
@@ -1,15 +1,17 @@
-import {Plugin, type UniqueIdentifier} from '@dnd-kit/abstract';
+import {Plugin} from '@dnd-kit/abstract';
 import type {DragDropManager} from '@dnd-kit/dom';
 import {move} from '@dnd-kit/helpers';
 import {batch} from '@dnd-kit/state';
 
 import {Sortable, SortableDroppable} from '../sortable.ts';
 import {isSortable} from '../utilities.ts';
+import {
+  getSortableIndices,
+  hasChanged,
+  type SortableInstances,
+} from './OptimisticSortingPlugin.helpers.ts';
 
 const defaultGroup = '__default__';
-
-type SortableInstances = Map<UniqueIdentifier | undefined, Set<Sortable>>;
-type SortableIndices = Map<UniqueIdentifier, number>;
 
 export class OptimisticSortingPlugin extends Plugin<DragDropManager> {
   constructor(manager: DragDropManager) {
@@ -35,40 +37,6 @@ export class OptimisticSortingPlugin extends Plugin<DragDropManager> {
       }
 
       return sortableInstances;
-    };
-
-    const getSortableIndices = (instances: SortableInstances) => {
-      const sortableIndices: SortableIndices = new Map();
-
-      for (const [, group] of instances) {
-        for (const sortable of group) {
-          sortableIndices.set(sortable.id, sortable.index);
-        }
-      }
-
-      return sortableIndices;
-    };
-
-    const hasChanged = (
-      expectedIndices: SortableIndices,
-      instances: SortableInstances,
-      newInstances: SortableInstances
-    ) => {
-      for (const [group, sortables] of instances) {
-        for (const sortable of sortables) {
-          const index = expectedIndices.get(sortable.id);
-
-          if (
-            sortable.index !== index ||
-            sortable.group !== group ||
-            !newInstances.get(group)?.has(sortable)
-          ) {
-            return true;
-          }
-        }
-      }
-
-      return false;
     };
 
     const unsubscribe = [
@@ -206,8 +174,8 @@ export class OptimisticSortingPlugin extends Plugin<DragDropManager> {
               sortByInitialIndex
             );
             const sourceElement = source.sortable.element;
-            const initialIndex = initialSortables.indexOf(source.sortable);
-            const target = currentSortables[initialIndex];
+            const initialPosition = initialSortables.indexOf(source.sortable);
+            const target = currentSortables[initialPosition];
             const targetElement = target?.element;
 
             if (!target || !targetElement || !sourceElement) {

--- a/packages/dom/src/sortable/plugins/OptimisticSortingPlugin.ts
+++ b/packages/dom/src/sortable/plugins/OptimisticSortingPlugin.ts
@@ -8,15 +8,15 @@ import {isSortable} from '../utilities.ts';
 
 const defaultGroup = '__default__';
 
+type SortableInstances = Map<UniqueIdentifier | undefined, Set<Sortable>>;
+type SortableIndices = Map<UniqueIdentifier, number>;
+
 export class OptimisticSortingPlugin extends Plugin<DragDropManager> {
   constructor(manager: DragDropManager) {
     super(manager);
 
     const getSortableInstances = () => {
-      const sortableInstances = new Map<
-        UniqueIdentifier | undefined,
-        Set<Sortable>
-      >();
+      const sortableInstances: SortableInstances = new Map();
 
       for (const droppable of manager.registry.droppables) {
         if (droppable instanceof SortableDroppable) {
@@ -34,11 +34,41 @@ export class OptimisticSortingPlugin extends Plugin<DragDropManager> {
         }
       }
 
-      for (const [group, instances] of sortableInstances) {
-        sortableInstances.set(group, new Set(sort(instances)));
+      return sortableInstances;
+    };
+
+    const getSortableIndices = (instances: SortableInstances) => {
+      const sortableIndices: SortableIndices = new Map();
+
+      for (const [, group] of instances) {
+        for (const sortable of group) {
+          sortableIndices.set(sortable.id, sortable.index);
+        }
       }
 
-      return sortableInstances;
+      return sortableIndices;
+    };
+
+    const hasChanged = (
+      expectedIndices: SortableIndices,
+      instances: SortableInstances,
+      newInstances: SortableInstances
+    ) => {
+      for (const [group, sortables] of instances) {
+        for (const sortable of sortables) {
+          const index = expectedIndices.get(sortable.id);
+
+          if (
+            sortable.index !== index ||
+            sortable.group !== group ||
+            !newInstances.get(group)?.has(sortable)
+          ) {
+            return true;
+          }
+        }
+      }
+
+      return false;
     };
 
     const unsubscribe = [
@@ -59,6 +89,7 @@ export class OptimisticSortingPlugin extends Plugin<DragDropManager> {
         }
 
         const instances = getSortableInstances();
+        const sortableIndices = getSortableIndices(instances);
         const sameGroup = source.sortable.group === target.sortable.group;
         const sourceInstances = instances.get(source.sortable.group);
         const targetInstances = sameGroup
@@ -74,19 +105,9 @@ export class OptimisticSortingPlugin extends Plugin<DragDropManager> {
           manager.renderer.rendering.then(() => {
             const newInstances = getSortableInstances();
 
-            for (const [group, sortableInstances] of instances.entries()) {
-              const entries = Array.from(sortableInstances).entries();
-
-              for (const [index, sortable] of entries) {
-                if (
-                  sortable.index !== index ||
-                  sortable.group !== group ||
-                  !newInstances.get(group)?.has(sortable)
-                ) {
-                  // At least one index or group was changed so we should abort optimistic updates
-                  return;
-                }
-              }
+            if (hasChanged(sortableIndices, instances, newInstances)) {
+              // At least one index or group was changed so we should abort optimistic updates
+              return;
             }
 
             const sourceElement = source.sortable.element;
@@ -163,6 +184,7 @@ export class OptimisticSortingPlugin extends Plugin<DragDropManager> {
 
         queueMicrotask(() => {
           const instances = getSortableInstances();
+          const sortableIndices = getSortableIndices(instances);
           const initialGroupInstances = instances.get(
             source.sortable.initialGroup
           );
@@ -171,20 +193,21 @@ export class OptimisticSortingPlugin extends Plugin<DragDropManager> {
 
           // Wait for the renderer to handle the event before attempting to optimistically update
           manager.renderer.rendering.then(() => {
-            for (const [group, sortableInstances] of instances.entries()) {
-              const entries = Array.from(sortableInstances).entries();
+            const newInstances = getSortableInstances();
 
-              for (const [index, sortable] of entries) {
-                if (sortable.index !== index || sortable.group !== group) {
-                  // At least one index or group was changed so we should abort optimistic updates
-                  return;
-                }
-              }
+            if (hasChanged(sortableIndices, instances, newInstances)) {
+              // At least one index or group was changed so we should abort optimistic updates
+              return;
             }
 
-            const initialGroup = sort(initialGroupInstances);
+            const currentSortables = sort(initialGroupInstances);
+            const initialSortables = sort(
+              initialGroupInstances,
+              sortByInitialIndex
+            );
             const sourceElement = source.sortable.element;
-            const target = initialGroup[source.sortable.initialIndex];
+            const initialIndex = initialSortables.indexOf(source.sortable);
+            const target = currentSortables[initialIndex];
             const targetElement = target?.element;
 
             if (!target || !targetElement || !sourceElement) {
@@ -194,7 +217,7 @@ export class OptimisticSortingPlugin extends Plugin<DragDropManager> {
             reorder(sourceElement, target.index, targetElement, source.index);
 
             batch(() => {
-              for (const [_, sortableInstances] of instances.entries()) {
+              for (const sortableInstances of instances.values()) {
                 const entries = Array.from(sortableInstances).values();
 
                 for (const sortable of entries) {
@@ -231,6 +254,10 @@ function sortByIndex(a: Sortable, b: Sortable) {
   return a.index - b.index;
 }
 
-function sort(instances: Set<Sortable>) {
-  return Array.from(instances).sort(sortByIndex);
+function sortByInitialIndex(a: Sortable, b: Sortable) {
+  return a.initialIndex - b.initialIndex;
+}
+
+function sort(instances: Set<Sortable>, sortFn = sortByIndex) {
+  return Array.from(instances).sort(sortFn);
 }

--- a/packages/dom/tests/optimistic-sorting-plugin.test.ts
+++ b/packages/dom/tests/optimistic-sorting-plugin.test.ts
@@ -1,0 +1,90 @@
+import {describe, expect, it} from 'bun:test';
+
+import type {Sortable} from '@dnd-kit/dom/sortable';
+
+import {
+  getSortableIndices,
+  hasChanged,
+} from '../src/sortable/plugins/OptimisticSortingPlugin.helpers.ts';
+
+// The helpers only read id/index/group, so a duck-typed fake avoids both the
+// real Sortable constructor (which needs a DragDropManager) and the circular
+// import between sortable.ts and OptimisticSortingPlugin.ts.
+function createSortable(
+  id: string | number,
+  index: number,
+  group?: string
+): Sortable {
+  return {id, index, group} as unknown as Sortable;
+}
+
+function buildInstances(sortables: Sortable[]) {
+  const instances = new Map<string | number | undefined, Set<Sortable>>();
+  for (const sortable of sortables) {
+    let set = instances.get(sortable.group);
+    if (!set) {
+      set = new Set();
+      instances.set(sortable.group, set);
+    }
+    set.add(sortable);
+  }
+  return instances;
+}
+
+describe('hasChanged', () => {
+  it('returns false when nothing changed', () => {
+    const a = createSortable('a', 0);
+    const b = createSortable('b', 1);
+    const c = createSortable('c', 2);
+    const instances = buildInstances([a, b, c]);
+    const snapshot = getSortableIndices(instances);
+
+    expect(hasChanged(snapshot, instances, instances)).toBe(false);
+  });
+
+  it('returns false when indices are non-contiguous and unchanged', () => {
+    // Regression: previously the check used position-in-set rather than the
+    // sortable's actual index, which broke when indices had gaps.
+    const a = createSortable('a', 0);
+    const b = createSortable('b', 2);
+    const c = createSortable('c', 5);
+    const instances = buildInstances([a, b, c]);
+    const snapshot = getSortableIndices(instances);
+
+    expect(hasChanged(snapshot, instances, instances)).toBe(false);
+  });
+
+  it('returns true when a sortable index changes after the snapshot', () => {
+    const a = createSortable('a', 0);
+    const b = createSortable('b', 2);
+    const c = createSortable('c', 5);
+    const instances = buildInstances([a, b, c]);
+    const snapshot = getSortableIndices(instances);
+
+    (b as {index: number}).index = 3;
+
+    expect(hasChanged(snapshot, instances, instances)).toBe(true);
+  });
+
+  it('returns true when a sortable group changes after the snapshot', () => {
+    const a = createSortable('a', 0, 'g1');
+    const b = createSortable('b', 1, 'g1');
+    const instances = buildInstances([a, b]);
+    const snapshot = getSortableIndices(instances);
+
+    (b as {group: string}).group = 'g2';
+    const newInstances = buildInstances([a, b]);
+
+    expect(hasChanged(snapshot, instances, newInstances)).toBe(true);
+  });
+
+  it('returns true when a sortable is missing from newInstances', () => {
+    const a = createSortable('a', 0);
+    const b = createSortable('b', 1);
+    const instances = buildInstances([a, b]);
+    const snapshot = getSortableIndices(instances);
+    const newInstances = buildInstances([a]);
+
+    expect(hasChanged(snapshot, instances, newInstances)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Problem
The OptimisticSortingPlugin is incompatible with non-contiguous sortable indices e.g. `items.map((id, i) => id !== "ignore" ?  <Sortable id={id} index={i} />  : null)`. When this happens, the plugin fails silently and prevents visual feedback for the dragged element.

This PR improves the ergonomics of the plugin to align with the non-optimistic behavior of dnd-kit.

Issue example: https://codesandbox.io/p/sandbox/tender-nash-pz8xfg

## Solution

The issue occurs when the code checks if the sortables have changed between microtask execution:
- The code uses the index of the generated `Set<Sortable>` to determine if  `sortable.index` has changed.
- This requires the sortables to have strict contiguous indexes starting at 0: `0,1,2,3`.

The PR solves the issue by taking a snapshot of the sortable indices before the microtask, and using those to determine if the index changed.

Additionally, the code in `dragend` was updated to resolve potentially non-contiguous `source.initialIndex` to an index relative to the generated contiguous set, so we can correctly determine the `target`.

**Before:**
<img width="300" alt="Kooha-2026-05-08-10-22-10" src="https://github.com/user-attachments/assets/b21f24f5-fb06-4618-9c29-7af58c1c3eed" />

**After:**
<img width="300" alt="Kooha-2026-05-08-10-23-40" src="https://github.com/user-attachments/assets/2c8ee743-d1cd-4357-b158-385e360be254" />

## Notes
- This is a non-breaking change.
