### PR TITLE
fix(dom): allow dragging anchor descendants (closes #2049)

### DIFF
--- a/.changeset/fix-anchor-descendant-drag.md
+++ b/.changeset/fix-anchor-descendant-drag.md
@@ -1,0 +1,5 @@
+---
+'@dnd-kit/dom': patch
+---
+
+Allow pointer dragging from descendants of interactive draggable elements, such as text inside sortable anchor elements.

--- a/apps/stories/stories/react/Sortable/Vertical/AnchorElementsExample.tsx
+++ b/apps/stories/stories/react/Sortable/Vertical/AnchorElementsExample.tsx
@@ -1,0 +1,81 @@
+import React, {memo, useState} from 'react';
+import {DragDropProvider} from '@dnd-kit/react';
+import {useSortable} from '@dnd-kit/react/sortable';
+import {move} from '@dnd-kit/helpers';
+
+const initialItems = [
+  {id: 'a', title: 'Documentation', href: 'https://dndkit.com'},
+  {id: 'b', title: 'React', href: 'https://react.dev'},
+  {id: 'c', title: 'CodePen', href: 'https://codepen.io'},
+  {id: 'd', title: 'MDN', href: 'https://developer.mozilla.org'},
+];
+
+export function AnchorElementsExample() {
+  const [items, setItems] = useState(initialItems);
+
+  return (
+    <DragDropProvider
+      onDragEnd={(event) => {
+        setItems((items) => move(items, event));
+      }}
+    >
+      <div
+        style={{
+          alignItems: 'center',
+          display: 'flex',
+          flexDirection: 'column',
+          gap: 18,
+          padding: '0 30px',
+        }}
+      >
+        {items.map((item, index) => (
+          <SortableLink key={item.id} item={item} index={index} />
+        ))}
+      </div>
+    </DragDropProvider>
+  );
+}
+
+interface SortableLinkProps {
+  item: (typeof initialItems)[number];
+  index: number;
+}
+
+const SortableLink = memo(function SortableLink({
+  item,
+  index,
+}: SortableLinkProps) {
+  const [element, setElement] = useState<Element | null>(null);
+  const {isDragging} = useSortable({
+    id: item.id,
+    index,
+    element,
+  });
+
+  return (
+    <a
+      ref={setElement}
+      href={item.href}
+      draggable={false}
+      className="Item"
+      data-shadow={isDragging}
+      style={{
+        alignItems: 'flex-start',
+        background: '#f4f5f7',
+        border: '1px solid #d7dce1',
+        borderRadius: 6,
+        boxSizing: 'border-box',
+        color: '#1f2933',
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 6,
+        padding: 16,
+        textDecoration: 'none',
+        width: 360,
+      }}
+    >
+      <strong>{item.title}</strong>
+      <span>{item.href}</span>
+    </a>
+  );
+});

--- a/apps/stories/stories/react/Sortable/Vertical/Vertical.stories.tsx
+++ b/apps/stories/stories/react/Sortable/Vertical/Vertical.stories.tsx
@@ -3,6 +3,7 @@ import {RestrictToVerticalAxis} from '@dnd-kit/abstract/modifiers';
 import {Feedback} from '@dnd-kit/dom';
 
 import {SortableExample} from '../SortableExample';
+import {AnchorElementsExample} from './AnchorElementsExample';
 import {AutoScrollExample} from './AutoScrollExample';
 
 const meta: Meta<typeof SortableExample> = {
@@ -28,6 +29,11 @@ export const WithDragHandle: Story = {
     dragHandle: true,
     itemCount: 100,
   },
+};
+
+export const AnchorElements: StoryObj<typeof AnchorElementsExample> = {
+  name: 'Anchor elements',
+  render: () => <AnchorElementsExample />,
 };
 
 export const VariableHeights: Story = {
@@ -143,7 +149,9 @@ type AutoScrollStory = StoryObj<typeof AutoScrollExample>;
 
 export const AutoScrollDisabled: AutoScrollStory = {
   name: 'Auto-scroll disabled',
-  render: (args: React.ComponentProps<typeof AutoScrollExample>) => <AutoScrollExample {...args} />,
+  render: (args: React.ComponentProps<typeof AutoScrollExample>) => (
+    <AutoScrollExample {...args} />
+  ),
   args: {
     itemCount: 100,
     threshold: 0,
@@ -152,7 +160,9 @@ export const AutoScrollDisabled: AutoScrollStory = {
 
 export const AutoScrollCustomSpeed: AutoScrollStory = {
   name: 'Auto-scroll custom speed',
-  render: (args: React.ComponentProps<typeof AutoScrollExample>) => <AutoScrollExample {...args} />,
+  render: (args: React.ComponentProps<typeof AutoScrollExample>) => (
+    <AutoScrollExample {...args} />
+  ),
   args: {
     itemCount: 100,
     acceleration: 50,

--- a/apps/stories/tests/sortable-vertical.spec.ts
+++ b/apps/stories/tests/sortable-vertical.spec.ts
@@ -1,6 +1,28 @@
 import {sortableVerticalTests} from '../../stories-shared/tests/sortable-vertical.tests.ts';
+import {test, expect} from '../../stories-shared/tests/fixtures.ts';
 
 sortableVerticalTests({
   basicSetup: 'react-sortable-vertical-list--basic-setup',
   withDragHandle: 'react-sortable-vertical-list--with-drag-handle',
+});
+
+test.describe('Sortable anchor elements', () => {
+  test.beforeEach(async ({dnd}) => {
+    await dnd.goto('react-sortable-vertical-list--anchor-elements');
+    await expect(dnd.items.first()).toBeVisible();
+  });
+
+  test('drag from anchor descendant content with pointer', async ({dnd}) => {
+    const first = dnd.items.nth(0);
+    const third = dnd.items.nth(2);
+
+    await expect(first.locator('strong')).toHaveText('Documentation');
+
+    await dnd.pointer.drag(first.locator('strong'), third);
+    await dnd.waitForDrop();
+
+    await expect(dnd.items.nth(2).locator('strong')).toHaveText(
+      'Documentation'
+    );
+  });
 });

--- a/packages/dom/src/core/sensors/pointer/PointerSensor.ts
+++ b/packages/dom/src/core/sensors/pointer/PointerSensor.ts
@@ -12,9 +12,9 @@ import {
   getDocuments,
   getEventCoordinates,
   getFrameTransform,
+  getInteractiveElement,
   isElement,
   isHTMLElement,
-  isInteractiveElement,
   isPointerEvent,
   isTextInput,
   Listeners,
@@ -78,7 +78,11 @@ const defaults = Object.freeze<PointerSensorOptions>({
     if (!isElement(target)) return false;
     if (source.handle?.contains(target)) return false;
 
-    return isInteractiveElement(target);
+    const interactiveElement = getInteractiveElement(target);
+
+    if (interactiveElement === source.element) return false;
+
+    return Boolean(interactiveElement);
   },
 });
 
@@ -226,10 +230,10 @@ export class PointerSensor extends Sensor<
           capture: true,
         },
       },
-      {                                                                     
-        type: 'pointercancel',                 
-        listener: this.handleCancel,                                        
-      },   
+      {
+        type: 'pointercancel',
+        listener: this.handleCancel,
+      },
       {
         // Cancel activation if there is a competing Drag and Drop interaction
         type: 'dragstart',

--- a/packages/dom/src/utilities/element/isInteractiveElement.ts
+++ b/packages/dom/src/utilities/element/isInteractiveElement.ts
@@ -1,12 +1,14 @@
 export function isInteractiveElement(element: Element): boolean {
-  return Boolean(
-    element.closest(`
-      input:not([disabled]),
-      select:not([disabled]),
-      textarea:not([disabled]),
-      button:not([disabled]),
-      a[href],
-      [contenteditable]:not([contenteditable="false"])
-    `)
-  );
+  return Boolean(getInteractiveElement(element));
+}
+
+export function getInteractiveElement(element: Element): Element | null {
+  return element.closest(`
+    input:not([disabled]),
+    select:not([disabled]),
+    textarea:not([disabled]),
+    button:not([disabled]),
+    a[href],
+    [contenteditable]:not([contenteditable="false"])
+  `);
 }

--- a/packages/dom/src/utilities/index.ts
+++ b/packages/dom/src/utilities/index.ts
@@ -22,7 +22,10 @@ export {
   getElementFromPoint,
   ProxiedElements,
 } from './element/index.ts';
-export {isInteractiveElement} from './element/isInteractiveElement.ts';
+export {
+  getInteractiveElement,
+  isInteractiveElement,
+} from './element/isInteractiveElement.ts';
 
 export {Listeners} from './event-listeners/index.ts';
 export {PositionObserver} from './observers/index.ts';


### PR DESCRIPTION
## Summary

Fixes pointer activation for draggable anchor elements when dragging starts from descendant content, such as text inside `<strong>` or `<span>`.

The default `PointerSensor.preventActivation` now allows activation when the nearest interactive ancestor is the draggable source element itself, while still preventing activation from nested interactive controls.

## Changes

- Added `getInteractiveElement(element)` utility.
- Updated `PointerSensor` activation prevention logic.
- Added a React sortable anchor-elements story.
- Added Playwright regression coverage for dragging from anchor descendant content.
- Added a patch changeset for `@dnd-kit/dom`.

## Validation

- `bun --filter @dnd-kit/dom build`
- `bun --filter @dnd-kit/dom test`
- `bunx turbo run build --filter=@dnd-kit/stories`
- `bun --filter @dnd-kit/stories test:e2e tests/sortable-vertical.spec.ts --project=chromium`

Fixes #2049