### PR TITLE
Harden CI workflows against supply-chain attacks

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -5,6 +5,9 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   chromatic-vanilla:
     name: Chromatic (Vanilla)
@@ -206,6 +209,9 @@ jobs:
       - chromatic-vue
       - chromatic-solid
       - chromatic-svelte
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/continous-release.yml
+++ b/.github/workflows/continous-release.yml
@@ -4,19 +4,21 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Continuous release
     runs-on: ubuntu-latest
-    environment: production
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Setup node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           node-version: 20
           # https://github.com/atlassian/changesets/issues/550#issuecomment-811245508

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -5,12 +5,15 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   e2e:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,15 +5,17 @@ on:
       - main
 
 permissions:
-  id-token: write # Required for OIDC
-  contents: write # Required for changesets/action@v1
-  pull-requests: write # Required for changesets/action@v1
+  contents: read
 
 jobs:
   release:
     name: ${{ matrix.channel }}
     runs-on: ubuntu-latest
     environment: production
+    permissions:
+      id-token: write # Required for OIDC
+      contents: write # Required for changesets/action@v1
+      pull-requests: write # Required for changesets/action@v1
     strategy:
       max-parallel: 1
       matrix:
@@ -21,25 +23,25 @@ jobs:
           - current
           - beta
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
 
       - name: Setup node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '20'
           # https://github.com/atlassian/changesets/issues/550#issuecomment-811245508
           registry-url: 'https://registry.npmjs.org'
 
-      - run: npm install -g npm@latest
+      - run: npm install -g npm@10
 
-      - uses: oven-sh/setup-bun@v1
+      - uses: oven-sh/setup-bun@f4d14e03ff726c06358e5557344e1da148b56cf7 # v1
       - run: bun install && bun run build
 
       - name: Create Release Pull Request or Publish to npm
         if: matrix.channel == 'current'
-        uses: changesets/action@v1
+        uses: changesets/action@d94a5c301145045a0960133674e003b265942a22 # v1.8.0
         with:
           publish: npm run release
         env:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,12 +5,15 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v1


### PR DESCRIPTION
## Summary

Hardening pass on our GitHub Actions workflows. No known exploit — these are defense-in-depth changes that shrink the blast radius of a compromised dependency, action, or contributor account.

### `release.yml`
- **Scope write permissions to the release job** instead of granting them workflow-wide. Workflow-level defaults to `contents: read`.
- **Pin all third-party actions by commit SHA** (`actions/checkout`, `actions/setup-node`, `oven-sh/setup-bun`, `changesets/action`) so a tag rewrite by a compromised action maintainer can't swap code under our publish step. Original version tag kept in a comment for readability.
- **Pin npm to `@10`** (current stable major) instead of `@latest`, removing one moving piece from the publish path.

### `continous-release.yml`
- **Drop `environment: production`.** This workflow is triggered by `pull_request`. `pkg-pr-new` authenticates via the workflow's `GITHUB_TOKEN` and never needed the environment's secrets. Attaching a production environment to a PR-triggered workflow is a latent exfil vector if anyone ever adds an `NPM_TOKEN` there.
- Bump `actions/checkout` and `actions/setup-node` from v2 to v4.
- Add workflow-level `permissions: contents: read`.

### `chromatic.yml`, `playwright.yml`, `tests.yml`
- Add explicit workflow-level `permissions: contents: read` so a future step using `GITHUB_TOKEN` can't accidentally write back to the repo.
- Bump `actions/checkout` to v4.
- The chromatic comment-posting job gets a job-level override granting `pull-requests: write` for the `github-script` step that posts the storybook preview comment.

## Test plan

- [ ] Tests workflow runs green on this PR
- [ ] Playwright workflow runs green on this PR
- [ ] Chromatic workflow runs green on this PR — verify the storybook comment still gets posted on fork-style PRs (token check fallback path)
- [ ] Continuous release workflow runs green and `pkg-pr-new` still publishes a preview
- [ ] After merge: confirm next push to `main` triggers `release.yml` and changesets opens a release PR as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)
