### PR TITLE
fix(abstract): recompute transforms for drag operation snapshots (closes #2055)

### DIFF
--- a/.changeset/fast-wolves-reply.md
+++ b/.changeset/fast-wolves-reply.md
@@ -1,0 +1,5 @@
+---
+'@dnd-kit/abstract': patch
+---
+
+Fix drag operation snapshots to report current transforms when feedback is disabled.

--- a/packages/abstract/src/core/manager/actions.ts
+++ b/packages/abstract/src/core/manager/actions.ts
@@ -189,10 +189,12 @@ export class DragActions<
         return;
       }
 
-      const coordinates = args.to ?? {
-        x: dragOperation.position.current.x + (args.by?.x ?? 0),
-        y: dragOperation.position.current.y + (args.by?.y ?? 0),
-      };
+      const getCoordinates = () =>
+        args.to ?? {
+          x: dragOperation.position.current.x + (args.by?.x ?? 0),
+          y: dragOperation.position.current.y + (args.by?.y ?? 0),
+        };
+      const coordinates = getCoordinates();
 
       const event = defaultPreventable(
         {
@@ -213,7 +215,7 @@ export class DragActions<
           return;
         }
 
-        dragOperation.position.current = coordinates;
+        dragOperation.position.current = getCoordinates();
       });
     });
   }

--- a/packages/abstract/src/core/manager/actions.ts
+++ b/packages/abstract/src/core/manager/actions.ts
@@ -189,10 +189,15 @@ export class DragActions<
         return;
       }
 
+      const coordinates = args.to ?? {
+        x: dragOperation.position.current.x + (args.by?.x ?? 0),
+        y: dragOperation.position.current.y + (args.by?.y ?? 0),
+      };
+
       const event = defaultPreventable(
         {
           nativeEvent: args.event,
-          operation: dragOperation.snapshot(),
+          operation: dragOperation.snapshot(coordinates),
           by: args.by,
           to: args.to,
         },
@@ -207,11 +212,6 @@ export class DragActions<
         if (event.defaultPrevented) {
           return;
         }
-
-        const coordinates = args.to ?? {
-          x: dragOperation.position.current.x + (args.by?.x ?? 0),
-          y: dragOperation.position.current.y + (args.by?.y ?? 0),
-        };
 
         dragOperation.position.current = coordinates;
       });

