### PR TITLE
fix(helpers): stabilize grouped move insertion over containers (closes #2096)

### DIFF
--- a/.changeset/wise-spies-jog.md
+++ b/.changeset/wise-spies-jog.md
@@ -1,0 +1,5 @@
+---
+'@dnd-kit/helpers': patch
+---
+
+Fix grouped `move` insertion over non-empty containers by placing dragged items relative to measured child centers instead of the container midpoint.

--- a/packages/helpers/src/move.ts
+++ b/packages/helpers/src/move.ts
@@ -142,7 +142,9 @@ function mutate<
   W extends DragDropManager<U, V>,
 >(
   items: T,
-  event: DragDropEventMap<U, V, W>['dragover'] | DragDropEventMap<U, V, W>['dragend'],
+  event:
+    | DragDropEventMap<U, V, W>['dragover']
+    | DragDropEventMap<U, V, W>['dragend'],
   mutation: typeof arrayMove | typeof arraySwap
 ): T {
   const {source, target, canceled} = event.operation;
@@ -385,7 +387,9 @@ export function move<
   W extends DragDropManager<U, V>,
 >(
   items: T,
-  event: DragDropEventMap<U, V, W>['dragover'] | DragDropEventMap<U, V, W>['dragend']
+  event:
+    | DragDropEventMap<U, V, W>['dragover']
+    | DragDropEventMap<U, V, W>['dragend']
 ) {
   return mutate(items, event, arrayMove);
 }
@@ -397,7 +401,9 @@ export function swap<
   W extends DragDropManager<U, V>,
 >(
   items: T,
-  event: DragDropEventMap<U, V, W>['dragover'] | DragDropEventMap<U, V, W>['dragend']
+  event:
+    | DragDropEventMap<U, V, W>['dragover']
+    | DragDropEventMap<U, V, W>['dragend']
 ) {
   return mutate(items, event, arraySwap);
 }

--- a/packages/helpers/src/move.ts
+++ b/packages/helpers/src/move.ts
@@ -61,6 +61,62 @@ function getRecordKey(
 }
 
 /**
+ * Resolve an item ID from either a primitive item or an object with an `id` field.
+ */
+function getItemId(item: Items[number]): UniqueIdentifier | undefined {
+  if (item === null) {
+    return undefined;
+  }
+
+  return typeof item === 'object' && 'id' in item ? item.id : item;
+}
+
+/**
+ * Resolve the insertion index for a container target.
+ * Uses measured child centers when available, excluding the source item for same-container moves.
+ * Falls back to the container center when child measurements are unavailable.
+ */
+function getContainerInsertionIndex(
+  children: Items,
+  source: Draggable,
+  target: Droppable,
+  position: {y: number},
+  excludedItemId?: UniqueIdentifier
+) {
+  const {registry} = source.manager!;
+  let hasMeasuredChildren = false;
+  let insertionIndex = 0;
+
+  for (const item of children) {
+    const id = getItemId(item);
+
+    if (id === excludedItemId) {
+      continue;
+    }
+
+    const droppable = id == null ? undefined : registry?.droppables.get(id);
+
+    if (droppable?.shape) {
+      hasMeasuredChildren = true;
+
+      if (Math.round(position.y) < Math.round(droppable.shape.center.y)) {
+        return insertionIndex;
+      }
+    }
+
+    insertionIndex++;
+  }
+
+  if (hasMeasuredChildren) {
+    return insertionIndex;
+  }
+
+  return target.shape && position.y > target.shape.center.y
+    ? insertionIndex
+    : 0;
+}
+
+/**
  * Check if the source has sortable index properties via duck typing.
  * The `move` helper lives in `@dnd-kit/helpers` which has no dependency on `@dnd-kit/dom`,
  * so we discover sortable properties at runtime.
@@ -97,7 +153,7 @@ function mutate<
   }
 
   const findIndex = (item: Items[0], id: UniqueIdentifier) =>
-    item === id || ( item !== null && typeof item === 'object' && 'id' in item && item.id === id); // adding the fix/ guardrails for check the item is not null
+    getItemId(item) === id;
 
   if (Array.isArray(items)) {
     const sourceIndex = items.findIndex((item) => findIndex(item, source.id));
@@ -141,6 +197,7 @@ function mutate<
   let sourceParent: UniqueIdentifier | undefined;
   let targetIndex = -1;
   let targetParent: UniqueIdentifier | undefined;
+  let targetIsContainer = false;
 
   for (const [id, children] of entries) {
     if (sourceIndex === -1) {
@@ -220,14 +277,18 @@ function mutate<
     const targetKey = getRecordKey(items, target.id);
 
     if (targetKey != null) {
-      const insertionIndex =
-        target.shape && position.y > target.shape.center.y
-          ? items[targetKey].length
-          : 0;
+      const insertionIndex = getContainerInsertionIndex(
+        items[targetKey],
+        source,
+        target,
+        position,
+        sourceParent === targetKey ? source.id : undefined
+      );
 
       // The target does not have any matching children, but appears to be a valid target
       targetParent = targetKey;
       targetIndex = insertionIndex;
+      targetIsContainer = true;
     }
   }
 
@@ -300,7 +361,7 @@ function mutate<
 
   const isBelowTarget =
     target.shape && Math.round(position.y) > Math.round(target.shape.center.y);
-  const modifier = isBelowTarget ? 1 : 0;
+  const modifier = targetIsContainer ? 0 : isBelowTarget ? 1 : 0;
   const sourceItem = items[sourceParent][sourceIndex];
 
   return {

--- a/packages/helpers/tests/move.test.ts
+++ b/packages/helpers/tests/move.test.ts
@@ -59,6 +59,36 @@ function dragEndEvent(source: any, target: any, canceled = false) {
   } as any;
 }
 
+/** Build a drag manager mock with droppable item center measurements. */
+function managerWithDroppableCenters(
+  position: {x: number; y: number},
+  centers: Record<string, number>
+) {
+  return {
+    dragOperation: {
+      position: {current: position},
+      shape: null,
+    },
+    registry: {
+      droppables: {
+        get(id: string | number) {
+          const center = centers[String(id)];
+
+          if (center == null) {
+            return undefined;
+          }
+
+          return {
+            shape: {
+              center: {x: 662, y: center},
+            },
+          };
+        },
+      },
+    },
+  };
+}
+
 // ===========================================================================
 // arrayMove / arraySwap
 // ===========================================================================
@@ -333,6 +363,121 @@ describe('move – grouped record, ID-based fallback', () => {
     expect(move(items, event)).toEqual({
       240: [24002, 24003, 24001],
       241: [24101, 24102],
+    });
+  });
+
+  it('should use child item centers when crossing groups over a non-empty container', () => {
+    const items = {
+      A: ['A0', 'A1', 'A2'],
+      B: ['B0'],
+      C: ['B1'],
+    };
+    const source = mockSource('A1');
+    source.manager = managerWithDroppableCenters({x: 627, y: 296}, {B0: 249});
+    const target = mockTarget('B');
+    target.shape = {
+      center: {x: 662, y: 301},
+    };
+    const event = dragOverEvent(source, target);
+
+    expect(move(items, event)).toEqual({
+      A: ['A0', 'A2'],
+      B: ['B0', 'A1'],
+      C: ['B1'],
+    });
+  });
+
+  it('should not offset child-based container insertion by the container center', () => {
+    const items = {
+      A: ['A0'],
+      B: ['B0', 'B1', 'B2'],
+    };
+    const source = mockSource('A0');
+    source.manager = managerWithDroppableCenters(
+      {x: 627, y: 475},
+      {
+        B0: 400,
+        B1: 500,
+        B2: 600,
+      }
+    );
+    const target = mockTarget('B');
+    target.shape = {
+      center: {x: 662, y: 450},
+    };
+    const event = dragOverEvent(source, target);
+
+    expect(move(items, event)).toEqual({
+      A: [],
+      B: ['B0', 'A0', 'B1', 'B2'],
+    });
+  });
+
+  it('should ignore the source item when measuring a same-container target', () => {
+    const items = {
+      B: ['B0', 'B1', 'B2'],
+    };
+    const source = mockSource('B0');
+    source.manager = managerWithDroppableCenters(
+      {x: 627, y: 550},
+      {
+        B0: 400,
+        B1: 500,
+        B2: 600,
+      }
+    );
+    const target = mockTarget('B');
+    target.shape = {
+      center: {x: 662, y: 450},
+    };
+    const event = dragOverEvent(source, target);
+
+    expect(move(items, event)).toEqual({
+      B: ['B1', 'B0', 'B2'],
+    });
+  });
+
+  it('should use child item centers for object items when targeting a container', () => {
+    const items = {
+      A: [{id: 'A0'}],
+      B: [{id: 'B0'}, {id: 'B1'}],
+    };
+    const source = mockSource('A0');
+    source.manager = managerWithDroppableCenters(
+      {x: 627, y: 475},
+      {
+        B0: 400,
+        B1: 500,
+      }
+    );
+    const target = mockTarget('B');
+    target.shape = {
+      center: {x: 662, y: 600},
+    };
+    const event = dragOverEvent(source, target);
+
+    expect(move(items, event)).toEqual({
+      A: [],
+      B: [{id: 'B0'}, {id: 'A0'}, {id: 'B1'}],
+    });
+  });
+
+  it('should fall back to the container center when child measurements are unavailable', () => {
+    const items = {
+      A: ['A0'],
+      B: ['B0'],
+    };
+    const source = mockSource('A0');
+    source.manager = managerWithDroppableCenters({x: 627, y: 550}, {});
+    const target = mockTarget('B');
+    target.shape = {
+      center: {x: 662, y: 500},
+    };
+    const event = dragOverEvent(source, target);
+
+    expect(move(items, event)).toEqual({
+      A: [],
+      B: ['B0', 'A0'],
     });
   });
 


### PR DESCRIPTION
Fixes #2096 

## Root cause

When dragging over a non-empty container target, `move` used the container center to decide the insertion index.

In edge cases, especially in Safari, this could place the dragged item before an existing child even when it was visually below that child. The next item-target update corrected the order, causing a visible flicker.

## Fix

Use measured child droppable centers to resolve the insertion index for non-empty container targets.

If child measurements are unavailable, fall back to the existing container-center behavior. Same-container moves also exclude the source item while measuring child positions.

## Test plan

- `bun test packages/helpers/tests/move.test.ts`
- `bun run test`
- `bun run build`
- `bun run test:e2e`
- `prettier --check .changeset/wise-spies-jog.md packages/helpers/src/move.ts packages/helpers/tests/move.test.ts`