### PR TITLE
fix: keep drag transform snapshots current

### DIFF
--- a/.changeset/quick-cooks-tap.md
+++ b/.changeset/quick-cooks-tap.md
@@ -1,0 +1,5 @@
+---
+"@dnd-kit/abstract": patch
+---
+
+Keep drag operation transform snapshots updated when no feedback plugin reads the live transform.

--- a/packages/abstract/src/core/manager/actions.ts
+++ b/packages/abstract/src/core/manager/actions.ts
@@ -189,10 +189,17 @@ export class DragActions<
         return;
       }
 
+      const coordinates = args.to ?? {
+        x: dragOperation.position.current.x + (args.by?.x ?? 0),
+        y: dragOperation.position.current.y + (args.by?.y ?? 0),
+      };
+
       const event = defaultPreventable(
         {
           nativeEvent: args.event,
-          operation: dragOperation.snapshot(),
+          operation: dragOperation.snapshot({
+            transform: dragOperation.getTransform(coordinates),
+          }),
           by: args.by,
           to: args.to,
         },
@@ -208,12 +215,8 @@ export class DragActions<
           return;
         }
 
-        const coordinates = args.to ?? {
-          x: dragOperation.position.current.x + (args.by?.x ?? 0),
-          y: dragOperation.position.current.y + (args.by?.y ?? 0),
-        };
-
         dragOperation.position.current = coordinates;
+        void dragOperation.transform;
       });
     });
   }

--- a/packages/abstract/src/core/manager/operation.ts
+++ b/packages/abstract/src/core/manager/operation.ts
@@ -1,4 +1,4 @@
-import {Position, type Shape} from '@dnd-kit/geometry';
+import {Point, Position, type Shape} from '@dnd-kit/geometry';
 import type {Coordinates} from '@dnd-kit/geometry';
 import {
   batch,
@@ -155,6 +155,19 @@ export class DragOperation<T extends Draggable, U extends Droppable>
 
   #transform = {x: 0, y: 0};
 
+  #computeTransform(transform: Coordinates) {
+    let nextTransform = transform;
+
+    for (const modifier of this.modifiers) {
+      nextTransform = modifier.apply({
+        ...this.snapshot(),
+        transform: nextTransform,
+      });
+    }
+
+    return nextTransform;
+  }
+
   /**
    * Gets the current transform after applying all modifiers.
    *
@@ -162,19 +175,17 @@ export class DragOperation<T extends Draggable, U extends Droppable>
    */
   @derived
   public get transform() {
-    const {x, y} = this.position.delta;
-    let transform = {x, y};
-
-    for (const modifier of this.modifiers) {
-      transform = modifier.apply({
-        ...this.snapshot(),
-        transform,
-      });
-    }
+    const transform = this.#computeTransform(this.position.delta);
 
     this.#transform = transform;
 
     return transform;
+  }
+
+  public getTransform(coordinates = this.position.current) {
+    return this.#computeTransform(
+      Point.delta(Point.from(coordinates), this.position.initial)
+    );
   }
 
   /**
@@ -182,12 +193,14 @@ export class DragOperation<T extends Draggable, U extends Droppable>
    *
    * @returns An immutable snapshot of the current operation state
    */
-  public snapshot(): DragOperationSnapshot<T, U> {
+  public snapshot(
+    overrides: Partial<Pick<DragOperationSnapshot<T, U>, 'transform'>> = {}
+  ): DragOperationSnapshot<T, U> {
     return untracked(() => ({
       source: this.source,
       target: this.target,
       activatorEvent: this.activatorEvent,
-      transform: this.#transform,
+      transform: overrides.transform ?? this.#transform,
       shape: this.shape ? snapshot(this.shape) : null,
       position: snapshot(this.position),
       status: snapshot(this.status),

--- a/packages/abstract/tests/manager-modifiers.test.ts
+++ b/packages/abstract/tests/manager-modifiers.test.ts
@@ -152,6 +152,30 @@ describe('Manager modifier lifecycle', () => {
     manager.destroy();
   });
 
+  it('should expose the next modified transform in dragmove events without feedback', async () => {
+    const manager = new DragDropManager({modifiers: [ClampXModifier]});
+    const draggable = new Draggable({id: 'd1', register: false}, manager);
+    const transforms: Array<{x: number; y: number}> = [];
+
+    draggable.register();
+    manager.monitor.addEventListener('dragmove', (event) => {
+      transforms.push(event.operation.transform);
+    });
+
+    manager.actions.start({source: draggable, coordinates: {x: 0, y: 0}});
+    await flush();
+
+    manager.actions.move({by: {x: 100, y: 50}});
+
+    expect(transforms).toEqual([{x: 0, y: 50}]);
+
+    await flush();
+    expect(manager.dragOperation.snapshot().transform).toEqual({x: 0, y: 50});
+
+    draggable.destroy();
+    manager.destroy();
+  });
+
   it('should destroy per-operation modifiers when draggable modifiers change mid-drag', () => {
     let destroyCount = 0;
 


### PR DESCRIPTION
Fixes #2055

## Summary

- Compute the next drag transform for `dragmove` event snapshots from the pending move coordinates.
- Refresh the cached operation transform after the move is committed, so later snapshots such as `dragend` do not depend on the Feedback plugin reading `dragOperation.transform`.
- Add a manager-level regression test for modified transforms when no feedback plugin is involved.
- Add a patch changeset for `@dnd-kit/abstract`.

## Testing

- `npx bun@1.3.11 test packages/abstract/tests/manager-modifiers.test.ts`
- `npx bun@1.3.11 run --cwd packages/abstract build`
- `git diff --check`

Note: I also tried running ESLint directly on the changed files, but it failed before linting with an ESLint/Ajv initialization error (`Cannot set properties of undefined (setting 'defaultMeta')`).
