### PR TITLE
Bump pinned npm to 11 to restore OIDC trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,8 @@ jobs:
           # https://github.com/atlassian/changesets/issues/550#issuecomment-811245508
           registry-url: 'https://registry.npmjs.org'
 
-      - run: npm install -g npm@10
+      # npm 11.5.1+ is required for OIDC trusted publishing to npm.
+      - run: npm install -g npm@11
 
       - uses: oven-sh/setup-bun@f4d14e03ff726c06358e5557344e1da148b56cf7 # v1
       - run: bun install && bun run build


### PR DESCRIPTION
## Summary

Fixes the broken release workflow run from #2050.

I pinned npm to `@10` to remove `@latest` floating, but npm 10 predates support for npm's OIDC trusted publisher flow (added in npm 11.5.1). The snapshot/beta publish step had no `NPM_TOKEN` configured because the original setup relied on OIDC — so it fell back to anonymous auth and the registry returned a 404 PUT.

Bumping the pin to `@11` restores the OIDC flow while keeping the major-version pin.

## Test plan

- [ ] Merge, then watch the next `Release` workflow run on `main` and confirm both `current` and `beta` channels publish successfully