### PR TITLE
Update sensor links in documentation

### DIFF
--- a/apps/docs/docs/extend/sensors.mdx
+++ b/apps/docs/docs/extend/sensors.mdx
@@ -17,14 +17,14 @@ The `@dnd-kit/dom` package provides a set of built-in sensors that can be used t
   <Card
     title="Pointer"
     icon="arrow-pointer"
-    href="./sensors/pointer-sensor"
+    href="./pointer-sensor"
   >
     Handles mouse, touch, and pen input with configurable activation constraints.
   </Card>
   <Card
     title="Keyboard"
     icon="keyboard"
-    href="./sensors/keyboard-sensor"
+    href="./keyboard-sensor"
   >
     Enables keyboard navigation and activation using customizable key bindings.
   </Card>


### PR DESCRIPTION
Updated the `href` attributes in the sensor documentation cards to point directly to `./pointer-sensor` and `./keyboard-sensor` instead of the previous nested paths, which would lead to a 404 page.