### PR TITLE
fix(dom): respect key remaps in KeyboardSensor (closes #1785)

### DIFF
--- a/.changeset/clever-keys-walk.md
+++ b/.changeset/clever-keys-walk.md
@@ -1,0 +1,5 @@
+---
+'@dnd-kit/dom': patch
+---
+
+Match KeyboardSensor shortcuts against KeyboardEvent.key so keyboard controls respect keyboard layouts and operating system key remaps. Common legacy Key* and Digit* configs still normalize.

--- a/apps/docs/docs/extend/sensors/keyboard-sensor.mdx
+++ b/apps/docs/docs/extend/sensors/keyboard-sensor.mdx
@@ -60,16 +60,20 @@ KeyboardSensor.configure({
     end: ['Tab'],
 
     // Use WASD for movement
-    up: ['KeyW'],
-    down: ['KeyS'],
-    left: ['KeyA'],
-    right: ['KeyD'],
+    up: ['w'],
+    down: ['s'],
+    left: ['a'],
+    right: ['d'],
 
     // Additional cancel keys
-    cancel: ['Escape', 'KeyQ'],
+    cancel: ['Escape', 'q'],
   },
 });
 ```
+
+Key bindings are matched against [`KeyboardEvent.key`](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key), so they respect keyboard layouts and operating system key remaps. Use `KeyboardEvent.key` values such as `w`, `Enter`, and `ArrowUp`. The `Space` alias is also supported for the Space key.
+
+If you are migrating a configuration that used [`KeyboardEvent.code`](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/code), common `Key*` and `Digit*` values such as `KeyW` and `Digit1` are normalized for compatibility. Other physical key codes, such as `NumpadEnter`, `BracketLeft`, or `Slash`, should be replaced with the key value they produce. Other named keys must match `KeyboardEvent.key` casing.
 
 ## Default behavior
 
@@ -80,7 +84,7 @@ By default, each arrow key press moves the dragged item by 10 pixels. Hold <kbd>
 ### Options
 
 <ParamField path="keyboardCodes" type="KeyboardCodes">
-  Configure which keyboard codes trigger different actions:
+  Configure which keyboard keys trigger different actions:
 
   ```ts
   interface KeyboardCodes {
@@ -93,7 +97,7 @@ By default, each arrow key press moves the dragged item by 10 pixels. Hold <kbd>
     right: KeyCode[];    // Move right
   }
 
-  type KeyCode = KeyboardEvent['code'];
+  type KeyCode = KeyboardEvent['key'];
   ```
 </ParamField>
 

--- a/apps/docs/docs/legacy/api-documentation/sensors/keyboard.mdx
+++ b/apps/docs/docs/legacy/api-documentation/sensors/keyboard.mdx
@@ -14,6 +14,10 @@ In order for the Keyboard sensor to function properly, the activator element tha
 
 The keyboard activator is the `onKeyDown` event handler. The Keyboard sensor is initialized if the [`event.code`](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/code) property matches one of the `start` keys passed to `keyboardCodes` option of the Keyboard sensor.
 
+<Note>
+  This legacy page documents the older `@dnd-kit/core` keyboard sensor behavior. The current `@dnd-kit/dom` `KeyboardSensor` matches custom bindings against [`KeyboardEvent.key`](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key) instead, with common `Key*` and `Digit*` code values normalized for migration.
+</Note>
+
 By default, the keys that activate the Keyboard sensor are `Space` and `Enter`.
 
 ### Options

--- a/apps/docs/docs/react/guides/sensors.mdx
+++ b/apps/docs/docs/react/guides/sensors.mdx
@@ -2,7 +2,7 @@
 title: 'Configuring sensors'
 sidebarTitle: 'Configuring sensors'
 metaTitle: 'Configuring Sensors - React | dnd kit'
-description: 'Customize how drag operations start in React: pointer activation constraints, keyboard codes, drag handles, and per-pointer-type behavior.'
+description: 'Customize how drag operations start in React: pointer activation constraints, keyboard keys, drag handles, and per-pointer-type behavior.'
 icon: 'monitor-waveform'
 ---
 
@@ -129,15 +129,17 @@ KeyboardSensor.configure({
     start: ['Space', 'Enter'],
     cancel: ['Escape'],
     end: ['Space', 'Enter', 'Tab'],
-    up: ['ArrowUp', 'KeyW'],
-    down: ['ArrowDown', 'KeyS'],
-    left: ['ArrowLeft', 'KeyA'],
-    right: ['ArrowRight', 'KeyD'],
+    up: ['ArrowUp', 'w'],
+    down: ['ArrowDown', 's'],
+    left: ['ArrowLeft', 'a'],
+    right: ['ArrowRight', 'd'],
   },
 });
 ```
 
