### PR TITLE
Fix modifiers import without ResizeObserver (closes #2060)

### DIFF
--- a/.changeset/fresh-teeth-kiss.md
+++ b/.changeset/fresh-teeth-kiss.md
@@ -1,0 +1,5 @@
+---
+'@dnd-kit/dom': patch
+---
+
+Avoid requiring ResizeObserver at import time when importing @dnd-kit/dom/modifiers in DOM-like test environments.

--- a/packages/dom/src/utilities/observers/ResizeNotifier.ts
+++ b/packages/dom/src/utilities/observers/ResizeNotifier.ts
@@ -1,12 +1,11 @@
-import {canUseDOM} from '../execution-context/canUseDOM.ts';
-
-const Observer = canUseDOM
-  ? ResizeObserver
-  : class MockResizeObserver implements ResizeObserver {
-      observe() {}
-      unobserve() {}
-      disconnect() {}
-    };
+const Observer =
+  typeof ResizeObserver !== 'undefined'
+    ? ResizeObserver
+    : class MockResizeObserver implements ResizeObserver {
+        observe() {}
+        unobserve() {}
+        disconnect() {}
+      };
 
 export class ResizeNotifier extends Observer {
   #initialized = false;

--- a/packages/dom/tests/modifiers-import.test.ts
+++ b/packages/dom/tests/modifiers-import.test.ts
@@ -1,0 +1,22 @@
+import {describe, expect, it} from 'bun:test';
+import {spawnSync} from 'node:child_process';
+
+describe('@dnd-kit/dom/modifiers', () => {
+  it('can be imported in DOM-like environments without ResizeObserver', () => {
+    const script = `
+      globalThis.window = {document: {createElement() { return {}; }}};
+      globalThis.document = globalThis.window.document;
+      delete globalThis.ResizeObserver;
+
+      await import('@dnd-kit/dom/modifiers');
+    `;
+
+    const result = spawnSync(process.execPath, ['--eval', script], {
+      cwd: process.cwd(),
+      encoding: 'utf8',
+    });
+
+    expect(result.stderr).toBe('');
+    expect(result.status).toBe(0);
+  });
+});


### PR DESCRIPTION
Fixes #2060

## Summary

- Avoid requiring `ResizeObserver` at import time when importing `@dnd-kit/dom/modifiers`
- Add a regression test for DOM-like test environments without `ResizeObserver`
- Add a patch changeset for `@dnd-kit/dom`

## Testing

- `bun test packages/dom/tests`