### PR TITLE
fix(react): defer useSignal update to a microtask to avoid scheduling during commit

### DIFF
--- a/.changeset/defer-usesignal-microtask.md
+++ b/.changeset/defer-usesignal-microtask.md
@@ -2,4 +2,4 @@
 '@dnd-kit/react': patch
 ---
 
-Defer `useSignal` re-renders to a microtask so a signal that changes while React is mid-commit no longer schedules a synchronous update from within a React lifecycle method. Reading `useDragOperation` in a component that renders during a drag previously threw `useInsertionEffect must not schedule updates` (and could crash reconciliation with `NotFoundError: Node.removeChild`) because dnd-kit resets the drag operation from a layout effect at drag end. Mirrors the existing guard in `useDeepSignal`.
+Defer `useSignal` re-renders to a microtask so a signal that changes while React is mid-commit no longer schedules a synchronous update from within a React lifecycle method. Reading `useDragOperation` in a component that renders during a drag previously logged the `useInsertionEffect must not schedule updates` warning, because dnd-kit resets the drag operation from a layout effect at drag end. Mirrors the existing guard in `useDeepSignal`.

--- a/.changeset/defer-usesignal-microtask.md
+++ b/.changeset/defer-usesignal-microtask.md
@@ -1,0 +1,5 @@
+---
+'@dnd-kit/react': patch
+---
+
+Defer `useSignal` re-renders to a microtask so a signal that changes while React is mid-commit no longer schedules a synchronous update from within a React lifecycle method. Reading `useDragOperation` in a component that renders during a drag previously threw `useInsertionEffect must not schedule updates` (and could crash reconciliation with `NotFoundError: Node.removeChild`) because dnd-kit resets the drag operation from a layout effect at drag end. Mirrors the existing guard in `useDeepSignal`.

--- a/packages/react/src/hooks/useSignal.ts
+++ b/packages/react/src/hooks/useSignal.ts
@@ -22,10 +22,16 @@ export function useSignal<T = any>(signal: Signal<T>, sync = false) {
 
           if (!read.current) return;
 
+          // Defer to a microtask so a signal that changes while React is mid-commit does not
+          // schedule a synchronous update from within a React lifecycle method — which triggers
+          // the "useInsertionEffect must not schedule updates" warning and can crash
+          // reconciliation. This happens, for example, when dnd-kit resets the drag operation
+          // from a layout effect at drag end and a component reads that state via
+          // `useDragOperation`. Mirrors the guard already present in `useDeepSignal`.
           if (sync) {
-            flushSync(forceUpdate);
+            queueMicrotask(() => flushSync(forceUpdate));
           } else {
-            forceUpdate();
+            queueMicrotask(forceUpdate);
           }
         }
       }),

--- a/packages/react/src/hooks/useSignal.ts
+++ b/packages/react/src/hooks/useSignal.ts
@@ -24,10 +24,10 @@ export function useSignal<T = any>(signal: Signal<T>, sync = false) {
 
           // Defer to a microtask so a signal that changes while React is mid-commit does not
           // schedule a synchronous update from within a React lifecycle method — which triggers
-          // the "useInsertionEffect must not schedule updates" warning and can crash
-          // reconciliation. This happens, for example, when dnd-kit resets the drag operation
-          // from a layout effect at drag end and a component reads that state via
-          // `useDragOperation`. Mirrors the guard already present in `useDeepSignal`.
+          // the "useInsertionEffect must not schedule updates" warning. This happens, for
+          // example, when dnd-kit resets the drag operation from a layout effect at drag end
+          // and a component reads that state via `useDragOperation`. Mirrors the guard already
+          // present in `useDeepSignal`.
           if (sync) {
             queueMicrotask(() => flushSync(forceUpdate));
           } else {


### PR DESCRIPTION
## Problem

`useSignal` (used by `useComputed` → `useDragOperation`) calls `forceUpdate()` **synchronously** from its signal `effect`. When the observed signal changes while React is mid-commit, that schedules a synchronous React update from within a React lifecycle method.

This happens in an ordinary scenario: a component reads drag state via `useDragOperation()` and re-renders during a drag (e.g. to show/highlight a drop zone — the use case the docs describe). At **drag end**, dnd-kit resets the drag operation (`DragOperation.reset()` clears `sourceIdentifier`) inside `manager.renderer.rendering.then(...)`, which runs from the React `Renderer`'s layout effect — i.e. during React's commit/effect phase. The `useSignal` effect then fires `forceUpdate()` synchronously, producing:

- `Warning: useInsertionEffect must not schedule updates.`

Minimal repro shape: any component under `DragDropProvider` that calls `useDragOperation()` and re-renders based on `source`/`target` logs the warning when a drag ends.

(An earlier version of this description also attributed a `NotFoundError: removeChild` crash to this path; that turned out to be an application-side issue in how we consumed `onDragOver` — leaving drag-overs unanswered so `OptimisticSortingPlugin` reordered DOM the app then also reconciled — not a `useSignal` bug. This PR is scoped to the warning.)

## Fix

Defer the `useSignal` update to a microtask so it runs after the commit completes instead of scheduling synchronously from within the effect. This mirrors the guard already present in `useDeepSignal` (`queueMicrotask(() => flushSync(forceUpdate))`).

`useDeepSignal` only deferred its `sync` branch; `useSignal`'s async branch — the one `useComputed`/`useDragOperation` use (`sync=false`) — has the same latent issue, so this defers both branches.

## Notes

- No API change; updates are just flushed a microtask later (imperceptible — React already batches).
- Nothing in `packages/react` calls `useSignal`/`useComputed` with `sync=true`, so the sync-branch change has effectively no blast radius.
- Changeset included (`@dnd-kit/react` patch).