### PR TITLE
Fix docs dev server and legacy context provider links

### DIFF
--- a/apps/docs/astro.config.mjs
+++ b/apps/docs/astro.config.mjs
@@ -35,13 +35,34 @@ export default defineConfig({
     },
     plugins: [tailwindcss()],
     resolve: {
-      alias: {
-        '@mintlify/astro/components': resolve('./src/lib/mintlify-components.tsx'),
-        '@mintlify/astro-internal-components': resolve(
-          '../../node_modules/@mintlify/astro/dist/utils/mintlify-components.js'
-        ),
-        '@components/CodeSandbox': resolve('./src/components/CodeSandbox.tsx'),
-      },
+      alias: [
+        {
+          // Generated Mintlify React snippets import this package directly.
+          find: /^@mintlify\/components$/,
+          replacement: resolve('./src/lib/mintlify-components-extended.tsx'),
+        },
+        {
+          // The wrapper above re-exports the real package under this escape hatch.
+          find: /^@mintlify\/components-original$/,
+          replacement: resolve(
+            '../../node_modules/@mintlify/components/dist/index.js',
+          ),
+        },
+        {
+          find: '@mintlify/astro/components',
+          replacement: resolve('./src/lib/mintlify-components.tsx'),
+        },
+        {
+          find: '@mintlify/astro-internal-components',
+          replacement: resolve(
+            '../../node_modules/@mintlify/astro/dist/utils/mintlify-components.js',
+          ),
+        },
+        {
+          find: '@components/CodeSandbox',
+          replacement: resolve('./src/components/CodeSandbox.tsx'),
+        },
+      ],
     },
   },
 });