-Key codes follow [`KeyboardEvent.code`](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/code) values.
+Key bindings follow [`KeyboardEvent.key`](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key) values so they respect keyboard layouts and operating system key remaps. Use values such as `w`, `Enter`, and `ArrowUp`. The `Space` alias is also supported for the Space key.
+
+When migrating older `KeyboardEvent.code` configs, common `Key*` and `Digit*` values such as `KeyW` and `Digit1` still normalize for compatibility. Other physical key codes, such as `NumpadEnter`, `BracketLeft`, or `Slash`, should be replaced with the key value they produce. Other named keys must match `KeyboardEvent.key` casing.
 
 ### Keyboard movement offset
 

--- a/apps/stories/stories/react/Draggable/Sensors/docs/SensorDocs.mdx
+++ b/apps/stories/stories/react/Draggable/Sensors/docs/SensorDocs.mdx
@@ -103,7 +103,7 @@ The keyboard sensor activates when the `handle` or `element` of a draggable sour
 
 #### Configuration
 
-The Keyboard sensor can be configured to respond to different keyboard codes:
+The Keyboard sensor can be configured to respond to different keyboard keys:
 
 ```js
 import {KeyboardSensor} from '@dnd-kit/dom';
@@ -122,6 +122,8 @@ const sensors = [
   }),
 ];
 ```
