### PR TITLE
fix(sortable): allow disabling drag and drop separately (closes #1998)

### DIFF
--- a/.changeset/shy-heads-matter.md
+++ b/.changeset/shy-heads-matter.md
@@ -1,0 +1,6 @@
+---
+'@dnd-kit/dom': minor
+'@dnd-kit/react': minor
+---
+
+Allow `useSortable` and `Sortable` to disable dragging and dropping independently with a `disabled` object while preserving the existing boolean behavior.

--- a/.changeset/shy-heads-matter.md
+++ b/.changeset/shy-heads-matter.md
@@ -1,6 +1,9 @@
 ---
 '@dnd-kit/dom': minor
 '@dnd-kit/react': minor
+'@dnd-kit/vue': minor
+'@dnd-kit/solid': minor
+'@dnd-kit/svelte': minor
 ---
 
-Allow `useSortable` and `Sortable` to disable dragging and dropping independently with a `disabled` object while preserving the existing boolean behavior.
+Allow `useSortable`, `createSortable` and `Sortable` to disable dragging and dropping independently with a `disabled` object while preserving the existing boolean behavior.

--- a/apps/docs/docs/concepts/sortable.mdx
+++ b/apps/docs/docs/concepts/sortable.mdx
@@ -322,8 +322,15 @@ The `Sortable` class accepts the following arguments:
   ```
 </ParamField>
 
-<ParamField path="disabled" type="boolean">
-  Set to `true` to temporarily disable sorting for this item.
+<ParamField path="disabled" type="boolean | SortableDisabled">
+  Set to `true` to temporarily disable sorting for this item. Pass an object to disable dragging and dropping independently:
+
+  ```ts
+  interface SortableDisabled {
+    draggable?: boolean; // Prevent this item from being dragged
+    droppable?: boolean; // Prevent other items from being dropped on this one
+  }
+  ```
 </ParamField>
 
 <ParamField path="type" type="string | number | Symbol">
@@ -354,7 +361,7 @@ The `Sortable` instance provides these key properties:
 - `group`: The assigned group identifier
 - `isDragging`: Whether this item is currently being dragged
 - `isDropTarget`: Whether this item is currently a drop target
-- `disabled`: Whether sorting is disabled for this item
+- `disabled`: Whether sorting is disabled for this item. Returns a `boolean` when dragging and dropping share the same state, or a `{draggable, droppable}` object when they differ
 - `element`: The main DOM element
 - `target`: The drop target element (if different from main element)
 

--- a/apps/docs/docs/react/hooks/use-sortable.mdx
+++ b/apps/docs/docs/react/hooks/use-sortable.mdx
@@ -120,8 +120,16 @@ The `useSortable` hook accepts all of the same arguments as the [useDraggable](/
   Optionally supply a number to set the collision priority of the droppable target of this sortable element. The higher the number, the higher the priority when detecting collisions. This can be useful if there are multiple droppable elements that overlap.
 </ParamField>
 
-<ParamField path="disabled" type="boolean">
-  Set to `true` to prevent the sortable element from being sortable.
+<ParamField path="disabled" type="boolean | {draggable?: boolean; droppable?: boolean}">
+  Set to `true` to prevent the sortable element from being dragged or used as a drop target. Pass an object to disable dragging and dropping independently:
+
+  ```ts
+  // Disable dragging only — other items can still be dropped on this one
+  disabled: {draggable: true}
+
+  // Disable dropping only — this item can still be dragged
+  disabled: {droppable: true}
+  ```
 </ParamField>
 
 <ParamField path="plugins" type="PluginDescriptor[]">

--- a/apps/docs/docs/solid/hooks/use-sortable.mdx
+++ b/apps/docs/docs/solid/hooks/use-sortable.mdx
@@ -138,8 +138,16 @@ export default function App() {
   The collision priority of this sortable element. Higher values take precedence when multiple droppable elements overlap.
 </ParamField>
 
-<ParamField path="disabled" type="boolean" optional>
-  Whether the sortable is disabled.
+<ParamField path="disabled" type="boolean | {draggable?: boolean; droppable?: boolean}" optional>
+  Whether the sortable is disabled. Pass an object to disable dragging and dropping independently:
+
+  ```ts
+  // Disable dragging only — other items can still be dropped on this one
+  disabled: {draggable: true}
+
+  // Disable dropping only — this item can still be dragged
+  disabled: {droppable: true}
+  ```
 </ParamField>
 
 <ParamField path="data" type="Data" optional>

--- a/apps/docs/docs/svelte/primitives/create-sortable.mdx
+++ b/apps/docs/docs/svelte/primitives/create-sortable.mdx
@@ -149,8 +149,15 @@ All input properties accept plain values or getter functions for reactivity.
   The collision priority of this sortable element. Higher values take precedence when multiple droppable elements overlap.
 </ParamField>
 
-<ParamField path="disabled" type="boolean | (() => boolean)" optional>
-  Whether the sortable is disabled.
+<ParamField path="disabled" type="boolean | SortableDisabled | (() => boolean | SortableDisabled)" optional>
+  Whether the sortable is disabled. Pass an object to disable dragging and dropping independently:
+
+  ```ts
+  interface SortableDisabled {
+    draggable?: boolean; // Prevent this item from being dragged
+    droppable?: boolean; // Prevent other items from being dropped on this one
+  }
+  ```
 </ParamField>
 
 <ParamField path="data" type="Data | (() => Data)" optional>

--- a/apps/docs/docs/vue/composables/use-sortable.mdx
+++ b/apps/docs/docs/vue/composables/use-sortable.mdx
@@ -139,8 +139,16 @@ All input properties accept plain values or Vue refs/getters (`MaybeRefOrGetter`
   The collision priority of this sortable element. Higher values take precedence when multiple droppable elements overlap.
 </ParamField>
 
-<ParamField path="disabled" type="MaybeRefOrGetter<boolean>" optional>
-  Whether the sortable is disabled.
+<ParamField path="disabled" type="MaybeRefOrGetter<boolean | {draggable?: boolean; droppable?: boolean}>" optional>
+  Whether the sortable is disabled. Pass an object to disable dragging and dropping independently:
+
+  ```ts
+  // Disable dragging only — other items can still be dropped on this one
+  disabled: {draggable: true}
+
+  // Disable dropping only — this item can still be dragged
+  disabled: {droppable: true}
+  ```
 </ParamField>
 
 <ParamField path="data" type="MaybeRefOrGetter<Data>" optional>

--- a/packages/dom/src/sortable/index.ts
+++ b/packages/dom/src/sortable/index.ts
@@ -4,7 +4,11 @@ export {
   SortableDraggable,
   SortableDroppable,
 } from './sortable.ts';
-export type {SortableInput, SortableTransition} from './sortable.ts';
+export type {
+  SortableDisabled,
+  SortableInput,
+  SortableTransition,
+} from './sortable.ts';
 export {isSortable, isSortableOperation} from './utilities.ts';
 export {OptimisticSortingPlugin} from './plugins/OptimisticSortingPlugin.ts';
 export {SortableKeyboardPlugin} from './plugins/SortableKeyboardPlugin.ts';

--- a/packages/dom/src/sortable/sortable.ts
+++ b/packages/dom/src/sortable/sortable.ts
@@ -50,14 +50,29 @@ export interface SortableTransition {
   idle?: boolean;
 }
 
+export interface SortableDisabled {
+  draggable?: boolean;
+  droppable?: boolean;
+}
+
+type SortableDisabledValue = boolean | SortableDisabled;
+
 const defaultPlugins: PluginConstructor[] = [
   SortableKeyboardPlugin,
   OptimisticSortingPlugin,
 ];
 
 export interface SortableInput<T extends Data>
-  extends Omit<DraggableInput<T>, 'plugins'>,
-    DroppableInput<T> {
+  extends Omit<DraggableInput<T>, 'disabled' | 'plugins'>,
+    Omit<DroppableInput<T>, 'disabled'> {
+  /**
+   * Whether the sortable item should be disabled.
+   *
+   * Passing a boolean disables dragging and dropping.
+   * Use the object form to disable dragging and dropping independently.
+   */
+  disabled?: boolean | SortableDisabled;
+
   /**
    * The index of the sortable item within its group.
    */
@@ -103,6 +118,22 @@ export const defaultSortableTransition: SortableTransition = {
   idle: false,
 };
 
+function normalizeDisabled(
+  disabled: SortableDisabledValue | undefined
+): Required<SortableDisabled> {
+  if (typeof disabled === 'boolean') {
+    return {
+      draggable: disabled,
+      droppable: disabled,
+    };
+  }
+
+  return {
+    draggable: disabled?.draggable ?? false,
+    droppable: disabled?.droppable ?? false,
+  };
+}
+
 interface TemporaryState {
   initialIndex: number;
   initialGroup: UniqueIdentifier | undefined;
@@ -141,6 +172,7 @@ export class Sortable<T extends Data = Data> {
   constructor(
     {
       effects: inputEffects = () => [],
+      disabled,
       group,
       index,
       sensors,
@@ -152,11 +184,17 @@ export class Sortable<T extends Data = Data> {
     manager: DragDropManager<any, any> | undefined
   ) {
     const plugins = resolveCustomizable(pluginsInput, defaultPlugins);
+    const disabledState = normalizeDisabled(disabled);
 
-    this.droppable = new SortableDroppable<T>(input, manager, this);
+    this.droppable = new SortableDroppable<T>(
+      {...input, disabled: disabledState.droppable},
+      manager,
+      this
+    );
     this.draggable = new SortableDraggable<T>(
       {
         ...input,
+        disabled: disabledState.draggable,
         plugins,
         effects: () => [
           () => {
@@ -351,18 +389,23 @@ export class Sortable<T extends Data = Data> {
     return this.draggable.element;
   }
 
-  public get disabled() {
-    return this.draggable.disabled && this.droppable.disabled;
+  public get disabled(): boolean | SortableDisabled {
+    const {disabled: draggable} = this.draggable;
+    const {disabled: droppable} = this.droppable;
+
+    return draggable === droppable ? draggable : {draggable, droppable};
   }
 
   public set plugins(value: Customizable<Plugins> | undefined) {
     this.draggable.plugins = resolveCustomizable(value, defaultPlugins);
   }
 
-  public set disabled(value: boolean) {
+  public set disabled(value: SortableDisabledValue) {
+    const disabled = normalizeDisabled(value);
+
     batch(() => {
-      this.droppable.disabled = value;
-      this.draggable.disabled = value;
+      this.droppable.disabled = disabled.droppable;
+      this.draggable.disabled = disabled.draggable;
     });
   }
 

--- a/packages/dom/tests/sortable-utilities.test.ts
+++ b/packages/dom/tests/sortable-utilities.test.ts
@@ -8,14 +8,27 @@ import {
   isSortable,
   isSortableOperation,
 } from '@dnd-kit/dom/sortable';
+import type {SortableDisabled} from '@dnd-kit/dom/sortable';
 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 
-function createSortable(id: string | number, index: number, group?: string) {
+interface CreateSortableOptions {
+  id?: string | number;
+  index?: number;
+  group?: string;
+  disabled?: boolean | SortableDisabled;
+}
+
+function createSortable({
+  id = 's1',
+  index = 0,
+  group,
+  disabled,
+}: CreateSortableOptions = {}) {
   const sortable = new Sortable(
-    {id, index, group, plugins: [], transition: null},
+    {id, index, group, disabled, plugins: [], transition: null},
     undefined
   );
   return sortable;
@@ -42,13 +55,13 @@ function mockOperation(
 
 describe('isSortable', () => {
   it('should return true for a SortableDraggable', () => {
-    const sortable = createSortable('s1', 0);
+    const sortable = createSortable({id: 's1', index: 0});
     expect(isSortable(sortable.draggable)).toBe(true);
     expect(sortable.draggable).toBeInstanceOf(SortableDraggable);
   });
 
   it('should return true for a SortableDroppable', () => {
-    const sortable = createSortable('s1', 0);
+    const sortable = createSortable({id: 's1', index: 0});
     expect(isSortable(sortable.droppable)).toBe(true);
     expect(sortable.droppable).toBeInstanceOf(SortableDroppable);
   });
@@ -74,34 +87,34 @@ describe('isSortable', () => {
 
 describe('isSortableOperation', () => {
   it('should return true when source and target are both sortable', () => {
-    const s1 = createSortable('s1', 0);
-    const s2 = createSortable('s2', 1);
+    const s1 = createSortable({id: 's1', index: 0});
+    const s2 = createSortable({id: 's2', index: 1});
     const op = mockOperation(s1.draggable, s2.droppable);
     expect(isSortableOperation(op)).toBe(true);
   });
 
   it('should return false when source is a plain Draggable', () => {
     const draggable = createDraggable('d1');
-    const sortable = createSortable('s1', 0);
+    const sortable = createSortable({id: 's1', index: 0});
     const op = mockOperation(draggable, sortable.droppable);
     expect(isSortableOperation(op)).toBe(false);
   });
 
   it('should return false when target is a plain Droppable', () => {
-    const sortable = createSortable('s1', 0);
+    const sortable = createSortable({id: 's1', index: 0});
     const droppable = createDroppable('d1');
     const op = mockOperation(sortable.draggable, droppable);
     expect(isSortableOperation(op)).toBe(false);
   });
 
   it('should return false when source is null', () => {
-    const sortable = createSortable('s1', 0);
+    const sortable = createSortable({id: 's1', index: 0});
     const op = mockOperation(null, sortable.droppable);
     expect(isSortableOperation(op)).toBe(false);
   });
 
   it('should return false when target is null', () => {
-    const sortable = createSortable('s1', 0);
+    const sortable = createSortable({id: 's1', index: 0});
     const op = mockOperation(sortable.draggable, null);
     expect(isSortableOperation(op)).toBe(false);
   });
@@ -119,8 +132,8 @@ describe('isSortableOperation', () => {
   });
 
   it('should narrow types to expose sortable properties on source', () => {
-    const s1 = createSortable('s1', 2, 'groupA');
-    const s2 = createSortable('s2', 5, 'groupA');
+    const s1 = createSortable({id: 's1', index: 2, group: 'groupA'});
+    const s2 = createSortable({id: 's2', index: 5, group: 'groupA'});
     const op = mockOperation(s1.draggable, s2.droppable);
 
     if (isSortableOperation(op)) {
@@ -142,121 +155,111 @@ describe('isSortableOperation', () => {
 
 describe('Sortable disabled', () => {
   it('sets sortable.disabled when disabled is true', () => {
-    const sortable = createSortableWithDisabled(true);
+    const sortable = createSortable({disabled: true});
     expect(sortable.disabled).toBe(true);
   });
 
   it('disables dragging when disabled is true', () => {
-    const sortable = createSortableWithDisabled(true);
+    const sortable = createSortable({disabled: true});
     expect(sortable.draggable.disabled).toBe(true);
   });
 
   it('disables dropping when disabled is true', () => {
-    const sortable = createSortableWithDisabled(true);
+    const sortable = createSortable({disabled: true});
     expect(sortable.droppable.disabled).toBe(true);
   });
 
   it('clears sortable.disabled when disabled is false', () => {
-    const sortable = createSortableWithDisabled(false);
+    const sortable = createSortable({disabled: false});
     expect(sortable.disabled).toBe(false);
   });
 
   it('keeps dragging enabled when disabled is false', () => {
-    const sortable = createSortableWithDisabled(false);
+    const sortable = createSortable({disabled: false});
     expect(sortable.draggable.disabled).toBe(false);
   });
 
   it('keeps dropping enabled when disabled is false', () => {
-    const sortable = createSortableWithDisabled(false);
+    const sortable = createSortable({disabled: false});
     expect(sortable.droppable.disabled).toBe(false);
   });
 
   it('disables dragging when disabled.draggable is true', () => {
-    const sortable = createSortable('s1', 0);
-    sortable.disabled = {draggable: true};
+    const sortable = createSortable({disabled: {draggable: true}});
 
     expect(sortable.draggable.disabled).toBe(true);
   });
 
   it('returns split disabled state when disabled.draggable is true', () => {
-    const sortable = createSortable('s1', 0);
-    sortable.disabled = {draggable: true};
+    const sortable = createSortable({disabled: {draggable: true}});
 
     expect(sortable.disabled).toEqual({draggable: true, droppable: false});
   });
 
   it('keeps dropping enabled when disabled.draggable is true', () => {
-    const sortable = createSortable('s1', 0);
-    sortable.disabled = {draggable: true};
+    const sortable = createSortable({disabled: {draggable: true}});
 
     expect(sortable.droppable.disabled).toBe(false);
   });
 
   it('keeps dragging enabled when disabled.droppable is true', () => {
-    const sortable = createSortable('s1', 0);
-    sortable.disabled = {droppable: true};
+    const sortable = createSortable({disabled: {droppable: true}});
 
     expect(sortable.draggable.disabled).toBe(false);
   });
 
   it('returns split disabled state when disabled.droppable is true', () => {
-    const sortable = createSortable('s1', 0);
-    sortable.disabled = {droppable: true};
+    const sortable = createSortable({disabled: {droppable: true}});
 
     expect(sortable.disabled).toEqual({draggable: false, droppable: true});
   });
 
   it('disables dropping when disabled.droppable is true', () => {
-    const sortable = createSortable('s1', 0);
-    sortable.disabled = {droppable: true};
+    const sortable = createSortable({disabled: {droppable: true}});
 
     expect(sortable.droppable.disabled).toBe(true);
   });
 
   it('disables dragging when both disabled flags are true', () => {
-    const sortable = createSortable('s1', 0);
-    sortable.disabled = {draggable: true, droppable: true};
+    const sortable = createSortable({
+      disabled: {draggable: true, droppable: true},
+    });
 
     expect(sortable.draggable.disabled).toBe(true);
   });
 
   it('disables dropping when both disabled flags are true', () => {
-    const sortable = createSortable('s1', 0);
-    sortable.disabled = {draggable: true, droppable: true};
+    const sortable = createSortable({
+      disabled: {draggable: true, droppable: true},
+    });
 
     expect(sortable.droppable.disabled).toBe(true);
   });
 
   it('clears sortable.disabled when disabled is reset to false', () => {
-    const sortable = createSortable('s1', 0);
-    sortable.disabled = {draggable: true, droppable: true};
+    const sortable = createSortable({
+      disabled: {draggable: true, droppable: true},
+    });
     sortable.disabled = false;
 
     expect(sortable.disabled).toBe(false);
   });
 
   it('re-enables dragging when disabled is reset to false', () => {
-    const sortable = createSortable('s1', 0);
-    sortable.disabled = {draggable: true, droppable: true};
+    const sortable = createSortable({
+      disabled: {draggable: true, droppable: true},
+    });
     sortable.disabled = false;
 
     expect(sortable.draggable.disabled).toBe(false);
   });
 
   it('re-enables dropping when disabled is reset to false', () => {
-    const sortable = createSortable('s1', 0);
-    sortable.disabled = {draggable: true, droppable: true};
+    const sortable = createSortable({
+      disabled: {draggable: true, droppable: true},
+    });
     sortable.disabled = false;
 
     expect(sortable.droppable.disabled).toBe(false);
   });
 });
-
-function createSortableWithDisabled(
-  disabled: boolean | {draggable?: boolean; droppable?: boolean}
-) {
-  return new Sortable(
-    {id: 's1', index: 0, disabled, plugins: [], transition: null},
-    undefined
-  );
-}

--- a/packages/dom/tests/sortable-utilities.test.ts
+++ b/packages/dom/tests/sortable-utilities.test.ts
@@ -135,3 +135,128 @@ describe('isSortableOperation', () => {
     }
   });
 });
+
+// ---------------------------------------------------------------------------
+// Sortable disabled
+// ---------------------------------------------------------------------------
+
+describe('Sortable disabled', () => {
+  it('sets sortable.disabled when disabled is true', () => {
+    const sortable = createSortableWithDisabled(true);
+    expect(sortable.disabled).toBe(true);
+  });
+
+  it('disables dragging when disabled is true', () => {
+    const sortable = createSortableWithDisabled(true);
+    expect(sortable.draggable.disabled).toBe(true);
+  });
+
+  it('disables dropping when disabled is true', () => {
+    const sortable = createSortableWithDisabled(true);
+    expect(sortable.droppable.disabled).toBe(true);
+  });
+
+  it('clears sortable.disabled when disabled is false', () => {
+    const sortable = createSortableWithDisabled(false);
+    expect(sortable.disabled).toBe(false);
+  });
+
+  it('keeps dragging enabled when disabled is false', () => {
+    const sortable = createSortableWithDisabled(false);
+    expect(sortable.draggable.disabled).toBe(false);
+  });
+
+  it('keeps dropping enabled when disabled is false', () => {
+    const sortable = createSortableWithDisabled(false);
+    expect(sortable.droppable.disabled).toBe(false);
+  });
+
+  it('disables dragging when disabled.draggable is true', () => {
+    const sortable = createSortable('s1', 0);
+    sortable.disabled = {draggable: true};
+
+    expect(sortable.draggable.disabled).toBe(true);
+  });
+
+  it('returns split disabled state when disabled.draggable is true', () => {
+    const sortable = createSortable('s1', 0);
+    sortable.disabled = {draggable: true};
+
+    expect(sortable.disabled).toEqual({draggable: true, droppable: false});
+  });
+
+  it('keeps dropping enabled when disabled.draggable is true', () => {
+    const sortable = createSortable('s1', 0);
+    sortable.disabled = {draggable: true};
+
+    expect(sortable.droppable.disabled).toBe(false);
+  });
+
+  it('keeps dragging enabled when disabled.droppable is true', () => {
+    const sortable = createSortable('s1', 0);
+    sortable.disabled = {droppable: true};
+
+    expect(sortable.draggable.disabled).toBe(false);
+  });
+
+  it('returns split disabled state when disabled.droppable is true', () => {
+    const sortable = createSortable('s1', 0);
+    sortable.disabled = {droppable: true};
+
+    expect(sortable.disabled).toEqual({draggable: false, droppable: true});
+  });
+
+  it('disables dropping when disabled.droppable is true', () => {
+    const sortable = createSortable('s1', 0);
+    sortable.disabled = {droppable: true};
+
+    expect(sortable.droppable.disabled).toBe(true);
+  });
+
+  it('disables dragging when both disabled flags are true', () => {
+    const sortable = createSortable('s1', 0);
+    sortable.disabled = {draggable: true, droppable: true};
+
+    expect(sortable.draggable.disabled).toBe(true);
+  });
+
+  it('disables dropping when both disabled flags are true', () => {
+    const sortable = createSortable('s1', 0);
+    sortable.disabled = {draggable: true, droppable: true};
+
+    expect(sortable.droppable.disabled).toBe(true);
+  });
+
+  it('clears sortable.disabled when disabled is reset to false', () => {
+    const sortable = createSortable('s1', 0);
+    sortable.disabled = {draggable: true, droppable: true};
+    sortable.disabled = false;
+
+    expect(sortable.disabled).toBe(false);
+  });
+
+  it('re-enables dragging when disabled is reset to false', () => {
+    const sortable = createSortable('s1', 0);
+    sortable.disabled = {draggable: true, droppable: true};
+    sortable.disabled = false;
+
+    expect(sortable.draggable.disabled).toBe(false);
+  });
+
+  it('re-enables dropping when disabled is reset to false', () => {
+    const sortable = createSortable('s1', 0);
+    sortable.disabled = {draggable: true, droppable: true};
+    sortable.disabled = false;
+
+    expect(sortable.droppable.disabled).toBe(false);
+  });
+});
+
+function createSortableWithDisabled(
+  disabled: boolean | {draggable?: boolean; droppable?: boolean}
+) {
+  return new Sortable(
+    {id: 's1', index: 0, disabled, plugins: [], transition: null},
+    undefined
+  );
+}

--- a/packages/react/src/sortable/useSortable.ts
+++ b/packages/react/src/sortable/useSortable.ts
@@ -84,7 +84,12 @@ export function useSortable<T extends Data = Data>(input: UseSortableInput<T>) {
   useOnElementChange(handle, (handle) => (sortable.handle = handle));
   useOnElementChange(element, (element) => (sortable.element = element));
   useOnElementChange(target, (target) => (sortable.target = target));
-  useOnValueChange(disabled, () => (sortable.disabled = disabled === true));
+  useOnValueChange(
+    disabled,
+    () => (sortable.disabled = disabled ?? false),
+    undefined,
+    deepEqual
+  );
   useOnValueChange(
     sensors,
     () => (sortable.sensors = sensors),


### PR DESCRIPTION
## Summary

Closes #1998.

Adds support for configuring sortable disabled state separately:

```ts
disabled: {
  draggable: true,
  droppable: false,
}
```

Boolean behavior is preserved:

```ts
disabled: true  // disables both
disabled: false // enables both
```

## Verification

- `bun test packages/dom/tests/sortable-utilities.test.ts`
- `bun run test`
- `bun run test:e2e`