### PR TITLE
fix(dom): restore DOM elements on dragend to prevent removeChild crash

### DIFF
--- a/.changeset/fix-dom-reconciliation-crash.md
+++ b/.changeset/fix-dom-reconciliation-crash.md
@@ -1,0 +1,5 @@
+---
+'@dnd-kit/dom': patch
+---
+
+Restore elements to their original DOM position on drag end to prevent framework DOM reconciliation crash (e.g. Node.removeChild error).

--- a/packages/dom/src/core/plugins/feedback/Feedback.ts
+++ b/packages/dom/src/core/plugins/feedback/Feedback.ts
@@ -576,7 +576,7 @@ export class Feedback extends Plugin<DragDropManager, FeedbackOptions> {
             translate = {x: 0, y: 0};
           }
 
-          if (!translate || dropAnimationConfig === null) {
+          if (!translate || dropAnimationConfig === null || feedbackElement !== feedbackPlugin.overlay) {
             cleanup();
             return;
           }

--- a/packages/dom/src/core/plugins/feedback/Feedback.ts
+++ b/packages/dom/src/core/plugins/feedback/Feedback.ts
@@ -444,7 +444,11 @@ export class Feedback extends Plugin<DragDropManager, FeedbackOptions> {
       }
     };
 
+    let cleanedUp = false;
     const cleanup = () => {
+      if (cleanedUp) return;
+      cleanedUp = true;
+
       elementMutationObserver?.disconnect();
       documentMutationObserver?.disconnect();
       resizeObserver.disconnect();
@@ -602,7 +606,14 @@ export class Feedback extends Plugin<DragDropManager, FeedbackOptions> {
       }
     );
 
+    const dragendUnsubscribe = manager.monitor.addEventListener('dragend', () => {
+      if (feedbackElement !== feedbackPlugin.overlay) {
+        cleanup();
+      }
+    });
+
     return () => {
+      dragendUnsubscribe();
       cleanup();
       cleanupEffects();
     };

--- a/packages/dom/src/sortable/plugins/OptimisticSortingPlugin.ts
+++ b/packages/dom/src/sortable/plugins/OptimisticSortingPlugin.ts
@@ -17,6 +17,10 @@ export class OptimisticSortingPlugin extends Plugin<DragDropManager> {
   constructor(manager: DragDropManager) {
     super(manager);
 
+    let originalSourceElement: Element | undefined;
+    let originalParent: Node | null = null;
+    let originalNextSibling: Node | null = null;
+
     const getSortableInstances = () => {
       const sortableInstances: SortableInstances = new Map();
 
@@ -40,6 +44,22 @@ export class OptimisticSortingPlugin extends Plugin<DragDropManager> {
     };
 
     const unsubscribe = [
+      manager.monitor.addEventListener('dragstart', (event, manager) => {
+        if (this.disabled) {
+          return;
+        }
+
+        const {dragOperation} = manager;
+        const {source} = dragOperation;
+
+        if (isSortable(source)) {
+          originalSourceElement = source.sortable.element;
+          if (originalSourceElement) {
+            originalParent = originalSourceElement.parentNode;
+            originalNextSibling = originalSourceElement.nextSibling;
+          }
+        }
+      }),
       manager.monitor.addEventListener('dragover', (event, manager) => {
         if (this.disabled) {
           return;
@@ -132,6 +152,20 @@ export class OptimisticSortingPlugin extends Plugin<DragDropManager> {
         });
       }),
       manager.monitor.addEventListener('dragend', (event, manager) => {
+        // Restore the original DOM position of the dragged element so the renderer (e.g. React)
+        // can reconcile the DOM starting from a clean, expected state.
+        if (originalSourceElement && originalParent) {
+          if (originalNextSibling && originalNextSibling.parentNode === originalParent) {
+            originalParent.insertBefore(originalSourceElement, originalNextSibling);
+          } else {
+            originalParent.appendChild(originalSourceElement);
+          }
+        }
+
+        originalSourceElement = undefined;
+        originalParent = null;
+        originalNextSibling = null;
+
         if (!event.canceled) {
           return;
         }
@@ -167,22 +201,6 @@ export class OptimisticSortingPlugin extends Plugin<DragDropManager> {
               // At least one index or group was changed so we should abort optimistic updates
               return;
             }
-
-            const currentSortables = sort(initialGroupInstances);
-            const initialSortables = sort(
-              initialGroupInstances,
-              sortByInitialIndex
-            );
-            const sourceElement = source.sortable.element;
-            const initialPosition = initialSortables.indexOf(source.sortable);
-            const target = currentSortables[initialPosition];
-            const targetElement = target?.element;
-
-            if (!target || !targetElement || !sourceElement) {
-              return;
-            }
-
-            reorder(sourceElement, target.index, targetElement, source.index);
 
             batch(() => {
               for (const sortableInstances of instances.values()) {


### PR DESCRIPTION
### Summary
This PR fixes issues #1747 and #1780 where the application crashes with DOMException: Node.removeChild: The node to be removed is not a child of this node (or NotFoundError on Vite/Rollup) when dragging sortable items or elements across different groups/containers.

### Cause of the Issue
During dragging operations, OptimisticSortingPlugin and Feedback directly manipulate the DOM tree (e.g., using insertAdjacentElement to reorder nodes, or appending dragging elements to a popover/overlay root element). When a drag operation ends, the framework (React/Solid/Vue/Svelte) updates state and reconciles the DOM tree. However, because the DOM structure was altered directly outside the framework, the virtual DOM reconciliation gets out of sync, leading to errors like parent.removeChild failing to find the target element.

### Solution
1. **OptimisticSortingPlugin**:
   - Capture the original parent and sibling elements of the dragging element on dragstart.
   - On dragend, always restore the dragging element back to its original parent and position synchronously before the framework reconciles the DOM.
2. **Feedback**:
   - Detect if the feedback element is the real element itself (i.e. not using a separate DragOverlay).
   - If not using a separate DragOverlay, bypass the asynchronous drop animation and synchronously clean up / restore the element's original position on dragend to ensure a clean DOM state for the renderer's reconciliation tick.

This completely avoids any DOM reconciliation mismatches and resolves the crashes across all list component structures.