### PR TITLE
fix(vue): use watchEffect onCleanup in DragOverlay

### DIFF
--- a/.changeset/fix-vue-dragoverlay-onunmounted.md
+++ b/.changeset/fix-vue-dragoverlay-onunmounted.md
@@ -1,0 +1,5 @@
+---
+"@dnd-kit/vue": patch
+---
+
+Fix `onUnmounted` warning in Vue `DragOverlay` by using `watchEffect`'s `onCleanup` callback instead of the `onUnmounted` lifecycle hook

--- a/packages/vue/src/core/draggable/DragOverlay.ts
+++ b/packages/vue/src/core/draggable/DragOverlay.ts
@@ -4,7 +4,6 @@ import {
   computed,
   defineComponent,
   h,
-  onUnmounted,
   ref,
   watchEffect,
   type PropType,
@@ -64,7 +63,7 @@ export default /* #__PURE__ */ defineComponent({
     const source = computed(() => trackedDragOperation.value.source ?? null);
 
     // Register overlay element and dropAnimation with the Feedback plugin
-    watchEffect(() => {
+    watchEffect((onCleanup) => {
       const el = overlayRef.value;
       const mgr = manager.value;
 
@@ -79,7 +78,7 @@ export default /* #__PURE__ */ defineComponent({
       feedback.overlay = el;
       feedback.dropAnimation = props.dropAnimation;
 
-      onUnmounted(() => {
+      onCleanup(() => {
         feedback.overlay = undefined;
         feedback.dropAnimation = undefined;
       });


### PR DESCRIPTION
Fixes #2045

## Summary
The Vue `DragOverlay` component registered cleanup logic using `onUnmounted` inside a `watchEffect` callback. Vue's lifecycle hooks can only be registered during the synchronous portion of `setup()`. The first `watchEffect` run happens during setup (so the hook registers), but every subsequent re-run logs:

> onUnmounted is called when there is no active component instance to be associated with…

and the cleanup is silently dropped, leaving stale `feedback.overlay` / `feedback.dropAnimation` references on the manager.

This change switches to `watchEffect`'s own `onCleanup` callback. The cleanup now runs both before each re-execution of the effect and on component unmount, which is the intended behaviour for resource registration that depends on reactive state.

## Test plan
- [ ] Mount `DragOverlay` in a Vue app and observe the console — the `onUnmounted` warning no longer appears.
- [ ] Trigger a drag and drop with the overlay visible — drop animation still plays.
- [ ] Toggle the overlay's `disabled` prop and unmount the component — `feedback.overlay` and `feedback.dropAnimation` are cleared on the manager.

---
*Automated fix by Claude Code*