### PR TITLE
fix(abstract): preserve initial dragstart target (closes #2054)

### DIFF
--- a/.changeset/brown-rooms-push.md
+++ b/.changeset/brown-rooms-push.md
@@ -1,0 +1,5 @@
+---
+'@dnd-kit/abstract': patch
+---
+
+Fix `dragstart` events so `operation.target` includes the initial droppable target while preserving `dragstart` before `dragover` ordering and queued `setDropTarget()` completion semantics.

--- a/packages/abstract/src/core/manager/actions.ts
+++ b/packages/abstract/src/core/manager/actions.ts
@@ -8,8 +8,18 @@ import type {
 } from '../entities/index.ts';
 
 import type {DragDropManager} from './manager.ts';
-import {defaultPreventable} from './events.ts';
+import {defaultPreventable, type DragOverEvent} from './events.ts';
 import {StatusValue} from './status.ts';
+
+type DeferredDragOverEvent<
+  T extends Draggable,
+  U extends Droppable,
+  V extends DragDropManager<T, U>,
+> = {
+  event: DragOverEvent<T, U, V>;
+  resolve(value: boolean): void;
+  reject(reason?: unknown): void;
+};
 
 /**
  * Provides actions for controlling drag and drop operations.
@@ -29,6 +39,75 @@ export class DragActions<
    * @param manager - The drag and drop manager instance
    */
   constructor(private readonly manager: V) {}
+
+  #deferredDragOverEvents: DeferredDragOverEvent<T, U, V>[] | null = null;
+
+  #dispatchDragOver(event: DragOverEvent<T, U, V>): Promise<boolean> {
+    const deferredEvents = this.#deferredDragOverEvents;
+
+    if (deferredEvents) {
+      return new Promise<boolean>((resolve, reject) => {
+        deferredEvents.push({event, resolve, reject});
+      });
+    }
+
+    return this.#dispatchDragOverNow(event);
+  }
+
+  #dispatchDragOverNow(event: DragOverEvent<T, U, V>): Promise<boolean> {
+    this.manager.monitor.dispatch('dragover', event);
+    return this.manager.renderer.rendering.then(() => event.defaultPrevented);
+  }
+
+  #flushDeferredDragOverEvents() {
+    const events = this.#deferredDragOverEvents;
+    this.#deferredDragOverEvents = null;
+
+    if (!events) {
+      return;
+    }
+
+    let error: unknown;
+
+    for (const {event, resolve, reject} of events) {
+      try {
+        this.#dispatchDragOverNow(event).then(resolve, reject);
+      } catch (reason) {
+        error ??= reason;
+        reject(reason);
+      }
+    }
+
+    if (error) {
+      throw error;
+    }
+  }
+
+  #resolveDeferredDragOverEvents(value: boolean) {
+    const events = this.#deferredDragOverEvents;
+    this.#deferredDragOverEvents = null;
+
+    if (!events) {
+      return;
+    }
+
+    for (const {resolve} of events) {
+      resolve(value);
+    }
+  }
+
+  #rejectDeferredDragOverEvents(reason: unknown) {
+    const events = this.#deferredDragOverEvents;
+    this.#deferredDragOverEvents = null;
+
+    if (!events) {
+      return;
+    }
+
+    for (const {reject} of events) {
+      reject(reason);
+    }
+  }
 
   /**
    * Sets the source of the drag operation.
@@ -67,7 +146,7 @@ export class DragActions<
       });
 
       if (dragOperation.status.dragging) {
-        this.manager.monitor.dispatch('dragover', event);
+        return this.#dispatchDragOver(event);
       }
 
       return this.manager.renderer.rendering.then(() => event.defaultPrevented);
@@ -144,14 +223,41 @@ export class DragActions<
         const {status} = dragOperation;
         if (status.current !== StatusValue.Initializing) return;
 
-        batch(() => {
-          dragOperation.status.set(StatusValue.Dragging);
+        this.#deferredDragOverEvents = [];
 
-          this.manager.monitor.dispatch('dragstart', {
-            nativeEvent,
-            operation: dragOperation.snapshot(),
-            cancelable: false,
-          });
+        dragOperation.status.set(StatusValue.Dragging);
+
+        // Let start-time collision effects populate the initial target before
+        // dragstart, while keeping dragover ordered after dragstart.
+        queueMicrotask(() => {
+          try {
+            if (
+              controller.signal.aborted ||
+              dragOperation.status.current !== StatusValue.Dragging
+            ) {
+              this.#resolveDeferredDragOverEvents(false);
+              return;
+            }
+
+            this.manager.monitor.dispatch('dragstart', {
+              nativeEvent,
+              operation: dragOperation.snapshot(),
+              cancelable: false,
+            });
+
+            if (
+              controller.signal.aborted ||
+              dragOperation.status.current !== StatusValue.Dragging
+            ) {
+              this.#resolveDeferredDragOverEvents(false);
+              return;
+            }
+
+            this.#flushDeferredDragOverEvents();
+          } catch (error) {
+            this.#rejectDeferredDragOverEvents(error);
+            throw error;
+          }
         });
       });
 

--- a/packages/abstract/tests/drag-event-order.test.ts
+++ b/packages/abstract/tests/drag-event-order.test.ts
@@ -14,52 +14,64 @@ function flush() {
   return new Promise((resolve) => setTimeout(resolve, 10));
 }
 
+function setupCollidingDraggable(
+  manager: DragDropManager<Draggable, Droppable>
+) {
+  // Create draggable and droppable with the same id (as in the reported bug)
+  const draggable = new Draggable({id: 'item', register: false}, manager);
+  draggable.register();
+
+  const droppable = new Droppable(
+    {
+      id: 'item',
+      register: false,
+      collisionDetector: ({droppable}) => ({
+        id: droppable.id,
+        value: 1,
+        type: CollisionType.ShapeIntersection,
+        priority: CollisionPriority.Normal,
+      }),
+    },
+    manager
+  );
+  droppable.shape = new Rectangle(0, 0, 100, 100);
+  droppable.register();
+
+  // Mimic the Feedback plugin's behavior: it only sets the drag shape
+  // when status is initialized AND not initializing (i.e., when Dragging).
+  // See: packages/dom/src/core/plugins/feedback/Feedback.ts lines 136-143
+  const dispose = effects(() => {
+    const {status} = manager.dragOperation;
+
+    if (status.initialized && !status.initializing) {
+      manager.dragOperation.shape = new Rectangle(0, 0, 100, 100);
+    }
+  });
+
+  return {dispose, draggable, droppable};
+}
+
 describe('Drag event ordering', () => {
   it('should fire dragstart before dragover when element is both draggable and droppable', async () => {
     const manager = new DragDropManager();
     const events: string[] = [];
+    let dragStartTarget: string | number | null | undefined;
+    let dragOverTarget: string | number | null | undefined;
 
     // Listen for all drag events
     manager.monitor.addEventListener('beforedragstart', () => {
       events.push('beforedragstart');
     });
-    manager.monitor.addEventListener('dragstart', () => {
+    manager.monitor.addEventListener('dragstart', (event) => {
       events.push('dragstart');
+      dragStartTarget = event.operation.target?.id;
     });
-    manager.monitor.addEventListener('dragover', () => {
+    manager.monitor.addEventListener('dragover', (event) => {
       events.push('dragover');
+      dragOverTarget = event.operation.target?.id;
     });
 
-    // Create draggable and droppable with the same id (as in the reported bug)
-    const draggable = new Draggable({id: 'item', register: false}, manager);
-    draggable.register();
-
-    const droppable = new Droppable(
-      {
-        id: 'item',
-        register: false,
-        collisionDetector: ({droppable}) => ({
-          id: droppable.id,
-          value: 1,
-          type: CollisionType.ShapeIntersection,
-          priority: CollisionPriority.Normal,
-        }),
-      },
-      manager
-    );
-    droppable.shape = new Rectangle(0, 0, 100, 100);
-    droppable.register();
-
-    // Mimic the Feedback plugin's behavior: it only sets the drag shape
-    // when status is initialized AND not initializing (i.e., when Dragging).
-    // See: packages/dom/src/core/plugins/feedback/Feedback.ts lines 136-143
-    const dispose = effects(() => {
-      const {status} = manager.dragOperation;
-
-      if (status.initialized && !status.initializing) {
-        manager.dragOperation.shape = new Rectangle(0, 0, 100, 100);
-      }
-    });
+    const {dispose, draggable, droppable} = setupCollidingDraggable(manager);
 
     // Start drag operation
     manager.actions.start({
@@ -77,8 +89,109 @@ describe('Drag event ordering', () => {
     expect(dragStartIndex).not.toBe(-1);
     expect(dragOverIndex).not.toBe(-1);
     expect(dragStartIndex).toBeLessThan(dragOverIndex);
+    expect(dragStartTarget).toBe('item');
+    expect(dragOverTarget).toBe('item');
 
     // Clean up
+    manager.actions.stop();
+    await flush();
+    dispose();
+    draggable.destroy();
+    droppable.destroy();
+    manager.destroy();
+  });
+
+  it('should not fire queued dragover when dragstart stops the operation', async () => {
+    const manager = new DragDropManager();
+    const events: string[] = [];
+    let dragStartTarget: string | number | null | undefined;
+
+    manager.monitor.addEventListener('dragstart', (event) => {
+      events.push('dragstart');
+      dragStartTarget = event.operation.target?.id;
+      manager.actions.stop();
+    });
+    manager.monitor.addEventListener('dragover', () => {
+      events.push('dragover');
+    });
+
+    const {dispose, draggable, droppable} = setupCollidingDraggable(manager);
+
+    manager.actions.start({
+      source: draggable,
+      coordinates: {x: 50, y: 50},
+    });
+
+    await flush();
+
+    expect(dragStartTarget).toBe('item');
+    expect(events).toEqual(['dragstart']);
+
+    await flush();
+    dispose();
+    draggable.destroy();
+    droppable.destroy();
+    manager.destroy();
+  });
+
+  it('should resolve queued setDropTarget after dragover dispatches', async () => {
+    const events: string[] = [];
+    const renderingSnapshots: string[] = [];
+    const manager = new DragDropManager({
+      renderer: {
+        get rendering() {
+          renderingSnapshots.push(events.join('|'));
+          return Promise.resolve();
+        },
+      },
+    });
+    let targetPromise: Promise<boolean> | undefined;
+    let targetPromiseResolved = false;
+
+    const draggable = new Draggable({id: 'item', register: false}, manager);
+    draggable.register();
+
+    const droppable = new Droppable(
+      {
+        id: 'target',
+        register: false,
+        collisionDetector: () => null,
+      },
+      manager
+    );
+    droppable.register();
+
+    const dispose = effects(() => {
+      if (manager.dragOperation.status.dragging && !targetPromise) {
+        targetPromise = manager.actions.setDropTarget(droppable.id);
+        targetPromise.then(() => {
+          targetPromiseResolved = true;
+        });
+      }
+    });
+
+    manager.monitor.addEventListener('dragstart', () => {
+      events.push('dragstart');
+    });
+    manager.monitor.addEventListener('dragover', (event) => {
+      events.push('dragover');
+      expect(targetPromiseResolved).toBe(false);
+      event.preventDefault();
+    });
+
+    manager.actions.start({
+      source: draggable,
+      coordinates: {x: 50, y: 50},
+    });
+
+    await flush();
+
+    expect(targetPromise).toBeDefined();
+    expect(events).toEqual(['dragstart', 'dragover']);
+    expect(renderingSnapshots[1]).toBe('dragstart|dragover');
+    expect(await targetPromise!).toBe(true);
+    expect(targetPromiseResolved).toBe(true);
+
     manager.actions.stop();
     await flush();
     dispose();

--- a/packages/abstract/tests/drag-event-order.test.ts
+++ b/packages/abstract/tests/drag-event-order.test.ts
@@ -134,6 +134,38 @@ describe('Drag event ordering', () => {
     manager.destroy();
   });
 
+  it('should start without a target when there is no initial droppable', async () => {
+    const manager = new DragDropManager();
+    const events: string[] = [];
+    let dragStartTarget: Droppable | null | undefined;
+
+    manager.monitor.addEventListener('dragstart', (event) => {
+      events.push('dragstart');
+      dragStartTarget = event.operation.target;
+    });
+    manager.monitor.addEventListener('dragover', () => {
+      events.push('dragover');
+    });
+
+    const draggable = new Draggable({id: 'item', register: false}, manager);
+    draggable.register();
+
+    manager.actions.start({
+      source: draggable,
+      coordinates: {x: 50, y: 50},
+    });
+
+    await flush();
+
+    expect(events).toEqual(['dragstart']);
+    expect(dragStartTarget).toBeNull();
+
+    manager.actions.stop();
+    await flush();
+    draggable.destroy();
+    manager.destroy();
+  });
+
   it('should resolve queued setDropTarget after dragover dispatches', async () => {
     const events: string[] = [];
     const renderingSnapshots: string[] = [];


### PR DESCRIPTION
## Summary

Closes #2054.

Fixes a regression in `@dnd-kit/abstract` where `event.operation.target` was `null` in `onDragStart`.

The fix keeps `dragstart` before `dragover`, restores the initial droppable target on the `dragstart` event, and preserves queued `setDropTarget()` promise behavior.

## Changes

- Restore `operation.target` on `dragstart`.
- Defer initial `dragover` until after `dragstart`.
- Keep queued `setDropTarget()` pending until deferred `dragover` finishes.
- Add regression tests.

## Testing

- `bun run build`
- `bun test packages/abstract/tests/drag-event-order.test.ts`
- `bun test packages/abstract/tests`
- `bun run test`