--- a/apps/docs/astro.config.mjs
+++ b/apps/docs/astro.config.mjs
@@ -28,6 +28,22 @@ export default defineConfig({
     // Preserve legacy group/index links that predate the generated DndContext page.
     '/legacy/api-documentation/context-provider':
       '/legacy/api-documentation/context-provider/dnd-context',
+    // Keep stale production links working after legacy introduction pages are fixed.
+    '/legacy/introduction/api-documentation/context-provider/dnd-context':
+      '/legacy/api-documentation/context-provider/dnd-context',
+    '/legacy/introduction/api-documentation/draggable':
+      '/legacy/api-documentation/draggable',
+    '/legacy/introduction/api-documentation/draggable/drag-overlay':
+      '/legacy/api-documentation/draggable/drag-overlay',
+    '/legacy/introduction/api-documentation/draggable/use-draggable':
+      '/legacy/api-documentation/draggable/use-draggable',
+    '/legacy/introduction/api-documentation/droppable':
+      '/legacy/api-documentation/droppable',
+    '/legacy/introduction/api-documentation/droppable/use-droppable':
+      '/legacy/api-documentation/droppable/use-droppable',
+    '/legacy/introduction/guides/accessibility': '/legacy/guides/accessibility',
+    '/legacy/introduction/presets/sortable':
+      '/legacy/presets/sortable/overview',
   },
   markdown: {
     shikiConfig: {

--- a/apps/docs/astro.config.mjs
+++ b/apps/docs/astro.config.mjs
@@ -9,6 +9,7 @@ import tailwindcss from '@tailwindcss/vite';
 
 export default defineConfig({
   site: 'https://dndkit.com',
+  trailingSlash: 'ignore',
   integrations: [
     mintlify({ docsDir: './docs' }),
     react(),
@@ -26,11 +27,22 @@ export default defineConfig({
   ],
   redirects: {
     // Preserve legacy group/index links that predate the generated DndContext page.
+    // Remove this once a context-provider index page exists.
     '/legacy/api-documentation/context-provider':
       '/legacy/api-documentation/context-provider/dnd-context',
     // Keep stale production links working after legacy introduction pages are fixed.
+    // The legacy MDX previously used relative links like `../api-documentation/...`,
+    // which Mintlify resolved against `/legacy/introduction/...`, producing the URLs below.
+    '/legacy/introduction/api-documentation/context-provider':
+      '/legacy/api-documentation/context-provider/dnd-context',
     '/legacy/introduction/api-documentation/context-provider/dnd-context':
       '/legacy/api-documentation/context-provider/dnd-context',
+    '/legacy/introduction/api-documentation/context-provider/collision-detection-algorithms':
+      '/legacy/api-documentation/context-provider/collision-detection-algorithms',
+    '/legacy/introduction/api-documentation/context-provider/use-dnd-context':
+      '/legacy/api-documentation/context-provider/use-dnd-context',
+    '/legacy/introduction/api-documentation/context-provider/use-dnd-monitor':
+      '/legacy/api-documentation/context-provider/use-dnd-monitor',
     '/legacy/introduction/api-documentation/draggable':
       '/legacy/api-documentation/draggable',
     '/legacy/introduction/api-documentation/draggable/drag-overlay':
@@ -41,9 +53,25 @@ export default defineConfig({
       '/legacy/api-documentation/droppable',
     '/legacy/introduction/api-documentation/droppable/use-droppable':
       '/legacy/api-documentation/droppable/use-droppable',
+    '/legacy/introduction/api-documentation/modifiers':
+      '/legacy/api-documentation/modifiers',
+    '/legacy/introduction/api-documentation/sensors':
+      '/legacy/api-documentation/sensors',
+    '/legacy/introduction/api-documentation/sensors/keyboard':
+      '/legacy/api-documentation/sensors/keyboard',
+    '/legacy/introduction/api-documentation/sensors/mouse':
+      '/legacy/api-documentation/sensors/mouse',
+    '/legacy/introduction/api-documentation/sensors/pointer':
+      '/legacy/api-documentation/sensors/pointer',
+    '/legacy/introduction/api-documentation/sensors/touch':
+      '/legacy/api-documentation/sensors/touch',
     '/legacy/introduction/guides/accessibility': '/legacy/guides/accessibility',
     '/legacy/introduction/presets/sortable':
       '/legacy/presets/sortable/overview',
+    '/legacy/introduction/presets/sortable/sortable-context':
+      '/legacy/presets/sortable/sortable-context',
+    '/legacy/introduction/presets/sortable/use-sortable':
+      '/legacy/presets/sortable/use-sortable',
   },
   markdown: {
     shikiConfig: {

--- a/apps/docs/astro.config.mjs
+++ b/apps/docs/astro.config.mjs
@@ -24,6 +24,11 @@ export default defineConfig({
       },
     }),
   ],
+  redirects: {
+    // Preserve legacy group/index links that predate the generated DndContext page.
+    '/legacy/api-documentation/context-provider':
+      '/legacy/api-documentation/context-provider/dnd-context',
+  },
   markdown: {
     shikiConfig: {
       theme: 'monokai',

--- a/apps/docs/docs/legacy/api-documentation/context-provider/collision-detection-algorithms.mdx
+++ b/apps/docs/docs/legacy/api-documentation/context-provider/collision-detection-algorithms.mdx
@@ -16,11 +16,11 @@ This means that even if the draggable or droppable nodes look round or triangula
 
 ![Axis-aligned bounding boxes](/images/legacy/axis-aligned-rectangle.png)
 
-If you'd like to use other shapes than rectangles for detecting collisions, build your own [custom collision detection algorithm](./collision-detection-algorithms#custom-collision-detection-strategies).
+If you'd like to use other shapes than rectangles for detecting collisions, build your own [custom collision detection algorithm](/legacy/api-documentation/context-provider/collision-detection-algorithms#custom-collision-detection-strategies).
 
 ## Rectangle intersection
 
-By default, [`DndContext`](./dnd-context) uses the **rectangle intersection** collision detection algorithm.
+By default, [`DndContext`](/legacy/api-documentation/context-provider/dnd-context) uses the **rectangle intersection** collision detection algorithm.
 
 The algorithm works by ensuring there is no gap between any of the 4 sides of the rectangles. Any gap means a collision does not exist.
 
@@ -32,7 +32,7 @@ This means that in order for a draggable item to be considered **over** a droppa
 
 While the rectangle intersection algorithm is well suited for most drag and drop use cases, it can be unforgiving, since it requires both the draggable and droppable bounding rectangles to come into direct contact and intersect.
 
-For some use cases, such as [sortable](../../presets/sortable/) lists, using a more forgiving collision detection algorithm is recommended.
+For some use cases, such as [sortable](/legacy/presets/sortable/overview) lists, using a more forgiving collision detection algorithm is recommended.
 
 As its name suggests, the closest center algorithm finds the droppable container who's center is closest to the center of the bounding rectangle of the active draggable item:
 

--- a/apps/docs/docs/legacy/api-documentation/context-provider/dnd-context.mdx
+++ b/apps/docs/docs/legacy/api-documentation/context-provider/dnd-context.mdx
@@ -8,11 +8,11 @@ sidebarTitle: <DndContext>
 
 ## Application structure
 
-In order for your your [Droppable](../droppable) and [Draggable](../draggable) components to interact with each other, you'll need to make sure that the part of your React tree that uses them is nested within a parent `<DndContext>` component. The `<DndContext>` provider makes use of the [React Context API](https://reactjs.org/docs/context.html) to share data between draggable and droppable components and hooks.
+In order for your your [Droppable](/legacy/api-documentation/droppable) and [Draggable](/legacy/api-documentation/draggable) components to interact with each other, you'll need to make sure that the part of your React tree that uses them is nested within a parent `<DndContext>` component. The `<DndContext>` provider makes use of the [React Context API](https://reactjs.org/docs/context.html) to share data between draggable and droppable components and hooks.
 
 > React context provides a way to pass data through the component tree without having to pass props down manually at every level.
 
-Therefore, components that use [`useDraggable`](../draggable/use-draggable), [`useDroppable`](../droppable/use-droppable) or [`DragOverlay`](../draggable/drag-overlay) will need to be nested within a `DndContext` provider.
+Therefore, components that use [`useDraggable`](/legacy/api-documentation/draggable/use-draggable), [`useDroppable`](/legacy/api-documentation/droppable/use-droppable) or [`DragOverlay`](/legacy/api-documentation/draggable/drag-overlay) will need to be nested within a `DndContext` provider.
 
 They don't need to be direct descendants, but, there does need to be a parent `<DndContext>` provider somewhere higher up in the tree.
 
@@ -52,7 +52,7 @@ function App() {
 
 When nesting `DndContext` providers, keep in mind that the `useDroppable` and `useDraggable` hooks will only have access to the other draggable and droppable nodes within that context.
 
-If multiple `DndContext` providers are listening for the same event, events will be captured by the first `DndContext` that contains a [Sensor](../sensors/) that is activated by that event, similar to how [events bubble in the DOM](https://developer.mozilla.org/en-US/docs/Learn/JavaScript/Building_blocks/Events#Event_bubbling_and_capture).
+If multiple `DndContext` providers are listening for the same event, events will be captured by the first `DndContext` that contains a [Sensor](/legacy/api-documentation/sensors) that is activated by that event, similar to how [events bubble in the DOM](https://developer.mozilla.org/en-US/docs/Learn/JavaScript/Building_blocks/Events#Event_bubbling_and_capture).
 
 ## Props
 
@@ -83,15 +83,15 @@ The main events you can listen to are:
 
 #### `onDragStart`
 
-Fires when a drag event that meets the [activation constraints](../sensors/#concepts) for that [sensor ](../sensors/)happens, along with the unique identifier of the draggable element that was picked up.
+Fires when a drag event that meets the [activation constraints](/legacy/api-documentation/sensors#concepts) for that [sensor ](/legacy/api-documentation/sensors)happens, along with the unique identifier of the draggable element that was picked up.
 
 #### `onDragMove`
 
-Fires anytime as the [draggable](../draggable) item is moved. Depending on the activated [sensor](../sensors/#activators), this could for example be as the [Pointer](../sensors/pointer) is moved or the [Keyboard](../sensors/keyboard) movement keys are pressed.
+Fires anytime as the [draggable](/legacy/api-documentation/draggable) item is moved. Depending on the activated [sensor](/legacy/api-documentation/sensors#activators), this could for example be as the [Pointer](/legacy/api-documentation/sensors/pointer) is moved or the [Keyboard](/legacy/api-documentation/sensors/keyboard) movement keys are pressed.
 
 #### `onDragOver`
 
-Fires when a [draggable](../draggable) item is moved over a [droppable](../droppable) container, along with the unique identifier of that droppable container.
+Fires when a [draggable](/legacy/api-documentation/draggable) item is moved over a [droppable](/legacy/api-documentation/droppable) container, along with the unique identifier of that droppable container.
 
 #### `onDragEnd`
 
@@ -99,10 +99,10 @@ Fires after a draggable item is dropped.
 
 This event contains information about the active draggable `id` along with information on whether the draggable item was dropped `over`.
 
-If there are no [collisions detected](./collision-detection-algorithms) when the draggable item is dropped, the `over` property will be `null`. If a collision is detected, the `over` property will contain the `id` of the droppable over which it was dropped.
+If there are no [collisions detected](/legacy/api-documentation/context-provider/collision-detection-algorithms) when the draggable item is dropped, the `over` property will be `null`. If a collision is detected, the `over` property will contain the `id` of the droppable over which it was dropped.
 
 <Info>
-It's important to understand that the `onDragEnd` event **does not move** [**draggable**](../draggable) **items into** [**droppable**](../droppable) **containers.**
+It's important to understand that the `onDragEnd` event **does not move** [**draggable**](/legacy/api-documentation/draggable) **items into** [**droppable**](/legacy/api-documentation/droppable) **containers.**
 
 Rather, it provides **information** about which draggable item was dropped and whether it was over a droppable container when it was dropped.
 
@@ -162,25 +162,25 @@ Use the `screenReaderInstructions` prop to customize the instructions that are r
 
 Use the optional `autoScroll` boolean prop to temporarily or permanently disable auto-scrolling for all sensors used within this `DndContext`.
 
-Auto-scrolling may also be disabled on an individual sensor basis using the static property `autoScrollEnabled` of the sensor. For example, the [Keyboard sensor](../sensors/keyboard) manages scrolling internally, and therefore has the static property `autoScrollEnabled` set to `false`.
+Auto-scrolling may also be disabled on an individual sensor basis using the static property `autoScrollEnabled` of the sensor. For example, the [Keyboard sensor](/legacy/api-documentation/sensors/keyboard) manages scrolling internally, and therefore has the static property `autoScrollEnabled` set to `false`.
 
 ### Collision detection
 
 Use the `collisionDetection` prop to customize the collision detection algorithm used to detect collisions between draggable nodes and droppable areas within the`DndContext` provider.
 
-The default collision detection algorithm is the [rectangle intersection](./collision-detection-algorithms.md#rectangle-intersection) algorithm.
+The default collision detection algorithm is the [rectangle intersection](/legacy/api-documentation/context-provider/collision-detection-algorithms#rectangle-intersection) algorithm.
 
 The built-in collision detection algorithms are:
 
-- [Rectangle intersection](./collision-detection-algorithms.md#rectangle-intersection)
-- [Closest center](./collision-detection-algorithms.md#closest-center)
-- [Closest corners](./collision-detection-algorithms.md#closest-corners)
+- [Rectangle intersection](/legacy/api-documentation/context-provider/collision-detection-algorithms#rectangle-intersection)
+- [Closest center](/legacy/api-documentation/context-provider/collision-detection-algorithms#closest-center)
+- [Closest corners](/legacy/api-documentation/context-provider/collision-detection-algorithms#closest-corners)
 
 You may also build custom collision detection algorithms or compose existing ones.
 
 To learn more, read the collision detection guide:
 
-<Card href="./collision-detection-algorithms">
+<Card href="/legacy/api-documentation/context-provider/collision-detection-algorithms">
   Learn more about collision detection
 </Card>
 
@@ -188,11 +188,11 @@ To learn more, read the collision detection guide:
 
 Sensors are an abstraction to detect different input methods in order to initiate drag operations, respond to movement and end or cancel the operation.
 
-The default sensors used by `DndContext` are the [Pointer](../sensors/pointer) and [Keyboard](../sensors/keyboard) sensors.
+The default sensors used by `DndContext` are the [Pointer](/legacy/api-documentation/sensors/pointer) and [Keyboard](/legacy/api-documentation/sensors/keyboard) sensors.
 
 To learn how to customize sensors or how to pass different sensors to `DndContext`, read the Sensors guide:
 
-<Card href="../sensors ">
+<Card href="/legacy/api-documentation/sensors">
   Learn more about sensors
 </Card>
 
@@ -207,7 +207,7 @@ Modifiers let you dynamically modify the movement coordinates that are detected 
 
 To learn more about how to use Modifiers, read the Modifiers guide:
 
-<Card href="../modifiers">
+<Card href="/legacy/api-documentation/modifiers">
   Learn more about modifiers
 </Card>
 

--- a/apps/docs/docs/legacy/api-documentation/context-provider/use-dnd-context.mdx
+++ b/apps/docs/docs/legacy/api-documentation/context-provider/use-dnd-context.mdx
@@ -22,6 +22,6 @@ function MyComponent() {
 ```
 
 <Warning>
-Make sure you use the `useDndContext` hook within a [`<DndContext>`](./dnd-context) provider.
+Make sure you use the `useDndContext` hook within a [`<DndContext>`](/legacy/api-documentation/context-provider/dnd-context) provider.
 </Warning>
 

--- a/apps/docs/docs/legacy/api-documentation/context-provider/use-dnd-monitor.mdx
+++ b/apps/docs/docs/legacy/api-documentation/context-provider/use-dnd-monitor.mdx
@@ -39,5 +39,5 @@ function MyComponent() {
 ```
 
 <Warning>
-Make sure you use the `useDndMonitor` hook within a [`<DndContext>`](./dnd-context) provider.
+Make sure you use the `useDndMonitor` hook within a [`<DndContext>`](/legacy/api-documentation/context-provider/dnd-context) provider.
 </Warning>

--- a/apps/docs/docs/legacy/api-documentation/draggable.mdx
+++ b/apps/docs/docs/legacy/api-documentation/draggable.mdx
@@ -2,7 +2,7 @@
 title: Draggable
 metaTitle: 'Draggable - Legacy | dnd kit'
 description: >-
-  Use the `useDraggable` hook turn DOM nodes into draggable sources that can be picked up, moved and dropped over [droppable](./droppable) containers.
+  Use the `useDraggable` hook turn DOM nodes into draggable sources that can be picked up, moved and dropped over [droppable](/legacy/api-documentation/droppable) containers.
 sidebarTitle: Overview
 ---
 
@@ -16,7 +16,7 @@ The `useDraggable` hook isn't particularly opinionated about how your app should
 
 ### Node ref
 
-At minimum though, you need to pass the `setNodeRef` function that is returned by the `useDraggable` hook to a DOM element so that it can access the underlying DOM node and keep track of it to [detect collisions and intersections](./context-provider/collision-detection-algorithms) with other [droppable](./droppable) elements.
+At minimum though, you need to pass the `setNodeRef` function that is returned by the `useDraggable` hook to a DOM element so that it can access the underlying DOM node and keep track of it to [detect collisions and intersections](/legacy/api-documentation/context-provider/collision-detection-algorithms) with other [droppable](/legacy/api-documentation/droppable) elements.
 
 ```jsx
 import {useDraggable} from '@dnd-kit/core';
@@ -40,7 +40,7 @@ function Draggable() {
 
 <Info>
 Always try to use the  DOM element that is most [semantic](https://developer.mozilla.org/en-US/docs/Glossary/Semantics) in the context of your app. \
-Check out our [Accessibility guide](../guides/accessibility) to learn more about how you can help provide a better experience for screen readers.
+Check out our [Accessibility guide](/legacy/guides/accessibility) to learn more about how you can help provide a better experience for screen readers.
 </Info>
 
 ### Identifier
@@ -77,7 +77,7 @@ function Draggable() {
 ```
 
 <Info>
-When attaching the listeners to a different element than the node that is draggable, make sure you also attach the attributes to the same node that has the listeners attached so that it is still [accessible](../guides/accessibility).
+When attaching the listeners to a different element than the node that is draggable, make sure you also attach the attributes to the same node that has the listeners attached so that it is still [accessible](/legacy/guides/accessibility).
 </Info>
 
 You can even have multiple drag handles if that makes sense in the context of your application:
@@ -148,7 +148,7 @@ For example, if the HTML element you are attaching the `useDraggable` `listeners
 
 To learn more about the best practices for making draggable interfaces accessible, read the full accessibility guide:
 
-<Card href="../guides/accessibility" horizontal icon="universal-access" iconType="light">
+<Card href="/legacy/guides/accessibility" horizontal icon="universal-access" iconType="light">
   Accessibility
 </Card>
 
@@ -165,7 +165,7 @@ We highly recommend you specify the `touch-action` CSS property for all of your 
 In general, we recommend you set the `touch-action` property to `none` for draggable elements in order to prevent scrolling on mobile devices.
 
 <Info>
-For [Pointer Events,](./sensors/pointer) there is no way to prevent the default behaviour of the browser on touch devices when interacting with a draggable element from the pointer event listeners. Using `touch-action: none;` is the only way to reliably prevent scrolling for pointer events.
+For [Pointer Events,](/legacy/api-documentation/sensors/pointer) there is no way to prevent the default behaviour of the browser on touch devices when interacting with a draggable element from the pointer event listeners. Using `touch-action: none;` is the only way to reliably prevent scrolling for pointer events.
 
 Further, using `touch-action: none;` is currently the only reliable way to prevent scrolling in iOS Safari for both Touch and Pointer events.
 </Info>
@@ -182,6 +182,6 @@ The `<DragOverlay>` component provides a way to render a draggable overlay that 
 
 To learn more about how to use drag overlays, read the in-depth guide:
 
-<Card href="./draggable/drag-overlay" horizontal icon="send-backward" iconType="light">
+<Card href="/legacy/api-documentation/draggable/drag-overlay" horizontal icon="send-backward" iconType="light">
   Drag overlay
 </Card>

--- a/apps/docs/docs/legacy/api-documentation/draggable.mdx
+++ b/apps/docs/docs/legacy/api-documentation/draggable.mdx
@@ -45,7 +45,7 @@ Check out our [Accessibility guide](../guides/accessibility) to learn more about
 
 ### Identifier
 
-The `id` argument is a string that should be a unique identifier, meaning there should be no other **draggable** elements that share that same identifier within a given [`DndContext`](./context-provider/) provider.
+The `id` argument is a string that should be a unique identifier, meaning there should be no other **draggable** elements that share that same identifier within a given [`DndContext`](/legacy/api-documentation/context-provider/dnd-context) provider.
 
 ### Listeners
 
@@ -144,7 +144,7 @@ For example, if the HTML element you are attaching the `useDraggable` `listeners
 | `role`                 | `"button"`                | <p>If possible, we recommend you use a semantic <code>&#x3C;button></code> element for the DOM element you plan on attaching draggable listeners to. </p><p></p><p>In case that's not possible, make sure you include the <code>role="button"</code>attribute, which is the default value.</p>      |
 | `tabIndex`             | `"0"`                     | In order for your draggable elements to receive keyboard focus, they **need** to have the `tabindex` attribute set to `0` if they are not natively interactive elements (such as the HTML `button` element). For this reason, the `useDraggable` hook sets the `tabindex="0"` attribute by default. |
 | `aria-roledescription` | `"draggable"`             | While `draggable` is a sensible default, we recommend you customize this value to something that is tailored to the use case you are building.                                                                                                                                                      |
-| `aria-describedby`     | `"DndContext-[uniqueId]"` | Each draggable item is provided a unique `aria-describedby` ID that points to the [screen reader instructions](./context-provider/#screen-reader-instructions) to be read out when a draggable item receives focus.                                                                                |
+| `aria-describedby`     | `"DndContext-[uniqueId]"` | Each draggable item is provided a unique `aria-describedby` ID that points to the [screen reader instructions](/legacy/api-documentation/context-provider/dnd-context#screen-reader-instructions) to be read out when a draggable item receives focus.                                                                                |
 
 To learn more about the best practices for making draggable interfaces accessible, read the full accessibility guide:
 

--- a/apps/docs/docs/legacy/api-documentation/draggable/drag-overlay.mdx
+++ b/apps/docs/docs/legacy/api-documentation/draggable/drag-overlay.mdx
@@ -10,7 +10,7 @@ description: >-
 
 ## When should I use a drag overlay?
 
-Depending on your use-case, you may want to use a drag overlay rather than transforming the original draggable source element that is connected to the [`useDraggable`](./use-draggable) hook:
+Depending on your use-case, you may want to use a drag overlay rather than transforming the original draggable source element that is connected to the [`useDraggable`](/legacy/api-documentation/draggable/use-draggable) hook:
 
 - If you'd like to **show a preview** of where the draggable source will be when dropped, you can update the position of the draggable source while dragging without affecting the drag overlay.
 - If your item needs to **move from one container to another while dragging**, we strongly recommend you use the `<DragOverlay>` component so the draggable item can unmount from its original container while dragging and mount back into a different container without affecting the drag overlay.
@@ -24,7 +24,7 @@ You may render any valid JSX within the children of the `<DragOverlay>`.
 
 The `<DragOverlay>` component should **remain mounted at all times** so that it can perform the drop animation. If you conditionally render the `<DragOverlay>` component, drop animations will not work.
 
-As a rule of thumb, try to render the `<DragOverlay>` outside of your draggable components, and follow the [presentational component pattern ](./drag-overlay#presentational-components)to maintain a good separation of concerns.
+As a rule of thumb, try to render the `<DragOverlay>` outside of your draggable components, and follow the [presentational component pattern ](/legacy/api-documentation/draggable/drag-overlay#presentational-components)to maintain a good separation of concerns.
 
 Instead, you should conditionally render the children passed to the `<DragOverlay>`:
 
@@ -247,7 +247,7 @@ Prefer conditionally rendering the `children` of `<DragOverlay>` rather than con
 
 ### Class name and inline styles
 
-If you'd like to customize the[ wrapper element](./drag-overlay#wrapper-element) that the `DragOverlay`'s children are rendered into, use the `className` and `style` props:
+If you'd like to customize the[ wrapper element](/legacy/api-documentation/draggable/drag-overlay#wrapper-element) that the `DragOverlay`'s children are rendered into, use the `className` and `style` props:
 
 ```jsx
 <DragOverlay
@@ -296,7 +296,7 @@ The `<DragOverlay>` component should **remain mounted at all times** so that it 
 
 ### Modifiers
 
-Modifiers let you dynamically modify the movement coordinates that are detected by sensors. They can be used for a wide range of use-cases, which you can learn more about by reading the [Modifiers](../modifiers) documentation.
+Modifiers let you dynamically modify the movement coordinates that are detected by sensors. They can be used for a wide range of use-cases, which you can learn more about by reading the [Modifiers](/legacy/api-documentation/modifiers) documentation.
 
 For example, you can use modifiers to restrict the movement of the `<DragOverlay>` to the bounds of the window:
 
@@ -316,7 +316,7 @@ function App() {
 
 ### Transition
 
-By default, the `<DragOverlay>` component does not have any transitions, unless activated by the [`Keyboard` sensor](../sensors/keyboard). Use the `transition` prop to create a function that returns the transition based on the [activator event](../sensors/#activators). The default implementation is:
+By default, the `<DragOverlay>` component does not have any transitions, unless activated by the [`Keyboard` sensor](/legacy/api-documentation/sensors/keyboard). Use the `transition` prop to create a function that returns the transition based on the [activator event](/legacy/api-documentation/sensors#activators). The default implementation is:
 
 ```javascript
 function defaultTransition(activatorEvent) {

--- a/apps/docs/docs/legacy/api-documentation/draggable/use-draggable.mdx
+++ b/apps/docs/docs/legacy/api-documentation/draggable/use-draggable.mdx
@@ -20,7 +20,7 @@ interface UseDraggableArguments {
 
 ### Identifier
 
-The `id` argument is a `string` or `number` that should be a unique identifier, meaning there should be no other **draggable** elements that share that same identifier within a given [`DndContext`](../context-provider/) provider.
+The `id` argument is a `string` or `number` that should be a unique identifier, meaning there should be no other **draggable** elements that share that same identifier within a given [`DndContext`](/legacy/api-documentation/context-provider/dnd-context) provider.
 
 If you're building a component that uses both the `useDraggable` and `useDroppable` hooks, they can both share the same identifier since draggable elements are stored in a different key-value store than droppable elements.
 
@@ -146,7 +146,7 @@ For this reason, the `useDraggable` hook sets the `tabindex="0"` attribute by de
 
 #### `active`
 
-If there is currently an active draggable element within the [`DndContext`](../context-provider/) provider where the `useDraggable` hook is used, the `active` property will be defined with the corresponding `id`, `node` and `rect` of that draggable element.
+If there is currently an active draggable element within the [`DndContext`](/legacy/api-documentation/context-provider/dnd-context) provider where the `useDraggable` hook is used, the `active` property will be defined with the corresponding `id`, `node` and `rect` of that draggable element.
 
 Otherwise, the `active` property will be set to `null`.
 

--- a/apps/docs/docs/legacy/api-documentation/draggable/use-draggable.mdx
+++ b/apps/docs/docs/legacy/api-documentation/draggable/use-draggable.mdx
@@ -186,7 +186,7 @@ function Draggable() {
 ```
 
 <Info>
-When attaching the listeners to a different element than the node that is draggable, make sure you also attach the attributes to the same node that has the listeners attached so that it is still [accessible](../../guides/accessibility).
+When attaching the listeners to a different element than the node that is draggable, make sure you also attach the attributes to the same node that has the listeners attached so that it is still [accessible](/legacy/guides/accessibility).
 </Info>
 
 You can even have multiple drag handles if that makes sense in the context of your application:

--- a/apps/docs/docs/legacy/api-documentation/droppable.mdx
+++ b/apps/docs/docs/legacy/api-documentation/droppable.mdx
@@ -2,7 +2,7 @@
 title: Droppable
 metaTitle: 'Droppable - Legacy | dnd kit'
 description: >-
-  Use the `useDroppable` hook to set up DOM nodes as droppable areas that [draggable](./draggable) elements can be dropped over.
+  Use the `useDroppable` hook to set up DOM nodes as droppable areas that [draggable](/legacy/api-documentation/draggable) elements can be dropped over.
 sidebarTitle: Overview
 ---
 
@@ -84,6 +84,6 @@ function MultipleDroppables() {
 
 For more details usage of the `useDroppable` hook, refer to the API documentation section:
 
-<Card href="./droppable/use-droppable">
+<Card href="/legacy/api-documentation/droppable/use-droppable">
   useDroppable
 </Card>

--- a/apps/docs/docs/legacy/api-documentation/droppable/use-droppable.mdx
+++ b/apps/docs/docs/legacy/api-documentation/droppable/use-droppable.mdx
@@ -15,7 +15,7 @@ interface UseDroppableArguments {
 
 ### Identifier
 
-The `id` argument is a `string` or `number` that should be a unique identifier, meaning there should be no other **droppable** elements that share that same identifier within a given [`DndContext`](../context-provider/) provider.
+The `id` argument is a `string` or `number` that should be a unique identifier, meaning there should be no other **droppable** elements that share that same identifier within a given [`DndContext`](/legacy/api-documentation/context-provider/dnd-context) provider.
 
 If you're building a component that uses both the `useDroppable` and `useDraggable` hooks, they can both share the same identifier since droppable elements are stored in a different key-value store than draggable elements.
 

--- a/apps/docs/docs/legacy/api-documentation/modifiers.mdx
+++ b/apps/docs/docs/legacy/api-documentation/modifiers.mdx
@@ -22,7 +22,7 @@ npm install @dnd-kit/modifiers
 
 ## Usage
 
-The modifiers repository contains a number of useful modifiers that can be applied on [`DndContext`](./context-provider/dnd-context) as well as [`DragOverlay`](./draggable/drag-overlay).
+The modifiers repository contains a number of useful modifiers that can be applied on [`DndContext`](/legacy/api-documentation/context-provider/dnd-context) as well as [`DragOverlay`](/legacy/api-documentation/draggable/drag-overlay).
 
 ```jsx
 import {DndContext, DragOverlay} from '@dnd-kit';

--- a/apps/docs/docs/legacy/api-documentation/sensors.mdx
+++ b/apps/docs/docs/legacy/api-documentation/sensors.mdx
@@ -16,10 +16,10 @@ Sensors are initialized once one of the activator events is detected.
 
 The built-in sensors are:
 
-* [Pointer](./sensors/pointer)
-* [Mouse](./sensors/mouse)
-* [Touch](./sensors/touch)
-* [Keyboard](./sensors/keyboard)
+* [Pointer](/legacy/api-documentation/sensors/pointer)
+* [Mouse](/legacy/api-documentation/sensors/mouse)
+* [Touch](/legacy/api-documentation/sensors/touch)
+* [Keyboard](/legacy/api-documentation/sensors/keyboard)
 
 ### Custom sensors
 
@@ -44,7 +44,7 @@ They are class-based rather than hooks because they need to be instantiated sync
 
 ### useSensor
 
-By default, `DndContext` uses the [Pointer](./sensors/pointer) and [Keyboard](./sensors/keyboard) sensors.
+By default, `DndContext` uses the [Pointer](/legacy/api-documentation/sensors/pointer) and [Keyboard](/legacy/api-documentation/sensors/keyboard) sensors.
 
 If you'd like to use other sensors, such as the Mouse and Touch sensors instead, initialize those sensors separately with the options you'd like to use using the `useSensor` hook
 

--- a/apps/docs/docs/legacy/api-documentation/sensors/keyboard.mdx
+++ b/apps/docs/docs/legacy/api-documentation/sensors/keyboard.mdx
@@ -4,7 +4,7 @@ metaTitle: 'Keyboard Sensor - Legacy | dnd kit'
 icon: 'keyboard'
 ---
 
-The Keyboard sensor responds to [Keyboard events](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent). It is one of the default sensors used by the [DndContext](../context-provider/) provider if none are defined.
+The Keyboard sensor responds to [Keyboard events](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent). It is one of the default sensors used by the [DndContext](/legacy/api-documentation/context-provider/dnd-context) provider if none are defined.
 
 <Warning>
 In order for the Keyboard sensor to function properly, the activator element that receives the `useDraggable` [listeners](../draggable/use-draggable.md#listeners) **must** be able to receive focus. To learn more, read the in-depth [Accessibility guide](../../guides/accessibility).
@@ -44,7 +44,7 @@ const defaultKeyboardCodes = {
 
 You can customize these values, but keep in mind that the [third rule of ARIA ](https://www.w3.org/TR/using-aria/#3rdrule)requires that a user **must** be able to activate the action associated with a draggable widget using **both** the `enter` \(on Windows\) or `return` \(on macOS\) and the `space` key. To learn more, read the in-depth [accessibility guide](../../guides/accessibility).
 
-Keep in mind that you should also customize the screen reader instructions using the `screenReaderInstructions` prop of [`<DndContext>`](../context-provider/) if you update these values, as the screen reader instructions assume that the Keyboard sensor is initialized with the default keyboard shortcuts.
+Keep in mind that you should also customize the screen reader instructions using the `screenReaderInstructions` prop of [`<DndContext>`](/legacy/api-documentation/context-provider/dnd-context) if you update these values, as the screen reader instructions assume that the Keyboard sensor is initialized with the default keyboard shortcuts.
 
 The `move` keyboard codes are not a customizable option, because those are handled by the [coordinate getter function](./keyboard#coordinates-getter). To customize them, write a custom coordinate getter function.
 

--- a/apps/docs/docs/legacy/api-documentation/sensors/keyboard.mdx
+++ b/apps/docs/docs/legacy/api-documentation/sensors/keyboard.mdx
@@ -7,7 +7,7 @@ icon: 'keyboard'
 The Keyboard sensor responds to [Keyboard events](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent). It is one of the default sensors used by the [DndContext](/legacy/api-documentation/context-provider/dnd-context) provider if none are defined.
 
 <Warning>
-In order for the Keyboard sensor to function properly, the activator element that receives the `useDraggable` [listeners](../draggable/use-draggable.md#listeners) **must** be able to receive focus. To learn more, read the in-depth [Accessibility guide](../../guides/accessibility).
+In order for the Keyboard sensor to function properly, the activator element that receives the `useDraggable` [listeners](/legacy/api-documentation/draggable/use-draggable#listeners) **must** be able to receive focus. To learn more, read the in-depth [Accessibility guide](/legacy/guides/accessibility).
 </Warning>
 
 ### Activator
@@ -42,11 +42,11 @@ const defaultKeyboardCodes = {
 };
 ```
 
-You can customize these values, but keep in mind that the [third rule of ARIA ](https://www.w3.org/TR/using-aria/#3rdrule)requires that a user **must** be able to activate the action associated with a draggable widget using **both** the `enter` \(on Windows\) or `return` \(on macOS\) and the `space` key. To learn more, read the in-depth [accessibility guide](../../guides/accessibility).
+You can customize these values, but keep in mind that the [third rule of ARIA ](https://www.w3.org/TR/using-aria/#3rdrule)requires that a user **must** be able to activate the action associated with a draggable widget using **both** the `enter` \(on Windows\) or `return` \(on macOS\) and the `space` key. To learn more, read the in-depth [accessibility guide](/legacy/guides/accessibility).
 
 Keep in mind that you should also customize the screen reader instructions using the `screenReaderInstructions` prop of [`<DndContext>`](/legacy/api-documentation/context-provider/dnd-context) if you update these values, as the screen reader instructions assume that the Keyboard sensor is initialized with the default keyboard shortcuts.
 
-The `move` keyboard codes are not a customizable option, because those are handled by the [coordinate getter function](./keyboard#coordinates-getter). To customize them, write a custom coordinate getter function.
+The `move` keyboard codes are not a customizable option, because those are handled by the [coordinate getter function](/legacy/api-documentation/sensors/keyboard#coordinates-getter). To customize them, write a custom coordinate getter function.
 
 #### Coordinates getter
 
@@ -88,7 +88,7 @@ function customCoordinatesGetter(event, args) {
 }
 ```
 
-While the example above is fairly simple, you can build complex coordinate getters to support advanced use cases. The [Sortable](../../presets/sortable/) preset uses the `getNextCoordinates` option to build on top of the Keyboard sensor and move the active sortable item to its new index depending on the arrow key that is pressed.
+While the example above is fairly simple, you can build complex coordinate getters to support advanced use cases. The [Sortable](/legacy/presets/sortable/overview) preset uses the `getNextCoordinates` option to build on top of the Keyboard sensor and move the active sortable item to its new index depending on the arrow key that is pressed.
 
 #### Scroll behavior
 

--- a/apps/docs/docs/legacy/api-documentation/sensors/mouse.mdx
+++ b/apps/docs/docs/legacy/api-documentation/sensors/mouse.mdx
@@ -12,7 +12,7 @@ The mouse activator is the `onMouseDown` event handler. The Mouse sensor is init
 
 ### Activation constraints
 
-Like the [Pointer](./pointer) sensor, the Mouse sensor has two activation constraints:
+Like the [Pointer](/legacy/api-documentation/sensors/pointer) sensor, the Mouse sensor has two activation constraints:
 
 * Distance constraint
 * Delay constraint

--- a/apps/docs/docs/legacy/api-documentation/sensors/pointer.mdx
+++ b/apps/docs/docs/legacy/api-documentation/sensors/pointer.mdx
@@ -69,13 +69,13 @@ We highly recommend you specify the `touch-action` CSS property for all of your 
 In general, we recommend you set the `touch-action` property to `none` for draggable elements in order to prevent scrolling on mobile devices.
 
 <Warning>
-For [Pointer Events,](./pointer) there is no way to prevent the default behaviour of the browser on touch devices when interacting with a draggable element from the pointer event listeners. Using `touch-action: none;` is the only way to reliably prevent scrolling for pointer events.
+For [Pointer Events,](/legacy/api-documentation/sensors/pointer) there is no way to prevent the default behaviour of the browser on touch devices when interacting with a draggable element from the pointer event listeners. Using `touch-action: none;` is the only way to reliably prevent scrolling for pointer events.
 </Warning>
 
 If your draggable item is part of a scrollable list, we recommend you use a drag handle and set `touch-action` to `none` only for the drag handle, so that the contents of the list can still be scrolled, but that initiating a drag from the drag handle does not scroll the page.
 
 <Info>
-If  the above recommendations are not suitable for your use-case, we recommend that you use both the [Mouse](./mouse) and [Touch](./touch) sensors instead, as Touch events do not suffer the same limitations as Pointer events, and it is possible to prevent the page from scrolling in `touchmove` events.
+If  the above recommendations are not suitable for your use-case, we recommend that you use both the [Mouse](/legacy/api-documentation/sensors/mouse) and [Touch](/legacy/api-documentation/sensors/touch) sensors instead, as Touch events do not suffer the same limitations as Pointer events, and it is possible to prevent the page from scrolling in `touchmove` events.
 </Info>
 
 Once a `pointerdown` or `touchstart` event has been initiated, any changes to the `touch-action` value will be ignored. Programmatically changing the `touch-action` value for an element from `auto` to `none` after a pointer or touch event has been initiated will not result in the user agent aborting or suppressing any default behavior for that event for as long as that pointer is active (for more details, refer to the [Pointer Events Level 2 Spec](https://www.w3.org/TR/pointerevents2/#determining-supported-touch-behavior)).

--- a/apps/docs/docs/legacy/api-documentation/sensors/pointer.mdx
+++ b/apps/docs/docs/legacy/api-documentation/sensors/pointer.mdx
@@ -4,7 +4,7 @@ metaTitle: 'Pointer Sensor - Legacy | dnd kit'
 icon: 'arrow-pointer'
 ---
 
-The Pointer sensor responds to [Pointer events](https://developer.mozilla.org/en-US/docs/Web/API/Pointer_events). It is one of the default sensors used by the [DndContext](../context-provider/) provider if none are defined.
+The Pointer sensor responds to [Pointer events](https://developer.mozilla.org/en-US/docs/Web/API/Pointer_events). It is one of the default sensors used by the [DndContext](/legacy/api-documentation/context-provider/dnd-context) provider if none are defined.
 
 > Pointer events are DOM events that are fired for a pointing device. They are designed to create a single DOM event model to handle pointing input devices such as a mouse, pen/stylus or touch (such as one or more fingers).
 >

--- a/apps/docs/docs/legacy/api-documentation/sensors/touch.mdx
+++ b/apps/docs/docs/legacy/api-documentation/sensors/touch.mdx
@@ -12,7 +12,7 @@ The touch activator is the `onTouchStart` event handler. The Touch sensor is ini
 
 ### Activation constraints
 
-Like the [Pointer](./pointer) sensor, the Touch sensor has two activation constraints:
+Like the [Pointer](/legacy/api-documentation/sensors/pointer) sensor, the Touch sensor has two activation constraints:
 
 - Distance constraint
 - Delay constraint

--- a/apps/docs/docs/legacy/guides/accessibility.mdx
+++ b/apps/docs/docs/legacy/guides/accessibility.mdx
@@ -47,9 +47,9 @@ You know your application best, and while these sensible defaults will go a long
 
 The three main areas of focus for this guide to help you make your drag and drop interface more accessible are:
 
-- [Keyboard support](./accessibility#keyboard-support)
-- [Screen reader instructions](./accessibility#screen-reader-instructions)
-- [Live regions to provide screen reader announcements](./accessibility#screen-reader-announcements-using-live-regions)
+- [Keyboard support](/legacy/guides/accessibility#keyboard-support)
+- [Screen reader instructions](/legacy/guides/accessibility#screen-reader-instructions)
+- [Live regions to provide screen reader announcements](/legacy/guides/accessibility#screen-reader-announcements-using-live-regions)
 
 ### Keyboard support
 
@@ -64,11 +64,11 @@ For drag and drop interfaces, this means that the activator element that initiat
 
 Both these guidelines should be respected to comply with the [third rule of ARIA](https://www.w3.org/TR/using-aria/#3rdrule).
 
-The `@dnd-kit/core` library ships with a [Keyboard sensor ](../api-documentation/sensors/keyboard)that adheres to these guidelines. The keyboard sensor is one of the two sensors that are enabled by default on the [`<DndContext>`](/legacy/api-documentation/context-provider/dnd-context) provider component.
+The `@dnd-kit/core` library ships with a [Keyboard sensor ](/legacy/api-documentation/sensors/keyboard)that adheres to these guidelines. The keyboard sensor is one of the two sensors that are enabled by default on the [`<DndContext>`](/legacy/api-documentation/context-provider/dnd-context) provider component.
 
 #### Focus
 
-In order for the Keyboard sensor to function properly, the activator element that receives the `useDraggable` [listeners](../api-documentation/draggable/use-draggable#listeners) **must** be able to receive focus.
+In order for the Keyboard sensor to function properly, the activator element that receives the `useDraggable` [listeners](/legacy/api-documentation/draggable/use-draggable#listeners) **must** be able to receive focus.
 
 The `tabindex` attribute dictates the order in which focus moves throughout the document.
 
@@ -89,11 +89,11 @@ After an item is picked up, it can be dropped using the `enter` (on Windows) or 
 
 A drag operation can be cancelled using the `escape` key. It is recommended to allow users to cancel the drag operation using the `escape` key for all sensors, not just the Keyboard sensor.
 
-The keyboard shortcuts of the Keyboard sensor can be [customized](../api-documentation/sensors/keyboard#keyboard-codes), but we discourage you to do so unless you maintain support for the `enter`, `return` and `space` keys to follow the guidelines set by the third rule of ARIA.
+The keyboard shortcuts of the Keyboard sensor can be [customized](/legacy/api-documentation/sensors/keyboard#keyboard-codes), but we discourage you to do so unless you maintain support for the `enter`, `return` and `space` keys to follow the guidelines set by the third rule of ARIA.
 
-By default, the [Keyboard sensor](../api-documentation/sensors/keyboard) moves in any given direction by `25` pixels when the arrow keys are pressed while dragging.
+By default, the [Keyboard sensor](/legacy/api-documentation/sensors/keyboard) moves in any given direction by `25` pixels when the arrow keys are pressed while dragging.
 
-This is an arbitrary default that is likely not suited for all use-cases. We encourage you to customize this behaviour and tailor it to the context of your application using the [`getNextCoordinates` option ](../api-documentation/sensors/keyboard#coordinates-getter)of the Keyboard sensor.
+This is an arbitrary default that is likely not suited for all use-cases. We encourage you to customize this behaviour and tailor it to the context of your application using the [`getNextCoordinates` option ](/legacy/api-documentation/sensors/keyboard#coordinates-getter)of the Keyboard sensor.
 
 For example, the `useSortable` hook ships with an augmented version of the Keyboard sensor that uses the `getNextCoordinates` option behind the scenes to find the coordinates of the next sortable element in any given direction when an arrow key is pressed.
 
@@ -105,7 +105,7 @@ In order to users know how to interact with draggable items using only the keybo
 
 #### Role
 
-To let users know that their focus is currently on a draggable item, the [`useDraggable`](../api-documentation/draggable/use-draggable) hook provides the [`role`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles) and [`aria-roledescription`](https://www.digitala11y.com/aria-roledescriptionproperties/), and [`aria-describedby`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-describedby_attribute) attributes by default:
+To let users know that their focus is currently on a draggable item, the [`useDraggable`](/legacy/api-documentation/draggable/use-draggable) hook provides the [`role`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles) and [`aria-roledescription`](https://www.digitala11y.com/aria-roledescriptionproperties/), and [`aria-describedby`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-describedby_attribute) attributes by default:
 
 | Attribute              | Default value             | Description                                                                                                                                                                                                                                                                                                                                                                                                                                             |
 | ---------------------- | ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -113,7 +113,7 @@ To let users know that their focus is currently on a draggable item, the [`useDr
 | `aria-roledescription` | `"draggable"`             | Defines a human-readable, localized description for the role of an element that is read by screen readers.<br/>While <code>draggable</code> is a sensible default, we recommend you customize this value to something that is tailored to your use-case.                                                                                                                                                                                   |
 | `aria-describedby`     | `"DndContext-[uniqueId]"` | Each draggable item is provided a unique `aria-describedby` ID that points to the voiceover instructions to be read out when a draggable item receives focus                                                                                                                                                                                                                                                                                            |
 
-The `role` and `aria-roledescription` attributes can be customized via the [options passed to the `useDraggable` hook](../api-documentation/draggable/use-draggable#arguments).
+The `role` and `aria-roledescription` attributes can be customized via the [options passed to the `useDraggable` hook](/legacy/api-documentation/draggable/use-draggable#arguments).
 
 To customize the `aria-describedby` instructions, refer to the section below.
 
@@ -127,7 +127,7 @@ The default instructions are:
 > While dragging, use the arrow keys to move the item in any given direction.\
 > Press space or enter again to drop the item in its new position, or press escape to cancel.
 
-We recommend you customize and localize these instructions to your application and use-case using the `screenReaderInstructions` prop of [`<DndContext>`](../api-documentation/context-provider/dnd-context).
+We recommend you customize and localize these instructions to your application and use-case using the `screenReaderInstructions` prop of [`<DndContext>`](/legacy/api-documentation/context-provider/dnd-context).
 
 For example, if you were building a sortable grocery shopping list, you may want to tailor the instructions like so:
 
@@ -143,7 +143,7 @@ If your application supports multiple languages, make sure you also translate th
 
 When building accessible drag and drop interfaces, live regions should be used to provide screen reader announcements in real-time of time-sensitive information of what is currently happening with draggable and droppable elements without having to move focus .
 
-By default, each [`<DndContext>`](../api-documentation/context-provider/dnd-context) component renders a unique HTML element that is rendered off-screen to be used for live screen-reader announcements of events like when a drag operation has started, when a draggable item has been dragged over a droppable container, when a drag operation has ended, and when a drag operation has been cancelled.
+By default, each [`<DndContext>`](/legacy/api-documentation/context-provider/dnd-context) component renders a unique HTML element that is rendered off-screen to be used for live screen-reader announcements of events like when a drag operation has started, when a draggable item has been dragged over a droppable container, when a drag operation has ended, and when a drag operation has been cancelled.
 
 These instructions can be customized using the `announcements` prop of `DndContext`.
 
@@ -224,6 +224,6 @@ function App() {
     >
 ```
 
-The example above assumes that the [`closestCenter` collision detection strategy](../api-documentation/context-provider/collision-detection-algorithms#closest-center) is used, so the `over` property should always be defined.
+The example above assumes that the [`closestCenter` collision detection strategy](/legacy/api-documentation/context-provider/collision-detection-algorithms#closest-center) is used, so the `over` property should always be defined.
 
 If your application supports multiple languages, make sure you also translate these announcements. The `<DndContext>` component only ships with announcements in English due to bundle size concerns.

--- a/apps/docs/docs/legacy/guides/accessibility.mdx
+++ b/apps/docs/docs/legacy/guides/accessibility.mdx
@@ -64,7 +64,7 @@ For drag and drop interfaces, this means that the activator element that initiat
 
 Both these guidelines should be respected to comply with the [third rule of ARIA](https://www.w3.org/TR/using-aria/#3rdrule).
 
-The `@dnd-kit/core` library ships with a [Keyboard sensor ](../api-documentation/sensors/keyboard)that adheres to these guidelines. The keyboard sensor is one of the two sensors that are enabled by default on the [`<DndContext>`](../api-documentation/context-provider/) provider component.
+The `@dnd-kit/core` library ships with a [Keyboard sensor ](../api-documentation/sensors/keyboard)that adheres to these guidelines. The keyboard sensor is one of the two sensors that are enabled by default on the [`<DndContext>`](/legacy/api-documentation/context-provider/dnd-context) provider component.
 
 #### Focus
 
@@ -119,7 +119,7 @@ To customize the `aria-describedby` instructions, refer to the section below.
 
 #### Instructions
 
-By default, each [`<DndContext>`](../api-documentation/context-provider/) component renders a unique HTML element that is rendered off-screen to be used to provide these instructions to screen readers.
+By default, each [`<DndContext>`](/legacy/api-documentation/context-provider/dnd-context) component renders a unique HTML element that is rendered off-screen to be used to provide these instructions to screen readers.
 
 The default instructions are:
 

--- a/apps/docs/docs/legacy/introduction/getting-started.mdx
+++ b/apps/docs/docs/legacy/introduction/getting-started.mdx
@@ -8,12 +8,12 @@ description: >-
 
 
 <Info>
-Before getting started, make sure you have followed the installation steps outlined in the [Installation guide](./installation).
+Before getting started, make sure you have followed the installation steps outlined in the [Installation guide](/legacy/introduction/installation).
 </Info>
 
 ### Context provider
 
-First, we'll set up the general structure of the app. In order for the [`useDraggable`](../api-documentation/draggable/use-draggable) and [`useDroppable`](../api-documentation/droppable/use-droppable) hooks to function correctly, you'll need to ensure that the components where they are used are wrapped within a [`<DndContext />`](../api-documentation/context-provider/dnd-context) component:
+First, we'll set up the general structure of the app. In order for the [`useDraggable`](/legacy/api-documentation/draggable/use-draggable) and [`useDroppable`](/legacy/api-documentation/droppable/use-droppable) hooks to function correctly, you'll need to ensure that the components where they are used are wrapped within a [`<DndContext />`](/legacy/api-documentation/context-provider/dnd-context) component:
 
 ```jsx App.jsx
 import React from 'react';
@@ -103,7 +103,7 @@ As you can see from the example above, it really only takes just a few lines to 
 
 - For performance reasons, we recommend you use **`transform`** over other positional CSS properties to move the dragged element.
 - You'll likely want to alter the **`z-index`** of your Draggable component to ensure it appears on top of other elements.
-- If your item needs to move from one container to another, we recommend you use the [`<DragOverlay>`](../api-documentation/draggable/drag-overlay) component.
+- If your item needs to move from one container to another, we recommend you use the [`<DragOverlay>`](/legacy/api-documentation/draggable/drag-overlay) component.
 </Success>
 
 Converting the `transform` object to a string can feel tedious. Fear not, you can avoid having to do this by hand by importing the `CSS` utility from the `@dnd-kit/utilities` package:
@@ -198,7 +198,7 @@ export function Draggable(props) {
 
 </CodeGroup>
 
-That's it! You've set up your first [**Droppable**](../api-documentation/droppable) \***\* and [**Draggable\*\*](../api-documentation/draggable) components.
+That's it! You've set up your first [**Droppable**](/legacy/api-documentation/droppable) \***\* and [**Draggable\*\*](/legacy/api-documentation/draggable) components.
 
 ### Pushing things a bit further
 

--- a/apps/docs/docs/legacy/introduction/getting-started.mdx
+++ b/apps/docs/docs/legacy/introduction/getting-started.mdx
@@ -119,7 +119,7 @@ const style = {
 
 ### Assembling all the pieces
 
-Once you've set up your **Droppable** and **Draggable** components, you'll want to come back to where you set up your [`<DndContext>`](../api-documentation/context-provider/) component so you can add event listeners to be able to respond to the different events that are fired.
+Once you've set up your **Droppable** and **Draggable** components, you'll want to come back to where you set up your [`<DndContext>`](/legacy/api-documentation/context-provider/dnd-context) component so you can add event listeners to be able to respond to the different events that are fired.
 
 In this example, we'll assume you want to move your `<Draggable>` component from outside into your `<Droppable>` component:
 

--- a/apps/docs/docs/legacy/introduction/installation.mdx
+++ b/apps/docs/docs/legacy/introduction/installation.mdx
@@ -32,15 +32,15 @@ In order to keep the core of the library small, `@dnd-kit/core` only ships with 
 
 * [Context provider](/legacy/api-documentation/context-provider/dnd-context)
 * Hooks for:
-  * [Draggable](../api-documentation/draggable)
-  * [Droppable](../api-documentation/droppable)
-* [Drag Overlay](../api-documentation/draggable/drag-overlay)
+  * [Draggable](/legacy/api-documentation/draggable)
+  * [Droppable](/legacy/api-documentation/droppable)
+* [Drag Overlay](/legacy/api-documentation/draggable/drag-overlay)
 * Sensors for:
-  * [Pointer](../api-documentation/sensors/pointer)
-  * [Mouse](../api-documentation/sensors/mouse)
-  * [Touch](../api-documentation/sensors/touch)
-  * [Keyboard](../api-documentation/sensors/keyboard)
-* [Accessibility features](../guides/accessibility)
+  * [Pointer](/legacy/api-documentation/sensors/pointer)
+  * [Mouse](/legacy/api-documentation/sensors/mouse)
+  * [Touch](/legacy/api-documentation/sensors/touch)
+  * [Keyboard](/legacy/api-documentation/sensors/keyboard)
+* [Accessibility features](/legacy/guides/accessibility)
 
 ### Modifiers
 
@@ -51,7 +51,7 @@ Modifiers let you dynamically modify the movement coordinates that are detected 
 * Restricting motion to the draggable node's scroll container bounding rectangle
 * Applying resistance or clamping the motion
 
-The modifiers repository contains a number of useful modifiers that can be applied on [`DndContext`](/legacy/api-documentation/context-provider/dnd-context) as well as [`DraggableClone`](../api-documentation/draggable/drag-overlay).
+The modifiers repository contains a number of useful modifiers that can be applied on [`DndContext`](/legacy/api-documentation/context-provider/dnd-context) as well as [`DraggableClone`](/legacy/api-documentation/draggable/drag-overlay).
 
 To start using modifiers, install the modifiers package via yarn or npm:
 
@@ -61,7 +61,7 @@ npm install @dnd-kit/modifiers
 
 ### Presets
 
-#### [Sortable](../presets/sortable/)
+#### [Sortable](/legacy/presets/sortable/overview)
 
 The `@dnd-kit/core` package provides all the building blocks you would need to build a sortable interface from scratch should you choose to, but thankfully you don't need to.
 

--- a/apps/docs/docs/legacy/introduction/installation.mdx
+++ b/apps/docs/docs/legacy/introduction/installation.mdx
@@ -30,7 +30,7 @@ npm install react react-dom
 
 In order to keep the core of the library small, `@dnd-kit/core` only ships with the main building blocks that the majority of users will need most of the time for building drag and drop experiences:
 
-* [Context provider](../api-documentation/context-provider/)
+* [Context provider](/legacy/api-documentation/context-provider/dnd-context)
 * Hooks for:
   * [Draggable](../api-documentation/draggable)
   * [Droppable](../api-documentation/droppable)
@@ -51,7 +51,7 @@ Modifiers let you dynamically modify the movement coordinates that are detected 
 * Restricting motion to the draggable node's scroll container bounding rectangle
 * Applying resistance or clamping the motion
 
-The modifiers repository contains a number of useful modifiers that can be applied on [`DndContext`](../api-documentation/context-provider/) as well as [`DraggableClone`](../api-documentation/draggable/drag-overlay).
+The modifiers repository contains a number of useful modifiers that can be applied on [`DndContext`](/legacy/api-documentation/context-provider/dnd-context) as well as [`DraggableClone`](../api-documentation/draggable/drag-overlay).
 
 To start using modifiers, install the modifiers package via yarn or npm:
 

--- a/apps/docs/docs/legacy/presets/sortable/overview.mdx
+++ b/apps/docs/docs/legacy/presets/sortable/overview.mdx
@@ -102,7 +102,7 @@ export function SortableItem(props) {
 
 </CodeGroup>
 
-For most sortable lists, we recommend you use a [`DragOverlay`](../../api-documentation/draggable/drag-overlay) if your sortable list is scrollable or if the contents of the scrollable list are taller than the viewport of the window. Check out the[ sortable drag overlay guide](./#drag-overlay) below to learn more.
+For most sortable lists, we recommend you use a [`DragOverlay`](/legacy/api-documentation/draggable/drag-overlay) if your sortable list is scrollable or if the contents of the scrollable list are taller than the viewport of the window. Check out the[ sortable drag overlay guide](/legacy/presets/sortable/overview#drag-overlay) below to learn more.
 
 ## Architecture
 
@@ -111,7 +111,7 @@ The sortable preset builds on top of the primitives exposed by `@dnd-kit/core` t
 The sortable preset exposes two main concepts: [`SortableContext`](#sortable-context) and the [`useSortable`](#usesortable) hook:
 
 - The `SortableContext` provides information via context that is consumed by the `useSortable` hook.
-- The `useSortable` hook is an abstraction that composes the [`useDroppable`](../../api-documentation/droppable) and [`useDraggable`](../../api-documentation/draggable) hooks:
+- The `useSortable` hook is an abstraction that composes the [`useDroppable`](/legacy/api-documentation/droppable) and [`useDraggable`](/legacy/api-documentation/draggable) hooks:
 
 ![The useSortable hook](/images/legacy/use-sortable.png)
 
@@ -137,7 +137,7 @@ If you paid close attention to the illustration above, you may also have noticed
 
 ### Sortable Context
 
-In addition to the [`DndContext` provider](../../introduction/getting-started.md#context-provider), the Sortable preset requires its own context provider that contains the **sorted** array of the unique identifiers associated to each sortable item:
+In addition to the [`DndContext` provider](/legacy/introduction/getting-started#context-provider), the Sortable preset requires its own context provider that contains the **sorted** array of the unique identifiers associated to each sortable item:
 
 ```jsx
 import React, {useState} from 'react';
@@ -189,19 +189,19 @@ In order for the `SortableContext` component to function properly, make sure it 
 
 ### useSortable
 
-As outlined above, the `useSortable` hook combines both the [`useDraggable`](../../api-documentation/draggable) and [`useDroppable`](../../api-documentation/droppable) hooks to connect elements as both draggable sources and drop targets:
+As outlined above, the `useSortable` hook combines both the [`useDraggable`](/legacy/api-documentation/draggable) and [`useDroppable`](/legacy/api-documentation/droppable) hooks to connect elements as both draggable sources and drop targets:
 
 <Info>
 In most cases, the draggable and droppable hooks will be attached to the same node, and therefore be identical in size. They are represented as different nodes for illustration purposes above.
 </Info>
 
-If you're already familiar with the [`useDraggable`](../../api-documentation/draggable) hook, the [`useSortable`](./use-sortable) hook should look very familiar, since, it is an abstraction on top of it.
+If you're already familiar with the [`useDraggable`](/legacy/api-documentation/draggable) hook, the [`useSortable`](/legacy/presets/sortable/use-sortable) hook should look very familiar, since, it is an abstraction on top of it.
 
 In addition to the `attributes`, `listeners`,`transform` and `setNodeRef` properties, which you should already be familiar with if you've used the `useDraggable` hook before, you'll notice that the `useSortable` hook also provides a `transition` property.
 
 The `transform` property for `useSortable` represents the displacement and change of scale transformation that a sortable item needs to apply to transition to its new position without needing to update the DOM order.
 
-The `transform` property for the `useSortable` hook behaves similarly to the [`transform`](../../api-documentation/draggable/#transforms) property of the [`useDraggable`](../../api-documentation/draggable) hook for the active sortable item, when there is no [`DragOverlay`](../../api-documentation/draggable/drag-overlay) being used.
+The `transform` property for the `useSortable` hook behaves similarly to the [`transform`](/legacy/api-documentation/draggable#transforms) property of the [`useDraggable`](/legacy/api-documentation/draggable) hook for the active sortable item, when there is no [`DragOverlay`](/legacy/api-documentation/draggable/drag-overlay) being used.
 
 <CodeGroup>
 ```jsx SortableItem.jsx
@@ -246,19 +246,19 @@ const {transition} = useSortable({
 });
 ```
 
-For more details on the `useSortable` hook, read the full [API documentation](./use-sortable).
+For more details on the `useSortable` hook, read the full [API documentation](/legacy/presets/sortable/use-sortable).
 
 ### Sensors
 
-Sensors are an abstraction to manage and listen to different input methods. If you're unfamiliar with the concept of sensors, we recommend you read the [introduction to sensors](../../api-documentation/sensors/) first.
+Sensors are an abstraction to manage and listen to different input methods. If you're unfamiliar with the concept of sensors, we recommend you read the [introduction to sensors](/legacy/api-documentation/sensors) first.
 
-By default, the [Keyboard](../../api-documentation/sensors/keyboard) sensor moves the active draggable item by `25` pixels in the direction of the arrow key that was pressed. This is an arbitrary default, and can be customized using the `coordinateGetter` option of the keyboard sensor.
+By default, the [Keyboard](/legacy/api-documentation/sensors/keyboard) sensor moves the active draggable item by `25` pixels in the direction of the arrow key that was pressed. This is an arbitrary default, and can be customized using the `coordinateGetter` option of the keyboard sensor.
 
 The sortable preset ships with a custom coordinate getter function for the keyboard sensor that moves the active draggable to the closest sortable element in a given direction within the same `DndContext`.
 
 To use it, import the `sortableKeyboardCoordinates` coordinate getter function provided by `@dnd-kit/sortable`, and pass it to the `coordiniateGetter` option of the Keyboard sensor.
 
-In this example, we'll also be setting up the [Pointer](../../api-documentation/sensors/pointer) sensor, which is the other sensor that is enabled by default on `DndContext` if none are defined. We use the `useSensor` and `useSensors` hooks to initialize the sensors:
+In this example, we'll also be setting up the [Pointer](/legacy/api-documentation/sensors/pointer) sensor, which is the other sensor that is enabled by default on `DndContext` if none are defined. We use the `useSensor` and `useSensors` hooks to initialize the sensors:
 
 ```jsx
 import {
@@ -287,7 +287,7 @@ function App() {
 }
 ```
 
-If you'd like to use the [Mouse](../../api-documentation/sensors/mouse) and [Touch](../../api-documentation/sensors/touch) sensors instead of the [Pointer](../../api-documentation/sensors/pointer) sensor, simply initialize those sensors instead:
+If you'd like to use the [Mouse](/legacy/api-documentation/sensors/mouse) and [Touch](/legacy/api-documentation/sensors/touch) sensors instead of the [Pointer](/legacy/api-documentation/sensors/pointer) sensor, simply initialize those sensors instead:
 
 ```jsx
 import {
@@ -331,7 +331,7 @@ function App() {
 
 To learn more about sensors, read the in-depth documentation on sensors:
 
-<Card href="../../api-documentation/sensors" icon="signal-stream" horizontal>
+<Card href="/legacy/api-documentation/sensors" icon="signal-stream" horizontal>
 Sensors
 </Card>
 
@@ -348,9 +348,9 @@ Make sure to use the sorting strategy that is the most adapted to the use case y
 
 ### Collision detection algorithm
 
-The default collision detection algorithm of `DndContext` is the [rectangle intersection](../../api-documentation/context-provider/collision-detection-algorithms.md#rectangle-intersection) algorithm. While the rectangle intersection strategy is well suited for many use cases, it can be unforgiving, since it requires both the draggable and droppable bounding rectangles to come into direct contact and intersect.
+The default collision detection algorithm of `DndContext` is the [rectangle intersection](/legacy/api-documentation/context-provider/collision-detection-algorithms#rectangle-intersection) algorithm. While the rectangle intersection strategy is well suited for many use cases, it can be unforgiving, since it requires both the draggable and droppable bounding rectangles to come into direct contact and intersect.
 
-For sortable lists, we recommend using a more forgiving collision detection strategy such as the [closest center](../../api-documentation/context-provider/collision-detection-algorithms.md#closest-center) or [closest corners](../../api-documentation/context-provider/collision-detection-algorithms.md#closest-corners) algorithms.
+For sortable lists, we recommend using a more forgiving collision detection strategy such as the [closest center](/legacy/api-documentation/context-provider/collision-detection-algorithms#closest-center) or [closest corners](/legacy/api-documentation/context-provider/collision-detection-algorithms#closest-corners) algorithms.
 
 In this example, we'll be using the closest center algorithm:
 
@@ -371,7 +371,7 @@ function App() {
 
 To learn more about collision detection algorithms and when to use one over the other, read our guide on collision detection algorithms:
 
-<Card href="../../api-documentation/context-provider/collision-detection-algorithms" icon="diagram-venn" horizontal>
+<Card href="/legacy/api-documentation/context-provider/collision-detection-algorithms" icon="diagram-venn" horizontal>
 Collision Detection Algorithms
 </Card>
 
@@ -591,15 +591,15 @@ function App() {
 
 ### Drag Overlay
 
-For most sortable lists, we recommend you use a [`DragOverlay`](../../api-documentation/draggable/drag-overlay) if your sortable list is scrollable or if the contents of the scrollable list are taller than the viewport of the window.
+For most sortable lists, we recommend you use a [`DragOverlay`](/legacy/api-documentation/draggable/drag-overlay) if your sortable list is scrollable or if the contents of the scrollable list are taller than the viewport of the window.
 
 The `<DragOverlay>` component provides a way to render a draggable overlay that is removed from the normal document flow and is positioned relative to the viewport. The drag overlay also implements drop animations.
 
 A **common pitfall** when using the `DragOverlay` component is rendering the same component that calls `useSortable` inside the `DragOverlay`. This will lead to unexpected results, since there will be an `id` collision between the two components both calling `useDraggable` with the same `id`, since `useSortable` is an abstraction on top of `useDraggable`.
 
-Instead, create a presentational version of your component that you intend on rendering in the drag overlay, and another version that is sortable and renders the presentational component. There are two recommended patterns for this, either using [wrapper nodes](../../api-documentation/draggable/drag-overlay.md#wrapper-nodes) or[ ref forwarding](../../api-documentation/draggable/drag-overlay.md#ref-forwarding).
+Instead, create a presentational version of your component that you intend on rendering in the drag overlay, and another version that is sortable and renders the presentational component. There are two recommended patterns for this, either using [wrapper nodes](/legacy/api-documentation/draggable/drag-overlay#wrapper-nodes) or[ ref forwarding](/legacy/api-documentation/draggable/drag-overlay#ref-forwarding).
 
-In this example, we'll use the [ref forwarding](../../api-documentation/draggable/drag-overlay.md#ref-forwarding) pattern to avoid introducing wrapper nodes:
+In this example, we'll use the [ref forwarding](/legacy/api-documentation/draggable/drag-overlay#ref-forwarding) pattern to avoid introducing wrapper nodes:
 
 <CodeGroup>
 

--- a/apps/docs/docs/legacy/presets/sortable/sortable-context.mdx
+++ b/apps/docs/docs/legacy/presets/sortable/sortable-context.mdx
@@ -4,7 +4,7 @@ metaTitle: 'Sortable Context - Legacy | dnd kit'
 sidebarTitle: <SortableContext>
 ---
 
-The `SortableContext` provides information via context that is consumed by the [`useSortable`](./use-sortable) hook.
+The `SortableContext` provides information via context that is consumed by the [`useSortable`](/legacy/presets/sortable/use-sortable) hook.
 
 ## Props
 
@@ -34,7 +34,7 @@ It's important that the `items` prop passed to `SortableContext` be sorted in th
 
 ### Strategy
 
-The `SortableContext` component also accepts different [sorting strategies](./#sorting-strategies) to compute transforms for the `useSortable` hook. The built in strategies include:
+The `SortableContext` component also accepts different [sorting strategies](/legacy/presets/sortable/sortable-context#sorting-strategies) to compute transforms for the `useSortable` hook. The built in strategies include:
 
 - `rectSortingStrategy`: This is the default value, and is suitable for most use cases. This strategy does not support virtualized lists.
 - `verticalListSortingStrategy`: This strategy is optimized for vertical lists, and supports virtualized lists.

--- a/apps/docs/docs/legacy/presets/sortable/use-sortable.mdx
+++ b/apps/docs/docs/legacy/presets/sortable/use-sortable.mdx
@@ -3,15 +3,15 @@ title: useSortable
 metaTitle: 'useSortable - Legacy | dnd kit'
 ---
 
-The `useSortable` hook is an abstraction that composes the [`useDroppable`](../../api-documentation/droppable) and [`useDraggable`](../../api-documentation/draggable) hooks.
+The `useSortable` hook is an abstraction that composes the [`useDroppable`](/legacy/api-documentation/droppable) and [`useDraggable`](/legacy/api-documentation/draggable) hooks.
 
 <Info>
-To function properly, the `useSortable` hook needs to be used within a descendant of a [`SortableContext`](./sortable-context) provider higher up in the tree.
+To function properly, the `useSortable` hook needs to be used within a descendant of a [`SortableContext`](/legacy/presets/sortable/sortable-context) provider higher up in the tree.
 </Info>
 
 ## Usage
 
-If you're already familiar with the [`useDraggable`](../../api-documentation/draggable) hook, the `useSortable` hook should look very familiar, since, it is an abstraction on top of it.
+If you're already familiar with the [`useDraggable`](/legacy/api-documentation/draggable) hook, the `useSortable` hook should look very familiar, since, it is an abstraction on top of it.
 
 In addition to the `attributes`, `listeners`,`transform` and `setNodeRef` arguments, which you should already be familiar with if you've used the `useDraggable` hook before, you'll notice that the `useSortable` hook also provides a [`transition`](#transform) argument.
 
@@ -41,23 +41,23 @@ function SortableItem(props) {
 
 ### Listeners
 
-The `listeners` property contains the [activator event handlers](../../api-documentation/sensors/#activators) for each [Sensor](../../api-documentation/sensors/) that is defined on the parent [`DndContext`](/legacy/api-documentation/context-provider/dnd-context#props) provider.
+The `listeners` property contains the [activator event handlers](/legacy/api-documentation/sensors#activators) for each [Sensor](/legacy/api-documentation/sensors) that is defined on the parent [`DndContext`](/legacy/api-documentation/context-provider/dnd-context#props) provider.
 
 It should be attached to the node(s) that you wish to use as the activator to begin a sort event. In most cases, that will be the same node as the one passed to `setNodeRef`, though not necessarily. For instance, when implementing a sortable element with a "drag handle", the ref should be attached to the parent node that should be sortable, but the listeners can be attached to the handle node instead.
 
-For additional details on the [`listeners`](../../api-documentation/draggable/#listeners) property, refer to the [`useDraggable`](../../api-documentation/draggable) documentation.
+For additional details on the [`listeners`](/legacy/api-documentation/draggable#listeners) property, refer to the [`useDraggable`](/legacy/api-documentation/draggable) documentation.
 
 ### Attributes
 
 The `useSortable` hook provides a set of sensible default attributes for draggable items. We recommend you attach these to your draggable elements, though nothing will break if you don't.
 
-For additional details on the [`attributes`](../../api-documentation/draggable/#attributes) property, refer to the [`useDraggable`](../../api-documentation/draggable) documentation.
+For additional details on the [`attributes`](/legacy/api-documentation/draggable#attributes) property, refer to the [`useDraggable`](/legacy/api-documentation/draggable) documentation.
 
 ### Transform
 
 The `transform` property represents the displacement and change of scale transformation that a sortable item needs to apply to transition to its new position without needing to update the DOM order.
 
-The `transform` property for the `useSortable` hook behaves similarly to the [`transform`](../../api-documentation/draggable/#transforms) property of the [`useDraggable`](../../api-documentation/draggable) hook for the active sortable item, when there is no [`DragOverlay`](../../api-documentation/draggable/drag-overlay) being used.
+The `transform` property for the `useSortable` hook behaves similarly to the [`transform`](/legacy/api-documentation/draggable#transforms) property of the [`useDraggable`](/legacy/api-documentation/draggable) hook for the active sortable item, when there is no [`DragOverlay`](/legacy/api-documentation/draggable/drag-overlay) being used.
 
 ### Node ref
 
@@ -92,7 +92,7 @@ function SortableItem(props) {
 }
 ```
 
-Since the `useSortable` hook is simply an abstraction on top of the [`useDraggable`](../../api-documentation/draggable/use-draggable) and [`useDroppable`](../../api-documentation/droppable/use-droppable) hooks, in some advanced use cases, you may also use the `setDroppableNodeRef` and `setDraggableNodeRef` properties to connect them to different nodes. For example, if you want the draggable element to have a different dimension than the droppable element that will be sortable:
+Since the `useSortable` hook is simply an abstraction on top of the [`useDraggable`](/legacy/api-documentation/draggable/use-draggable) and [`useDroppable`](/legacy/api-documentation/droppable/use-droppable) hooks, in some advanced use cases, you may also use the `setDroppableNodeRef` and `setDraggableNodeRef` properties to connect them to different nodes. For example, if you want the draggable element to have a different dimension than the droppable element that will be sortable:
 
 ```jsx
 function SortableItem(props) {
@@ -171,7 +171,7 @@ The `id` argument is a `string` or `number` that should be unique.
 
 Since the `useSortable` is an abstraction on top of the `useDroppable` and `useDraggable` hooks, which both require a unique identifier, the `useSortable` hook also requires a unique identifier.
 
-The argument passed to the `id` argument of `useSortable` should match the `id` passed in the `items` array of the parent [`SortableContext`](./sortable-context) provider.
+The argument passed to the `id` argument of `useSortable` should match the `id` passed in the `items` array of the parent [`SortableContext`](/legacy/presets/sortable/sortable-context) provider.
 
 ### Disabled
 
@@ -181,7 +181,7 @@ If you'd like to temporarily disable a sortable item from being interactive, set
 
 The transition argument controls the value of the `transition` property for you. It conveniently disables transform transitions while not dragging, but ensures that items transition back to their final positions when the drag operation is ended or cancelled.
 
-It also disables transitions for the active sortable element that is being dragged, unless there is a [`DragOverlay`](../../api-documentation/draggable/drag-overlay) being used.
+It also disables transitions for the active sortable element that is being dragged, unless there is a [`DragOverlay`](/legacy/api-documentation/draggable/drag-overlay) being used.
 
 The default transition is `250` milliseconds, with an easing function set to `ease`, but you can customize this and pass any valid [CSS transition timing function](https://developer.mozilla.org/en-US/docs/Web/CSS/transition-timing-function).
 
@@ -245,4 +245,4 @@ If you prefer to manage transitions yourself, you may also choose to do so, but 
 
 ### Sorting strategy
 
-Optionally, you can pass a local sorting strategy that differs from the [global sorting strategy](./sortable-context#strategy) passed to the parent `SortableContext` provider.
+Optionally, you can pass a local sorting strategy that differs from the [global sorting strategy](/legacy/presets/sortable/sortable-context#strategy) passed to the parent `SortableContext` provider.

--- a/apps/docs/docs/legacy/presets/sortable/use-sortable.mdx
+++ b/apps/docs/docs/legacy/presets/sortable/use-sortable.mdx
@@ -41,7 +41,7 @@ function SortableItem(props) {
 
 ### Listeners
 
-The `listeners` property contains the [activator event handlers](../../api-documentation/sensors/#activators) for each [Sensor](../../api-documentation/sensors/) that is defined on the parent [`DndContext`](../../api-documentation/context-provider/#props) provider.
+The `listeners` property contains the [activator event handlers](../../api-documentation/sensors/#activators) for each [Sensor](../../api-documentation/sensors/) that is defined on the parent [`DndContext`](/legacy/api-documentation/context-provider/dnd-context#props) provider.
 
 It should be attached to the node(s) that you wish to use as the activator to begin a sort event. In most cases, that will be the same node as the one passed to `setNodeRef`, though not necessarily. For instance, when implementing a sortable element with a "drag handle", the ref should be attached to the parent node that should be sortable, but the listeners can be attached to the handle node instead.
 


### PR DESCRIPTION
## Summary
- add the missing Vite aliases needed for the docs dev server to resolve the Mintlify components wrapper
- update legacy docs links that pointed at non-existent relative routes
- redirect stale legacy URLs from production pages to their existing canonical legacy pages

## Root cause
The docs wrapper re-exported @mintlify/components-original without a matching Vite alias. Separately, legacy MDX used file-relative links such as ../api-documentation/droppable. In the deployed site, those links are resolved relative to the current URL, e.g. /legacy/introduction/getting-started/ -> /legacy/introduction/api-documentation/droppable, which 404s.

## Validation
- bun run build
- bunx prettier --check apps/docs/astro.config.mjs
- custom legacy /legacy link consistency check
- started bun dev after clearing port 3000
- verified /legacy/introduction/getting-started/ renders Droppable links as /legacy/api-documentation/droppable
- verified /legacy/api-documentation/droppable returns 200
- verified /legacy/introduction/api-documentation/droppable redirects to /legacy/api-documentation/droppable and resolves to 200
- verified /legacy/api-documentation/context-provider/ redirects to /legacy/api-documentation/context-provider/dnd-context and resolves to 200