### PR TITLE
Fix issue where constraints broke when resizing the child element

### DIFF
--- a/.changeset/soft-lands-smoke.md
+++ b/.changeset/soft-lands-smoke.md
@@ -1,0 +1,5 @@
+---
+'@dnd-kit/dom': patch
+---
+
+Fix bug where dom constraints would not work properly when a draggable is resized during a drag operation

--- a/packages/dom/src/modifiers/RestrictToElement.ts
+++ b/packages/dom/src/modifiers/RestrictToElement.ts
@@ -2,6 +2,7 @@ import {Modifier, configurator} from '@dnd-kit/abstract';
 import {restrictShapeToBoundingRectangle} from '@dnd-kit/abstract/modifiers';
 import {BoundingRectangle, Rectangle} from '@dnd-kit/geometry';
 import {effect, signal} from '@dnd-kit/state';
+import type {Coordinates} from '@dnd-kit/geometry';
 import type {DragDropManager} from '@dnd-kit/dom';
 import {getBoundingRectangle} from '@dnd-kit/dom/utilities';
 
@@ -14,6 +15,7 @@ interface Options {
 
 export class RestrictToElement extends Modifier<DragDropManager, Options> {
   private boundingRectangle = signal<BoundingRectangle | null>(null);
+  private previousConstrainedTransform: Coordinates = {x: 0, y: 0};
 
   constructor(manager: DragDropManager, options?: Options) {
     super(manager, options);
@@ -27,6 +29,8 @@ export class RestrictToElement extends Modifier<DragDropManager, Options> {
       const {status} = dragOperation;
 
       if (status.initialized) {
+        this.previousConstrainedTransform = {x: 0, y: 0};
+
         const {element} = this.options;
         const target =
           typeof element === 'function' ? element(dragOperation) : element;
@@ -82,17 +86,19 @@ export class RestrictToElement extends Modifier<DragDropManager, Options> {
       return transform;
     }
 
-    const {initial, current} = shape;
-    const {height, width} = current.boundingRectangle;
-    const left = initial.center.x - width / 2;
-    const top = initial.center.y - height / 2;
+    const {current} = shape;
+    const {left, top, width, height} = current.boundingRectangle;
+
+    const baseLeft = left - this.previousConstrainedTransform.x;
+    const baseTop = top - this.previousConstrainedTransform.y;
 
     const restrictedTransform = restrictShapeToBoundingRectangle(
-      new Rectangle(left, top, width, height),
+      new Rectangle(baseLeft, baseTop, width, height),
       transform,
       boundingRectangle
     );
 
+    this.previousConstrainedTransform = restrictedTransform;
     return restrictedTransform;
   }
 

--- a/packages/dom/src/modifiers/RestrictToWindow.ts
+++ b/packages/dom/src/modifiers/RestrictToWindow.ts
@@ -1,7 +1,7 @@
 import {effect, untracked} from '@dnd-kit/state';
 import {Modifier, type DragOperation} from '@dnd-kit/abstract';
 import {restrictShapeToBoundingRectangle} from '@dnd-kit/abstract/modifiers';
-import {Rectangle, type BoundingRectangle} from '@dnd-kit/geometry';
+import {Rectangle, type BoundingRectangle, type Coordinates} from '@dnd-kit/geometry';
 import type {DragDropManager} from '@dnd-kit/dom';
 import {getViewportBoundingRectangle} from '@dnd-kit/dom/utilities';
 
@@ -21,9 +21,11 @@ export class RestrictToWindow extends Modifier<DragDropManager> {
 
     this.destroy = effect(() => {
       if (dragOperation.status.idle) {
+        this.previousConstrainedTransform = {x: 0, y: 0};
         return;
       }
 
+      this.previousConstrainedTransform = {x: 0, y: 0};
       getWindowBoundingRectangle();
 
       window.addEventListener('resize', getWindowBoundingRectangle);
@@ -35,23 +37,26 @@ export class RestrictToWindow extends Modifier<DragDropManager> {
   }
 
   windowBoundingRectangle: BoundingRectangle | undefined;
+  private previousConstrainedTransform: Coordinates = {x: 0, y: 0};
 
   apply({shape, transform}: DragOperation) {
     if (!this.windowBoundingRectangle || !shape) {
       return transform;
     }
 
-    const {initial, current} = shape;
-    const {height, width} = current.boundingRectangle;
-    const left = initial.center.x - width / 2;
-    const top = initial.center.y - height / 2;
+    const {current} = shape;
+    const {left, top, width, height} = current.boundingRectangle;
+
+    const baseLeft = left - this.previousConstrainedTransform.x;
+    const baseTop = top - this.previousConstrainedTransform.y;
 
     const restrictedTransform = restrictShapeToBoundingRectangle(
-      new Rectangle(left, top, width, height),
+      new Rectangle(baseLeft, baseTop, width, height),
       transform,
       this.windowBoundingRectangle
     );
 
+    this.previousConstrainedTransform = restrictedTransform;
     return restrictedTransform;
   }
 }


### PR DESCRIPTION
Hello, this fixes #2056. It uses information from the existing mutation/resize observers to properly handle constrained nodes resizing during a drag operation. Since those observers already exist it is cheap in terms of performance

Thanks