### PR TITLE
fix(docs): fix malformed navigation links in plugins and sensors section

### DIFF
--- a/apps/docs/docs/extend/plugins.mdx
+++ b/apps/docs/docs/extend/plugins.mdx
@@ -17,42 +17,42 @@ Several plugins are included by default when creating a new `DragDropManager`:
   <Card
     title="Accessibility"
     icon="universal-access"
-    href="./plugins/accessibility"
+    href="/extend/plugins/accessibility"
   >
     Manages ARIA attributes and screen reader announcements for drag and drop operations.
   </Card>
   <Card
     title="AutoScroller"
     icon="arrows-up-down"
-    href="./plugins/auto-scroller"
+    href="/extend/plugins/auto-scroller"
   >
     Automatically scrolls containers when dragging near edges.
   </Card>
   <Card
     title="Cursor"
     icon="arrow-pointer"
-    href="./plugins/cursor"
+    href="/extend/plugins/cursor"
   >
     Updates cursor styles during drag operations.
   </Card>
   <Card
     title="Debug"
     icon="bug"
-    href="./plugins/debug"
+    href="/extend/plugins/debug"
   >
     Visualize drag shapes, droppable zones, and collisions for debugging.
   </Card>
   <Card
     title="Feedback"
     icon="eye"
-    href="./plugins/feedback"
+    href="/extend/plugins/feedback"
   >
     Manages visual feedback during dragging, including top layer promotion and drop animations.
   </Card>
   <Card
     title="StyleInjector"
     icon="palette"
-    href="./plugins/style-injector"
+    href="/extend/plugins/style-injector"
   >
     Centralized style injection with CSP nonce support.
   </Card>

--- a/apps/docs/docs/extend/sensors.mdx
+++ b/apps/docs/docs/extend/sensors.mdx
@@ -17,14 +17,14 @@ The `@dnd-kit/dom` package provides a set of built-in sensors that can be used t
   <Card
     title="Pointer"
     icon="arrow-pointer"
-    href="./sensors/pointer-sensor"
+    href="/extend/sensors/pointer-sensor"
   >
     Handles mouse, touch, and pen input with configurable activation constraints.
   </Card>
   <Card
     title="Keyboard"
     icon="keyboard"
-    href="./sensors/keyboard-sensor"
+    href="/extend/sensors/keyboard-sensor"
   >
     Enables keyboard navigation and activation using customizable key bindings.
   </Card>


### PR DESCRIPTION
Replace relative href paths with absolute paths in plugins.mdx and sensors.mdx Card components to resolve incorrect URL generation.

I tested it with mintlify and it works correctly.