### PR TITLE
Fix grouped record sorting with numeric group IDs

### DIFF
--- a/.changeset/proud-socks-film.md
+++ b/.changeset/proud-socks-film.md
@@ -1,0 +1,5 @@
+---
+'@dnd-kit/helpers': patch
+---
+
+Fix grouped record sorting with numeric group IDs

--- a/packages/helpers/src/move.ts
+++ b/packages/helpers/src/move.ts
@@ -48,6 +48,19 @@ export function arraySwap<T extends any[]>(
 type Items = UniqueIdentifier[] | {id: UniqueIdentifier}[];
 
 /**
+ * Resolve a grouped record key from a UniqueIdentifier.
+ * Object keys are strings at runtime, even when sortable groups use numeric IDs.
+ */
+function getRecordKey(
+  items: Record<UniqueIdentifier, Items>,
+  id: UniqueIdentifier
+) {
+  const key = String(id);
+
+  return Object.prototype.hasOwnProperty.call(items, key) ? key : undefined;
+}
+
+/**
  * Check if the source has sortable index properties via duck typing.
  * The `move` helper lives in `@dnd-kit/helpers` which has no dependency on `@dnd-kit/dom`,
  * so we discover sortable properties at runtime.
@@ -154,17 +167,16 @@ function mutate<
   // Fallback: when the ID-based lookup fails for the source (e.g. computed IDs),
   // use the sortable index properties directly.
   if (sourceIndex === -1 && hasSortableIndices(source)) {
-    const srcParent = source.initialGroup;
+    const srcParent =
+      source.initialGroup == null
+        ? undefined
+        : getRecordKey(items, source.initialGroup);
     const srcIndex = source.initialIndex;
-    const tgtParent = source.group;
+    const tgtParent =
+      source.group == null ? undefined : getRecordKey(items, source.group);
     const tgtIndex = source.index;
 
-    if (
-      srcParent == null ||
-      tgtParent == null ||
-      !(srcParent in items) ||
-      !(tgtParent in items)
-    ) {
+    if (srcParent == null || tgtParent == null) {
       if ('preventDefault' in event) event.preventDefault();
       return items;
     }
@@ -205,14 +217,16 @@ function mutate<
     dragOperation.shape?.current.center ?? dragOperation.position.current;
 
   if (targetParent == null) {
-    if (target.id in items) {
+    const targetKey = getRecordKey(items, target.id);
+
+    if (targetKey != null) {
       const insertionIndex =
         target.shape && position.y > target.shape.center.y
-          ? items[target.id].length
+          ? items[targetKey].length
           : 0;
 
       // The target does not have any matching children, but appears to be a valid target
-      targetParent = target.id;
+      targetParent = targetKey;
       targetIndex = insertionIndex;
     }
   }
@@ -232,14 +246,17 @@ function mutate<
       sourceIndex === targetIndex &&
       hasSortableIndices(source)
     ) {
+      const sourceGroupParent =
+        source.group == null ? undefined : getRecordKey(items, source.group);
       const hasGroupChanged =
-        source.group != null && source.group !== sourceParent;
+        source.group != null && sourceGroupParent !== sourceParent;
       const hasIndexChanged = source.index !== sourceIndex;
 
       if (hasGroupChanged || hasIndexChanged) {
-        const reconciledTargetParent = source.group ?? sourceParent;
+        const reconciledTargetParent =
+          source.group == null ? sourceParent : sourceGroupParent;
 
-        if (reconciledTargetParent in items) {
+        if (reconciledTargetParent != null) {
           if (sourceParent === reconciledTargetParent) {
             return {
               ...items,

--- a/packages/helpers/tests/move.test.ts
+++ b/packages/helpers/tests/move.test.ts
@@ -312,6 +312,30 @@ describe('move – grouped record, ID-based fallback', () => {
     });
   });
 
+  it('should move to the end of the same numeric group when targeting the group container', () => {
+    const items = {
+      240: [24001, 24002, 24003],
+      241: [24101, 24102],
+    };
+    const source = mockSource(24001);
+    source.manager = {
+      dragOperation: {
+        position: {current: {x: 0, y: 1000}},
+        shape: null,
+      },
+    };
+    const target = mockTarget(240);
+    target.shape = {
+      center: {x: 0, y: 0},
+    };
+    const event = dragOverEvent(source, target);
+
+    expect(move(items, event)).toEqual({
+      240: [24002, 24003, 24001],
+      241: [24101, 24102],
+    });
+  });
+
   it('should return unchanged when source not found in any group', () => {
     const items = {
       A: ['a1', 'a2'],
@@ -359,6 +383,32 @@ describe('move – grouped record, optimistic reconciliation', () => {
     expect(move(items, event)).toEqual({
       A: ['a2', 'a3', 'a1'],
       B: ['b1', 'b2'],
+    });
+  });
+
+  it('should reconcile same-group reorder when group IDs are numbers', () => {
+    const items = {
+      240: [24001, 24002, 24003],
+      241: [24101, 24102],
+    };
+    const source = mockSortableSource({
+      id: 24001,
+      initialIndex: 0,
+      index: 2,
+      initialGroup: 240,
+      group: 240,
+    });
+    source.manager = {
+      dragOperation: {
+        position: {current: {x: 0, y: 0}},
+        shape: null,
+      },
+    };
+    const event = dragOverEvent(source, mockTarget(24001));
+
+    expect(move(items, event)).toEqual({
+      240: [24002, 24003, 24001],
+      241: [24101, 24102],
     });
   });
 


### PR DESCRIPTION
## Summary

Fixes grouped record handling in `move()` when sortable group IDs are numbers. Since object record keys are strings at runtime, numeric group IDs could fail parent/group comparisons and cause incorrect optimistic reconciliation, including duplicated items.

This change normalizes grouped record keys before comparing or indexing parent groups.

Closes #2065.

## Changes

- Normalize grouped record keys in `packages/helpers/src/move.ts`
- Fix numeric group handling for group-container targets
- Fix optimistic same-group reconciliation when group IDs are numbers
- Add regression tests for numeric grouped records
- Add a patch changeset for `@dnd-kit/helpers`

## Testing

- `bun test packages/helpers/tests/move.test.ts`
- `bun run --cwd packages/helpers build`