--- a/packages/abstract/src/core/manager/operation.ts
+++ b/packages/abstract/src/core/manager/operation.ts
@@ -1,4 +1,4 @@
-import {Position, type Shape} from '@dnd-kit/geometry';
+import {Point, Position, type Shape} from '@dnd-kit/geometry';
 import type {Coordinates} from '@dnd-kit/geometry';
 import {
   batch,
@@ -162,15 +162,7 @@ export class DragOperation<T extends Draggable, U extends Droppable>
    */
   @derived
   public get transform() {
-    const {x, y} = this.position.delta;
-    let transform = {x, y};
-
-    for (const modifier of this.modifiers) {
-      transform = modifier.apply({
-        ...this.snapshot(),
-        transform,
-      });
-    }
+    const transform = this.computeTransform();
 
     this.#transform = transform;
 
@@ -182,17 +174,57 @@ export class DragOperation<T extends Draggable, U extends Droppable>
    *
    * @returns An immutable snapshot of the current operation state
    */
-  public snapshot(): DragOperationSnapshot<T, U> {
-    return untracked(() => ({
+  public snapshot(coordinates?: Coordinates): DragOperationSnapshot<T, U> {
+    return untracked(() => {
+      const transform = this.computeTransform(coordinates);
+
+      if (!coordinates || Point.equals(coordinates, this.position.current)) {
+        this.#transform = transform;
+      }
+
+      return this.createSnapshot(transform, coordinates);
+    });
+  }
+
+  private computeTransform(coordinates: Coordinates = this.position.current) {
+    const {initial} = this.position;
+    let transform = {
+      x: coordinates.x - initial.x,
+      y: coordinates.y - initial.y,
+    };
+
+    for (const modifier of this.modifiers) {
+      transform = modifier.apply(
+        untracked(() => this.createSnapshot(transform, coordinates))
+      );
+    }
+
+    return transform;
+  }
+
+  private createSnapshot(
+    transform: Coordinates,
+    coordinates = this.position.current
+  ): DragOperationSnapshot<T, U> {
+    const position = snapshot(this.position);
+
+    if (!Point.equals(coordinates, this.position.current)) {
+      Object.assign(position, {
+        current: coordinates,
+        previous: this.position.current,
+      });
+    }
+
+    return {
       source: this.source,
       target: this.target,
       activatorEvent: this.activatorEvent,
-      transform: this.#transform,
+      transform,
       shape: this.shape ? snapshot(this.shape) : null,
-      position: snapshot(this.position),
+      position,
       status: snapshot(this.status),
       canceled: this.canceled,
-    }));
+    };
   }
 
   /**

--- a/packages/abstract/tests/drag-operation-snapshot.test.ts
+++ b/packages/abstract/tests/drag-operation-snapshot.test.ts
@@ -1,0 +1,168 @@
+import {describe, expect, it} from 'bun:test';
+
+import {
+  DragDropManager,
+  Draggable,
+  Modifier,
+} from '../src/core/index.ts';
+
+function flush() {
+  return new Promise((resolve) => setTimeout(resolve, 10));
+}
+
+function point(coordinates: {x: number; y: number}) {
+  return {
+    x: coordinates.x,
+    y: coordinates.y,
+  };
+}
+
+class ClampXModifier extends Modifier {
+  public apply(operation: Parameters<Modifier['apply']>[0]) {
+    return {x: 0, y: operation.transform.y};
+  }
+}
+
+describe('Drag operation event snapshots', () => {
+  it('should expose the current transform in dragmove and dragend events without visual feedback', async () => {
+    const manager = new DragDropManager();
+    const draggable = new Draggable({id: 'd1', register: false}, manager);
+    const transforms: Array<{event: string; transform: {x: number; y: number}}> =
+      [];
+    let dragMovePosition: {x: number; y: number} | undefined;
+
+    draggable.register();
+
+    manager.monitor.addEventListener('dragstart', (event) => {
+      transforms.push({
+        event: 'dragstart',
+        transform: point(event.operation.transform),
+      });
+    });
+
+    manager.monitor.addEventListener('dragmove', (event) => {
+      transforms.push({
+        event: 'dragmove',
+        transform: point(event.operation.transform),
+      });
+      dragMovePosition = point(event.operation.position.current);
+    });
+
+    manager.monitor.addEventListener('dragend', (event) => {
+      transforms.push({
+        event: 'dragend',
+        transform: point(event.operation.transform),
+      });
+    });
+
+    manager.actions.start({source: draggable, coordinates: {x: 10, y: 20}});
+    await flush();
+
+    manager.actions.move({to: {x: 35, y: 65}});
+    await flush();
+
+    manager.actions.stop();
+    await flush();
+
+    expect(transforms).toEqual([
+      {event: 'dragstart', transform: {x: 0, y: 0}},
+      {event: 'dragmove', transform: {x: 25, y: 45}},
+      {event: 'dragend', transform: {x: 25, y: 45}},
+    ]);
+    expect(dragMovePosition).toEqual({x: 35, y: 65});
+
+    draggable.destroy();
+    manager.destroy();
+  });
+
+  it('should expose modified transforms in dragmove and dragend events', async () => {
+    const manager = new DragDropManager({modifiers: [ClampXModifier]});
+    const draggable = new Draggable({id: 'd1', register: false}, manager);
+    const transforms: Array<{event: string; transform: {x: number; y: number}}> =
+      [];
+
+    draggable.register();
+
+    manager.monitor.addEventListener('dragmove', (event) => {
+      transforms.push({
+        event: 'dragmove',
+        transform: point(event.operation.transform),
+      });
+    });
+
+    manager.monitor.addEventListener('dragend', (event) => {
+      transforms.push({
+        event: 'dragend',
+        transform: point(event.operation.transform),
+      });
+    });
+
+    manager.actions.start({source: draggable, coordinates: {x: 0, y: 0}});
+    await flush();
+
+    manager.actions.move({to: {x: 100, y: 50}});
+    await flush();
+
+    manager.actions.stop();
+    await flush();
+
+    expect(transforms).toEqual([
+      {event: 'dragmove', transform: {x: 0, y: 50}},
+      {event: 'dragend', transform: {x: 0, y: 50}},
+    ]);
+
+    draggable.destroy();
+    manager.destroy();
+  });
+
+  it('should not commit a prevented dragmove transform to the operation state', async () => {
+    const manager = new DragDropManager();
+    const draggable = new Draggable({id: 'd1', register: false}, manager);
+    const transforms: Array<{event: string; transform: {x: number; y: number}}> =
+      [];
+    let committedPosition: {x: number; y: number} | undefined;
+
+    draggable.register();
+
+    manager.monitor.addEventListener('dragmove', (event) => {
+      transforms.push({
+        event: 'dragmove',
+        transform: point(event.operation.transform),
+      });
+
+      if (event.to?.x === 20 && event.to.y === 20) {
+        event.preventDefault();
+      }
+    });
+
+    manager.monitor.addEventListener('dragend', (event) => {
+      transforms.push({
+        event: 'dragend',
+        transform: point(event.operation.transform),
+      });
+      committedPosition = point(event.operation.position.current);
+    });
+
+    manager.actions.start({source: draggable, coordinates: {x: 0, y: 0}});
+    await flush();
+
+    manager.actions.move({to: {x: 10, y: 10}});
+    await flush();
+
+    manager.actions.move({to: {x: 20, y: 20}});
+    await flush();
+
+    manager.actions.stop();
+    await flush();
+
+    expect(transforms).toEqual([
+      {event: 'dragmove', transform: {x: 10, y: 10}},
+      {event: 'dragmove', transform: {x: 20, y: 20}},
+      {event: 'dragend', transform: {x: 10, y: 10}},
+    ]);
+    expect(committedPosition).toEqual({x: 10, y: 10});
+
+    draggable.destroy();
+    manager.destroy();
+  });
+});

--- a/packages/abstract/tests/drag-operation-snapshot.test.ts
+++ b/packages/abstract/tests/drag-operation-snapshot.test.ts
@@ -165,4 +165,34 @@ describe('Drag operation event snapshots', () => {
     draggable.destroy();
     manager.destroy();
   });
+
+  it('should accumulate relative moves queued in the same tick', async () => {
+    const manager = new DragDropManager();
+    const draggable = new Draggable({id: 'd1', register: false}, manager);
+    let dragEndTransform: {x: number; y: number} | undefined;
+    let committedPosition: {x: number; y: number} | undefined;
+
+    draggable.register();
+
+    manager.monitor.addEventListener('dragend', (event) => {
+      dragEndTransform = point(event.operation.transform);
+      committedPosition = point(event.operation.position.current);
+    });
+
+    manager.actions.start({source: draggable, coordinates: {x: 0, y: 0}});
+    await flush();
+
+    manager.actions.move({by: {x: 10, y: 0}});
+    manager.actions.move({by: {x: 5, y: 0}});
+    await flush();
+
+    manager.actions.stop();
+    await flush();
+
+    expect(dragEndTransform).toEqual({x: 15, y: 0});
+    expect(committedPosition).toEqual({x: 15, y: 0});
+
+    draggable.destroy();
+    manager.destroy();
+  });
 });

--- a/packages/dom/tests/feedback-none-transform.test.ts
+++ b/packages/dom/tests/feedback-none-transform.test.ts
@@ -1,0 +1,60 @@
+import {describe, expect, it} from 'bun:test';
+
+import {DragDropManager, Draggable} from '../../abstract/src/core/index.ts';
+import {Feedback} from '../src/core/plugins/feedback/index.ts';
+
+function flush() {
+  return new Promise((resolve) => setTimeout(resolve, 10));
+}
+
+function point(coordinates: {x: number; y: number}) {
+  return {
+    x: coordinates.x,
+    y: coordinates.y,
+  };
+}
+
+describe('Feedback none event snapshots', () => {
+  it('should not disable operation transform updates', async () => {
+    const manager = new DragDropManager({
+      plugins: [Feedback.configure({feedback: 'none'})],
+    });
+    const draggable = new Draggable({id: 'd1', register: false}, manager);
+    const transforms: Array<{event: string; transform: {x: number; y: number}}> =
+      [];
+
+    (draggable as unknown as {element: Element}).element = {} as Element;
+    draggable.register();
+
+    manager.monitor.addEventListener('dragmove', (event) => {
+      transforms.push({
+        event: 'dragmove',
+        transform: point(event.operation.transform),
+      });
+    });
+
+    manager.monitor.addEventListener('dragend', (event) => {
+      transforms.push({
+        event: 'dragend',
+        transform: point(event.operation.transform),
+      });
+    });
+
+    manager.actions.start({source: draggable, coordinates: {x: 5, y: 5}});
+    await flush();
+
+    manager.actions.move({to: {x: 20, y: 30}});
+    await flush();
+
+    manager.actions.stop();
+    await flush();
+
+    expect(transforms).toEqual([
+      {event: 'dragmove', transform: {x: 15, y: 25}},
+      {event: 'dragend', transform: {x: 15, y: 25}},
+    ]);
+
+    draggable.destroy();
+    manager.destroy();
+  });
+});


### PR DESCRIPTION
## Summary

Closes #2055.

This fixes drag operation event snapshots so `event.operation.transform` is kept up to date even when visual feedback is disabled with `Feedback.configure({feedback: 'none'})`.

The root cause was that `DragOperation.snapshot()` returned the cached transform, while the cache was normally refreshed as a side effect of the `Feedback` plugin reading `dragOperation.transform`. When feedback was disabled, that side effect never happened.

## Changes

- Recompute transforms in `DragOperation.snapshot()` instead of relying on a stale cached value.
- Snapshot proposed coordinates for `dragmove` events before the move is committed, while preserving `preventDefault()` behavior.
- Preserve same-tick relative move accumulation for queued `by` moves.
- Add abstract regression tests for transform snapshots, modifiers, prevented moves, and queued relative moves.
- Add DOM coverage for `Feedback.configure({feedback: 'none'})`.
- Add a patch changeset for `@dnd-kit/abstract`.

## Testing

- `bun test packages/abstract/tests`
- `bun test packages/dom/tests`
- `bunx tsc --noEmit -p packages/abstract/tsconfig.json`

## Notes

No stories or docs were added because this is a bug fix to existing event snapshot behavior, not a new feature or API.