### PR TITLE
docs(svelte): fix quickstart example to use child components

### DIFF
--- a/apps/docs/docs/svelte/quickstart.mdx
+++ b/apps/docs/docs/svelte/quickstart.mdx
@@ -45,7 +45,7 @@ Let's get started by creating draggable elements that can be dropped over droppa
 
 The `createDraggable` primitive requires a unique `id`. It returns an object with an `attach` function that you can use with the `{@attach}` directive to connect an element to the drag system.
 
-```svelte
+```svelte Draggable.svelte
 <script>
   import {createDraggable} from '@dnd-kit/svelte';
 
@@ -61,17 +61,19 @@ The `createDraggable` primitive requires a unique `id`. It returns an object wit
 
 In order for our draggable elements to have targets where they can be dropped, we need to create droppable elements. To do so, we'll be using the `createDroppable` primitive.
 
-Like `createDraggable`, the `createDroppable` primitive requires a unique `id`.
+Like `createDraggable`, the `createDroppable` primitive requires a unique `id`. This time, we'll accept the `id` as a prop so we can reuse the component for multiple droppable targets.
 
-```svelte
+```svelte Droppable.svelte
 <script>
   import {createDroppable} from '@dnd-kit/svelte';
 
-  const droppable = createDroppable({id: 'droppable'});
+  let {id, children} = $props();
+
+  const droppable = createDroppable({id});
 </script>
 
 <div {@attach droppable.attach} style="width: 300px; height: 300px;">
-  Droppable
+  {@render children?.()}
 </div>
 ```
 
@@ -81,14 +83,17 @@ Now that we have both draggable and droppable elements, we can put them together
 
 We'll be using the `DragDropProvider` component to wrap our draggable and droppable elements. This component handles the drag and drop interactions and allows us to listen to drag and drop events.
 
+<Note>
+  `createDraggable` and `createDroppable` rely on the context provided by `DragDropProvider`. They must be called from a component that is rendered **inside** a `DragDropProvider`, not from the same component that renders the provider — otherwise the context will not be available and an error will be thrown.
+</Note>
+
 ```svelte App.svelte
 <script>
-  import {DragDropProvider, createDraggable, createDroppable} from '@dnd-kit/svelte';
+  import {DragDropProvider} from '@dnd-kit/svelte';
+  import Draggable from './Draggable.svelte';
+  import Droppable from './Droppable.svelte';
 
   let parent = $state(undefined);
-
-  const draggable = createDraggable({id: 'draggable'});
-  const droppable = createDroppable({id: 'droppable'});
 
   function onDragEnd(event) {
     if (event.canceled) return;
@@ -98,14 +103,14 @@ We'll be using the `DragDropProvider` component to wrap our draggable and droppa
 
 <DragDropProvider {onDragEnd}>
   {#if parent == null}
-    <button {@attach draggable.attach}>Draggable</button>
+    <Draggable />
   {/if}
 
-  <div {@attach droppable.attach} style="width: 300px; height: 300px;">
+  <Droppable id="droppable">
     {#if parent === 'droppable'}
-      <button {@attach draggable.attach}>Draggable</button>
+      <Draggable />
     {/if}
-  </div>
+  </Droppable>
 </DragDropProvider>
 ```
 


### PR DESCRIPTION
Fixes #2035

## Summary
The Svelte quickstart's combined example called `createDraggable`/`createDroppable` at the top of the same component (`App.svelte`) that rendered `<DragDropProvider>`. Svelte's `getContext` only sees contexts set by **ancestor** components, so the primitives could not find the manager set by their sibling/descendant `DragDropProvider` and threw:

> getDragDropManager was called outside of a DragDropProvider. Make sure your component is wrapped in a DragDropProvider.

Restructure the combined example to match the React quickstart and the working storybook examples (e.g. [`DragHandlesApp.svelte`](https://github.com/clauderic/dnd-kit/blob/main/apps/stories-svelte/stories/Draggable/DragHandles/DragHandlesApp.svelte)) by extracting `Draggable` and `Droppable` into their own components that are rendered inside the `DragDropProvider`. Added a `<Note>` callout warning about the constraint so other users don't hit the same wall.

Documentation-only change, so no changeset is required.

> Note for maintainer: `apps/templates/svelte-draggable/src/App.svelte` (and likely the sortable variant) has the same broken pattern. Left untouched here so the fix stays scoped to the reported issue.

## Test plan
- [ ] Build the docs site locally and verify the rewritten quickstart renders correctly.
- [ ] Copy the new `App.svelte` / `Draggable.svelte` / `Droppable.svelte` snippets into a fresh Svelte 5 app and confirm the example mounts without the `getDragDropManager` error.

---
*Automated fix by Claude Code*