### PR TITLE
fix(dom): guard parseScale/parseTranslate against undefined transform…

### DIFF
--- a/.changeset/fix-parse-transform-undefined.md
+++ b/.changeset/fix-parse-transform-undefined.md
@@ -1,0 +1,5 @@
+---
+"@dnd-kit/dom": patch
+---
+
+Fix `TypeError: Cannot read properties of undefined (reading 'split')` in `parseScale`/`parseTranslate` on browsers that do not support the individual `scale`/`translate` CSS transform properties (Chromium < 104), where `getComputedStyle` returns `undefined` instead of `'none'`.

--- a/packages/dom/src/utilities/transform/parseScale.ts
+++ b/packages/dom/src/utilities/transform/parseScale.ts
@@ -1,5 +1,5 @@
-export function parseScale(scale: string) {
-  if (scale === 'none') {
+export function parseScale(scale?: string) {
+  if (!scale || scale === 'none') {
     return null;
   }
 

--- a/packages/dom/src/utilities/transform/parseTransform.ts
+++ b/packages/dom/src/utilities/transform/parseTransform.ts
@@ -10,9 +10,9 @@ export interface Transform extends Coordinates {
 }
 
 export function parseTransform(computedStyles: {
-  scale: string;
+  scale?: string;
   transform: string;
-  translate: string;
+  translate?: string;
 }): Transform | null {
   const {scale, transform, translate} = computedStyles;
   const parsedScale = parseScale(scale);

--- a/packages/dom/src/utilities/transform/parseTranslate.ts
+++ b/packages/dom/src/utilities/transform/parseTranslate.ts
@@ -1,5 +1,5 @@
-export function parseTranslate(translate: string) {
-  if (translate === 'none') {
+export function parseTranslate(translate?: string) {
+  if (!translate || translate === 'none') {
     return null;
   }
 


### PR DESCRIPTION
… values

`getComputedStyle(el).scale` / `.translate` return `undefined` on engines that do not support the individual `scale`/`translate` CSS transform properties (e.g. Chromium < 104). The existing guard only handled the string `'none'`, so `scale.split(' ')` threw "Cannot read properties of undefined (reading 'split')" during drag (via PositionObserver -> DOMRectangle -> parseTransform). Treat a missing value the same as `'none'`.

Closes #2078