+
+Keyboard sensor bindings use [`KeyboardEvent.key`](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key) values such as `w`, `Enter`, and `ArrowUp`. Common legacy `Key*` and `Digit*` code values normalize for compatibility, but physical key codes such as `NumpadEnter` should be replaced with the key value they produce. Other named keys must match `KeyboardEvent.key` casing.
 
 You may customize these values, but do keep in mind that the [third rule of ARIA](https://www.w3.org/TR/using-aria/#3rdrule) requires that a user must be able to activate the action associated with a draggable widget using both the enter (on Windows) or return (on macOS) and the space key. To learn more, read the in-depth accessibility guide.
 

--- a/packages/dom/src/core/sensors/keyboard/KeyboardSensor.helpers.ts
+++ b/packages/dom/src/core/sensors/keyboard/KeyboardSensor.helpers.ts
@@ -1,0 +1,67 @@
+export type KeyCode = KeyboardEvent['key'];
+
+export function isKeyboardKey(event: KeyboardEvent, codes: KeyCode[]) {
+  const eventKey = normalizeKey(event.key);
+
+  return codes.some((code) => normalizeKey(code) === eventKey);
+}
+
+const namedKeys = new Set([
+  'alt',
+  'altgraph',
+  'backspace',
+  'capslock',
+  'control',
+  'delete',
+  'end',
+  'enter',
+  'escape',
+  'home',
+  'insert',
+  'meta',
+  'pagedown',
+  'pageup',
+  'pause',
+  'printscreen',
+  'shift',
+  'space',
+  'tab',
+  'arrowdown',
+  'arrowleft',
+  'arrowright',
+  'arrowup',
+  'f1',
+  'f2',
+  'f3',
+  'f4',
+  'f5',
+  'f6',
+  'f7',
+  'f8',
+  'f9',
+  'f10',
+  'f11',
+  'f12',
+]);
+
+function normalizeKey(key: string) {
+  if (key === ' ' || key === 'Spacebar') {
+    return 'space';
+  }
+
+  if (/^Key[A-Z]$/.test(key)) {
+    return key.slice(3).toLowerCase();
+  }
+
+  if (/^Digit[0-9]$/.test(key)) {
+    return key.slice(5);
+  }
+
+  if (key.length === 1) {
+    return key.toLowerCase();
+  }
+
+  const lowerCaseKey = key.toLowerCase();
+
+  return namedKeys.has(lowerCaseKey) ? lowerCaseKey : key;
+}

--- a/packages/dom/src/core/sensors/keyboard/KeyboardSensor.ts
+++ b/packages/dom/src/core/sensors/keyboard/KeyboardSensor.ts
@@ -13,8 +13,9 @@ import {
 import type {DragDropManager} from '../../manager/index.ts';
 import type {Draggable} from '../../entities/index.ts';
 import {AutoScroller} from '../../plugins/index.ts';
+import {isKeyboardKey, type KeyCode} from './KeyboardSensor.helpers.ts';
 
-export type KeyCode = KeyboardEvent['code'];
+export type {KeyCode};
 
 export type KeyboardCodes = {
   start: KeyCode[];
@@ -34,7 +35,7 @@ export interface KeyboardSensorOptions {
    */
   offset?: number | {x: number; y: number};
   /**
-   * The keyboard codes that activate the keyboard sensor.
+   * The keyboard keys that activate the keyboard sensor.
    *
    * @default {
    *   start: ['Space', 'Enter'],
@@ -131,7 +132,7 @@ export class KeyboardSensor extends Sensor<
       preventActivation = defaults.preventActivation,
     } = options ?? {};
 
-    if (!keyboardCodes.start.includes(event.code)) {
+    if (!isKeyboardKey(event, keyboardCodes.start)) {
       return;
     }
 
@@ -196,23 +197,23 @@ export class KeyboardSensor extends Sensor<
   ) {
     const {keyboardCodes = defaults.keyboardCodes} = options ?? {};
 
-    if (isKeycode(event, [...keyboardCodes.end, ...keyboardCodes.cancel])) {
+    if (isKeyboardKey(event, [...keyboardCodes.end, ...keyboardCodes.cancel])) {
       event.preventDefault();
-      const canceled = isKeycode(event, keyboardCodes.cancel);
+      const canceled = isKeyboardKey(event, keyboardCodes.cancel);
 
       this.handleEnd(event, canceled);
       return;
     }
 
-    if (isKeycode(event, keyboardCodes.up)) {
+    if (isKeyboardKey(event, keyboardCodes.up)) {
       this.handleMove('up', event);
-    } else if (isKeycode(event, keyboardCodes.down)) {
+    } else if (isKeyboardKey(event, keyboardCodes.down)) {
       this.handleMove('down', event);
     }
 
-    if (isKeycode(event, keyboardCodes.left)) {
+    if (isKeyboardKey(event, keyboardCodes.left)) {
       this.handleMove('left', event);
-    } else if (isKeycode(event, keyboardCodes.right)) {
+    } else if (isKeyboardKey(event, keyboardCodes.right)) {
       this.handleMove('right', event);
     }
   }
@@ -297,8 +298,4 @@ export class KeyboardSensor extends Sensor<
   static configure = configurator(KeyboardSensor);
 
   static defaults = defaults;
-}
-
-function isKeycode(event: KeyboardEvent, codes: KeyCode[]) {
-  return codes.includes(event.code);
 }

--- a/packages/dom/tests/keyboard-sensor.test.ts
+++ b/packages/dom/tests/keyboard-sensor.test.ts
@@ -1,0 +1,146 @@
+import {describe, expect, it} from 'bun:test';
+
+import {isKeyboardKey} from '../src/core/sensors/keyboard/KeyboardSensor.helpers.ts';
+
+function createKeyboardEvent({
+  code,
+  key,
+  shiftKey = false,
+}: {
+  code: string;
+  key: string;
+  shiftKey?: boolean;
+}) {
+  return {
+    code,
+    key,
+    shiftKey,
+  } as KeyboardEvent;
+}
+
+describe('KeyboardSensor key matching', () => {
+  it('uses the logical keyboard key instead of the physical code', () => {
+    expect(
+      isKeyboardKey(createKeyboardEvent({key: 'Escape', code: 'CapsLock'}), [
+        'Escape',
+      ])
+    ).toBe(true);
+    expect(
+      isKeyboardKey(createKeyboardEvent({key: 'CapsLock', code: 'Escape'}), [
+        'Escape',
+      ])
+    ).toBe(false);
+  });
+
+  it('keeps Space as an alias when matching KeyboardEvent.key', () => {
+    expect(
+      isKeyboardKey(createKeyboardEvent({key: ' ', code: 'KeyA'}), [
+        'Space',
+        'Enter',
+      ])
+    ).toBe(true);
+    expect(
+      isKeyboardKey(createKeyboardEvent({key: 'a', code: 'Space'}), [
+        'Space',
+        'Enter',
+      ])
+    ).toBe(false);
+  });
+
+  it('normalizes printable character keys for configured movement keys', () => {
+    expect(
+      isKeyboardKey(
+        createKeyboardEvent({key: 'W', code: 'KeyW', shiftKey: true}),
+        ['w']
+      )
+    ).toBe(true);
+  });
+
+  it('keeps Key* and Digit* aliases for common legacy KeyboardEvent.code configs', () => {
+    expect(
+      isKeyboardKey(createKeyboardEvent({key: 'w', code: 'KeyW'}), ['KeyW'])
+    ).toBe(true);
+    expect(
+      isKeyboardKey(createKeyboardEvent({key: '1', code: 'Digit1'}), ['Digit1'])
+    ).toBe(true);
+    expect(
+      isKeyboardKey(createKeyboardEvent({key: 'Enter', code: 'NumpadEnter'}), [
+        'NumpadEnter',
+      ])
+    ).toBe(false);
+  });
+
+  it('matches common named keys without requiring exact casing', () => {
+    expect(
+      isKeyboardKey(createKeyboardEvent({key: 'Enter', code: 'Enter'}), [
+        'enter',
+      ])
+    ).toBe(true);
+    expect(
+      isKeyboardKey(createKeyboardEvent({key: 'Escape', code: 'Escape'}), [
+        'escape',
+      ])
+    ).toBe(true);
+    expect(
+      isKeyboardKey(createKeyboardEvent({key: 'ArrowUp', code: 'ArrowUp'}), [
+        'arrowup',
+      ])
+    ).toBe(true);
+    expect(
+      isKeyboardKey(createKeyboardEvent({key: 'Insert', code: 'Insert'}), [
+        'insert',
+      ])
+    ).toBe(true);
+    expect(
+      isKeyboardKey(createKeyboardEvent({key: 'F1', code: 'F1'}), ['f1'])
+    ).toBe(true);
+  });
+
+  it('matches the documented default KeyboardSensor bindings', () => {
+    expect(
+      isKeyboardKey(createKeyboardEvent({key: ' ', code: 'Space'}), [
+        'Space',
+        'Enter',
+      ])
+    ).toBe(true);
+    expect(
+      isKeyboardKey(createKeyboardEvent({key: 'Enter', code: 'Enter'}), [
+        'Space',
+        'Enter',
+      ])
+    ).toBe(true);
+    expect(
+      isKeyboardKey(createKeyboardEvent({key: 'Escape', code: 'Escape'}), [
+        'Escape',
+      ])
+    ).toBe(true);
+    expect(
+      isKeyboardKey(createKeyboardEvent({key: 'Tab', code: 'Tab'}), [
+        'Space',
+        'Enter',
+        'Tab',
+      ])
+    ).toBe(true);
+    expect(
+      isKeyboardKey(createKeyboardEvent({key: 'ArrowUp', code: 'ArrowUp'}), [
+        'ArrowUp',
+      ])
+    ).toBe(true);
+    expect(
+      isKeyboardKey(createKeyboardEvent({key: 'ArrowDown', code: 'ArrowDown'}), [
+        'ArrowDown',
+      ])
+    ).toBe(true);
+    expect(
+      isKeyboardKey(createKeyboardEvent({key: 'ArrowLeft', code: 'ArrowLeft'}), [
+        'ArrowLeft',
+      ])
+    ).toBe(true);
+    expect(
+      isKeyboardKey(
+        createKeyboardEvent({key: 'ArrowRight', code: 'ArrowRight'}),
+        ['ArrowRight']
+      )
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes `KeyboardSensor` key matching to use `KeyboardEvent.key` instead of `KeyboardEvent.code`, so keyboard controls respect keyboard layouts and OS-level key remaps.

Also adds normalization for common legacy `Key*` and `Digit*` configurations, updates the docs, and includes a changeset for `@dnd-kit/dom`.

Closes #1785.

## Testing

- `bun test packages/dom/tests/keyboard-sensor.test.ts`
- `bun test packages/dom/tests`
- `bun run --cwd packages/dom build:core`