### PR TITLE
docs: fix broken examples and misleading API claims

### DIFF
--- a/apps/docs/docs/concepts/drag-drop-manager.mdx
+++ b/apps/docs/docs/concepts/drag-drop-manager.mdx
@@ -72,7 +72,11 @@ The manager comes with sensible defaults, but you can customize its behavior. Th
 Use the function form to add to or configure the defaults without replacing them:
 
 ```js
-import {DragDropManager} from '@dnd-kit/dom';
+import {
+  DragDropManager,
+  PointerSensor,
+  PointerActivationConstraints,
+} from '@dnd-kit/dom';
 import {RestrictToWindow} from '@dnd-kit/dom/modifiers';
 
 const manager = new DragDropManager({
@@ -83,7 +87,9 @@ const manager = new DragDropManager({
   sensors: (defaults) => [
     ...defaults,
     PointerSensor.configure({
-      activationConstraints: { distance: 5 },
+      activationConstraints: [
+        new PointerActivationConstraints.Distance({value: 5}),
+      ],
     }),
   ],
 

--- a/apps/docs/docs/concepts/droppable.mdx
+++ b/apps/docs/docs/concepts/droppable.mdx
@@ -39,28 +39,28 @@ manager.monitor.addEventListener('dragend', (event) => {
 
 ## Accepting Specific Types
 
-You can restrict which draggable elements can be dropped by using the `accepts` property. See the [draggable types](/concepts/draggable#types) documentation for more details.
+You can restrict which draggable elements can be dropped by using the `accept` property. See the [draggable types](/concepts/draggable#types) documentation for more details.
 
 ```js
 // Accept only draggables with type 'item'
 const droppable = new Droppable({
   id: 'drop-zone',
   element,
-  accepts: 'item'
+  accept: 'item'
 }, manager);
 
 // Accept multiple types
 const droppable = new Droppable({
   id: 'drop-zone',
   element,
-  accepts: ['item', 'card']
+  accept: ['item', 'card']
 }, manager);
 
 // Use a function for custom logic
 const droppable = new Droppable({
   id: 'drop-zone',
   element,
-  accepts: (draggable) => {
+  accept: (draggable) => {
     // Custom acceptance logic
     return draggable.type === 'item' && draggable.data.category === 'fruit';
   }
@@ -69,7 +69,7 @@ const droppable = new Droppable({
 
 ## Collision Detection
 
-By default, the `Droppable` class uses rectangle intersection to detect when draggable elements are over the drop target:
+By default, the `Droppable` class uses the `defaultCollisionDetection` algorithm from `@dnd-kit/collision`: it first checks whether the pointer is over the drop target, and falls back to rectangle intersection when there is no pointer collision (for example, during keyboard-driven drags):
 
 <img src="/images/droppable/shape-intersection.svg" alt="Rectangle intersection collision detection" />
 
@@ -131,12 +131,13 @@ The `Droppable` class accepts the following arguments:
 </ParamField>
 
 <ParamField path="type" type="string | number | Symbol">
-  An identifier used by other droppables' `accept` rules to decide whether this droppable can be a target for a given draggable.
+  An optional identifier to categorize this droppable. Whether a draggable can be dropped on this target is determined by this droppable's own [`accept`](#param-accept) rule checked against the **draggable's** `type` — a droppable's `type` is not consulted by `accept` rules.
 </ParamField>
 
 <ParamField path="collisionDetector" type="CollisionDetector">
   A function to determine when draggable elements are over this target. See [collision detection](#collision-detection) for built-in options, such as:
-  - `shapeIntersection`: Default, uses rectangle intersection
+  - `defaultCollisionDetection`: Default, uses pointer intersection with a fallback to rectangle intersection
+  - `shapeIntersection`: Uses rectangle intersection
   - `pointerIntersection`: Uses pointer position for precise detection
   - `closestCenter`: Uses center point distance, ideal for card stacking
   - `directionBiased`: Considers drag direction, useful for sortable lists

--- a/apps/docs/docs/extend/modifiers.mdx
+++ b/apps/docs/docs/extend/modifiers.mdx
@@ -22,7 +22,7 @@ Available in `@dnd-kit/abstract/modifiers`, these modifiers are environment-agno
   <Card title="RestrictToVerticalAxis">
     Constrain movement to the vertical axis only
   </Card>
-  <Card title="Snap">
+  <Card title="SnapModifier">
     Snap movement to a grid with configurable size
   </Card>
 </CardGroup>
@@ -42,19 +42,16 @@ Example combining modifiers:
 
 ```ts
 import {
-  Snap,
+  SnapModifier,
   RestrictToHorizontalAxis
 } from '@dnd-kit/abstract/modifiers';
 
-// Horizontal movement that snaps to a grid
+// Horizontal movement that snaps to a 20px grid
 const manager = new DragDropManager({
   modifiers: [
-    RestrictToHorizontalAxis,
-    Snap.configure({
-      size: {
-        x: 20,  // Snap every 20px horizontally
-        y: 0    // No vertical snapping (already restricted)
-      }
+    RestrictToHorizontalAxis, // Vertical movement is already restricted
+    SnapModifier.configure({
+      size: 20, // Snap every 20px
     })
   ],
 });

--- a/apps/docs/docs/extend/plugins.mdx
+++ b/apps/docs/docs/extend/plugins.mdx
@@ -36,13 +36,6 @@ Several plugins are included by default when creating a new `DragDropManager`:
     Updates cursor styles during drag operations.
   </Card>
   <Card
-    title="Debug"
-    icon="bug"
-    href="/extend/plugins/debug"
-  >
-    Visualize drag shapes, droppable zones, and collisions for debugging.
-  </Card>
-  <Card
     title="Feedback"
     icon="eye"
     href="/extend/plugins/feedback"
@@ -55,6 +48,18 @@ Several plugins are included by default when creating a new `DragDropManager`:
     href="/extend/plugins/style-injector"
   >
     Centralized style injection with CSP nonce support.
+  </Card>
+</CardGroup>
+
+Other plugins are available but need to be opted into:
+
+<CardGroup cols={2}>
+  <Card
+    title="Debug"
+    icon="bug"
+    href="/extend/plugins/debug"
+  >
+    Visualize drag shapes, droppable zones, and collisions for debugging.
   </Card>
 </CardGroup>
 

--- a/apps/docs/docs/quickstart.mdx
+++ b/apps/docs/docs/quickstart.mdx
@@ -143,7 +143,7 @@ export default function App() {
   Configuration for the droppable target:
   - `id` (required): Unique identifier
   - `element`: The DOM element to make droppable
-  - `accepts`: Types of draggable elements to accept
+  - `accept`: Types of draggable elements to accept
   - `disabled`: Whether dropping is disabled
 </ParamField>
 

--- a/apps/docs/docs/react/components/drag-drop-provider.mdx
+++ b/apps/docs/docs/react/components/drag-drop-provider.mdx
@@ -33,23 +33,25 @@ Listen to drag and drop events to respond to user interactions:
 function App() {
   return (
     <DragDropProvider
-      onBeforeDragStart={({source, event}) => {
+      onBeforeDragStart={(event) => {
         // Optionally prevent dragging
-        if (shouldPreventDrag(source)) {
+        if (shouldPreventDrag(event.operation.source)) {
           event.preventDefault();
         }
       }}
-      onDragStart={({source}) => {
-        console.log('Started dragging', source.id);
+      onDragStart={({operation}) => {
+        console.log('Started dragging', operation.source.id);
       }}
       onDragMove={({operation}) => {
         const {position} = operation;
         console.log('Current position:', position);
       }}
-      onDragOver={({source, target}) => {
-        console.log(`${source.id} is over ${target.id}`);
+      onDragOver={({operation}) => {
+        const {source, target} = operation;
+        console.log(`${source.id} is over ${target?.id}`);
       }}
-      onDragEnd={({source, target}) => {
+      onDragEnd={({operation}) => {
+        const {source, target} = operation;
         if (target) {
           console.log(`Dropped ${source.id} onto ${target.id}`);
         }

--- a/apps/docs/docs/react/guides/collision-detection.mdx
+++ b/apps/docs/docs/react/guides/collision-detection.mdx
@@ -36,7 +36,7 @@ Returns the droppable with the **greatest overlap area** with the dragged elemen
 
 ### `closestCenter`
 
-Picks the droppable whose **center point** is closest to the dragged element's center. Ideal for card stacking or grids where items snap to the nearest slot.
+First runs `defaultCollisionDetection` and returns its result when the dragged element intersects a droppable; only when there is **no intersection** does it fall back to picking the droppable whose **center point** is closest to the dragged element's center. Ideal for card stacking or grids where items should snap to the nearest slot even without overlapping it.
 
 <Frame>
   <img src="/images/droppable/closest-center.svg" alt="Closest center: a line from the dragged element's center to the closest droppable's center" />

--- a/apps/docs/docs/react/guides/modifiers.mdx
+++ b/apps/docs/docs/react/guides/modifiers.mdx
@@ -39,7 +39,7 @@ function DraggableItem({container}: {container: React.RefObject<HTMLDivElement |
     id: 'draggable-1',
     modifiers: [
       RestrictToElement.configure({
-        element: container.current,
+        element: () => container.current,
       }),
     ],
   });
@@ -48,8 +48,12 @@ function DraggableItem({container}: {container: React.RefObject<HTMLDivElement |
 }
 ```
 
+<Note>
+  Pass a function (`element: () => container.current`) rather than the ref's current value (`element: container.current`). The function is evaluated when a drag starts, after the ref is populated. Passing `container.current` directly captures `null` on the initial render, and the modifier silently applies no restriction.
+</Note>
+
 <Tip>
-  The `element` option also accepts a function that receives the current drag operation and returns an element. This is useful when you need dynamic container references:
+  The function form also receives the current drag operation, which is useful when you need dynamic container references:
 
   ```tsx
   RestrictToElement.configure({
@@ -138,7 +142,7 @@ function DraggableItem({container}: {container: React.RefObject<HTMLDivElement |
   const {ref} = useDraggable({
     id: 'draggable-1',
     modifiers: [
-      RestrictToElement.configure({element: container.current}),
+      RestrictToElement.configure({element: () => container.current}),
       SnapModifier.configure({size: 20}),
     ],
   });

--- a/apps/docs/docs/react/guides/sensors.mdx
+++ b/apps/docs/docs/react/guides/sensors.mdx
@@ -81,7 +81,7 @@ PointerSensor.configure({
 });
 ```
 
-Returning `undefined` from the function falls back to the [default behavior](/extend/sensors/pointer-sensor#default-behavior).
+Returning `undefined` from the function means **no activation constraints** — the drag starts immediately on `pointerdown`. The [default behavior](/extend/sensors/pointer-sensor#default-behavior) is not restored; if you want the defaults for a given pointer type, return those constraints explicitly.
 
 ### Drag handles via activator elements
 

--- a/apps/docs/docs/react/hooks/use-drag-drop-manager.mdx
+++ b/apps/docs/docs/react/hooks/use-drag-drop-manager.mdx
@@ -43,7 +43,7 @@ function App() {
 ```
 
 <Warning>
-  The hook returns `null` when called outside of a `DragDropProvider`. Always guard against `null` before dereferencing the manager.
+  When called outside of a `DragDropProvider`, the hook does not return `null` at runtime — it returns a shared default manager instance that all provider-less hooks fall back to. The return type is still `DragDropManager | null`, so a `null` guard is needed to satisfy TypeScript.
 </Warning>
 
 ## API Reference
@@ -51,7 +51,7 @@ function App() {
 ### Output
 
 <ResponseField name="manager" type="DragDropManager | null">
-  The [`DragDropManager`](/concepts/drag-drop-manager) instance from the nearest ancestor `DragDropProvider`, or `null` if no provider is present.
+  The [`DragDropManager`](/concepts/drag-drop-manager) instance from the nearest ancestor `DragDropProvider`, or a shared default manager instance if no provider is present.
 </ResponseField>
 
 ## Related

--- a/apps/docs/docs/react/hooks/use-droppable.mdx
+++ b/apps/docs/docs/react/hooks/use-droppable.mdx
@@ -58,7 +58,7 @@ The `useDroppable` hook accepts the following arguments:
 </ParamField>
 
 <ParamField path="type" type="string | number | Symbol">
-  An identifier used by other droppables' `accept` rules to decide whether this droppable can be a target for a given draggable. Has no effect on its own — it pairs with `accept`.
+  An optional identifier to categorize this droppable. Whether a draggable can be dropped on this target is determined by this droppable's own [`accept`](#param-accept) rule checked against the **draggable's** `type` — a droppable's `type` is not consulted by `accept` rules.
 </ParamField>
 
 <ParamField path="collisionDetector" type="(input: CollisionDetectorInput) => Collision | null">

--- a/apps/docs/docs/react/hooks/use-sortable.mdx
+++ b/apps/docs/docs/react/hooks/use-sortable.mdx
@@ -105,7 +105,7 @@ The `useSortable` hook accepts all of the same arguments as the [useDraggable](/
 </ParamField>
 
 <ParamField path="type" type="string | number | Symbol">
-  An identifier used by other sortables' or droppables' `accept` rules to decide whether this item can be a drop target for a given draggable.
+  An identifier for this item that other sortables' or droppables' `accept` rules check when **this item is dragged** — it determines where this item can be dropped. Whether this item can act as a drop target for other draggables is governed by its own [`accept`](#param-accept) rule.
 </ParamField>
 
 <ParamField path="group" type="string | number | Symbol">

--- a/apps/docs/docs/svelte/components/drag-overlay.mdx
+++ b/apps/docs/docs/svelte/components/drag-overlay.mdx
@@ -15,15 +15,19 @@ The `DragOverlay` component renders a custom overlay element while a drag operat
 
 Import and place the `DragOverlay` component inside a [`DragDropProvider`](/svelte/components/drag-drop-provider). Its children will only be rendered when a drag operation is active.
 
-```svelte
-<script>
-  import {DragDropProvider, DragOverlay, createDraggable} from '@dnd-kit/svelte';
+<Note>
+  `createDraggable` relies on the context provided by `DragDropProvider`, so it must be called from a component that is rendered **inside** a `DragDropProvider` — not from the same component that renders the provider.
+</Note>
 
-  const draggable = createDraggable({id: 'my-item'});
+<CodeGroup>
+```svelte App.svelte
+<script>
+  import {DragDropProvider, DragOverlay} from '@dnd-kit/svelte';
+  import Draggable from './Draggable.svelte';
 </script>
 
 <DragDropProvider>
-  <button {@attach draggable.attach}>draggable</button>
+  <Draggable id="my-item" />
   <DragOverlay>
     {#snippet children(source)}
       <div>I will be rendered while dragging...</div>
@@ -31,6 +35,19 @@ Import and place the `DragOverlay` component inside a [`DragDropProvider`](/svel
   </DragOverlay>
 </DragDropProvider>
 ```
+
+```svelte Draggable.svelte
+<script>
+  import {createDraggable} from '@dnd-kit/svelte';
+
+  let {id} = $props();
+
+  const draggable = createDraggable({id});
+</script>
+
+<button {@attach draggable.attach}>draggable</button>
+```
+</CodeGroup>
 
 <Warning>
   You should only render the `DragOverlay` component once per [DragDropProvider](/svelte/components/drag-drop-provider).

--- a/apps/docs/docs/svelte/primitives/create-draggable.mdx
+++ b/apps/docs/docs/svelte/primitives/create-draggable.mdx
@@ -22,29 +22,29 @@ The `createDraggable` primitive requires a unique `id`. It returns an object wit
 
 ## Input
 
-All input properties accept plain values or getter functions for reactivity.
+Input properties are plain values that are read reactively. To keep an option in sync with reactive state, define it as a getter property on the input object (for example, `createDraggable({id, get disabled() { return disabled; }})`) so the primitive re-reads it when the underlying `$state` changes.
 
-<ParamField path="id" type="UniqueIdentifier | (() => UniqueIdentifier)" required>
+<ParamField path="id" type="UniqueIdentifier" required>
   A unique identifier for this draggable instance.
 </ParamField>
 
-<ParamField path="disabled" type="boolean | (() => boolean)" optional>
+<ParamField path="disabled" type="boolean" optional>
   Whether the draggable is disabled.
 </ParamField>
 
-<ParamField path="plugins" type="PluginDescriptor[] | (() => PluginDescriptor[])" optional>
+<ParamField path="plugins" type="PluginDescriptor[]" optional>
   An array of plugin descriptors for per-entity plugin configuration. Use `Plugin.configure()` to create descriptors. For example, `Feedback.configure({ feedback: 'clone' })`.
 </ParamField>
 
-<ParamField path="modifiers" type="Modifier[] | (() => Modifier[])" optional>
+<ParamField path="modifiers" type="Modifier[]" optional>
   Modifiers to apply to this draggable instance.
 </ParamField>
 
-<ParamField path="sensors" type="Sensor[] | (() => Sensor[])" optional>
+<ParamField path="sensors" type="Sensor[]" optional>
   Sensors to use for this draggable instance.
 </ParamField>
 
-<ParamField path="data" type="Data | (() => Data)" optional>
+<ParamField path="data" type="Data" optional>
   Custom data to attach to this draggable instance.
 </ParamField>
 
@@ -101,15 +101,15 @@ You can render a completely different element while the draggable element is bei
 
 <img src="/images/draggable/drag-overlay.png" />
 
-```svelte
+<CodeGroup>
+```svelte App.svelte
 <script>
-  import {DragDropProvider, DragOverlay, createDraggable} from '@dnd-kit/svelte';
-
-  const draggable = createDraggable({id: 'draggable'});
+  import {DragDropProvider, DragOverlay} from '@dnd-kit/svelte';
+  import Draggable from './Draggable.svelte';
 </script>
 
 <DragDropProvider>
-  <button {@attach draggable.attach}>Draggable</button>
+  <Draggable id="draggable" />
   <DragOverlay>
     {#snippet children(source)}
       <div>I will be rendered while dragging...</div>
@@ -117,6 +117,19 @@ You can render a completely different element while the draggable element is bei
   </DragOverlay>
 </DragDropProvider>
 ```
+
+```svelte Draggable.svelte
+<script>
+  import {createDraggable} from '@dnd-kit/svelte';
+
+  let {id} = $props();
+
+  const draggable = createDraggable({id});
+</script>
+
+<button {@attach draggable.attach}>Draggable</button>
+```
+</CodeGroup>
 
 The `<DragOverlay>` component will only render its children when a drag operation is in progress. This can be useful for rendering a completely different element while the draggable element is being dragged.
 

--- a/apps/docs/docs/svelte/primitives/create-droppable.mdx
+++ b/apps/docs/docs/svelte/primitives/create-droppable.mdx
@@ -24,27 +24,29 @@ The `createDroppable` primitive requires a unique `id`. It returns an object wit
 
 ## Input
 
-<ParamField path="id" type="UniqueIdentifier | (() => UniqueIdentifier)" required>
+Input properties are plain values that are read reactively. To keep an option in sync with reactive state, define it as a getter property on the input object (for example, `createDroppable({id, get disabled() { return disabled; }})`) so the primitive re-reads it when the underlying `$state` changes.
+
+<ParamField path="id" type="UniqueIdentifier" required>
   A unique identifier for this droppable instance.
 </ParamField>
 
-<ParamField path="accept" type="string | string[] | (() => string | string[])" optional>
+<ParamField path="accept" type="string | string[]" optional>
   The types of draggable elements this droppable accepts.
 </ParamField>
 
-<ParamField path="type" type="string | (() => string)" optional>
+<ParamField path="type" type="string" optional>
   The type of this droppable element.
 </ParamField>
 
-<ParamField path="collisionDetector" type="CollisionDetector | (() => CollisionDetector)" optional>
+<ParamField path="collisionDetector" type="CollisionDetector" optional>
   A custom collision detection algorithm.
 </ParamField>
 
-<ParamField path="disabled" type="boolean | (() => boolean)" optional>
+<ParamField path="disabled" type="boolean" optional>
   Whether the droppable is disabled.
 </ParamField>
 
-<ParamField path="data" type="Data | (() => Data)" optional>
+<ParamField path="data" type="Data" optional>
   Custom data to attach to this droppable instance.
 </ParamField>
 

--- a/apps/docs/docs/svelte/primitives/create-sortable.mdx
+++ b/apps/docs/docs/svelte/primitives/create-sortable.mdx
@@ -103,53 +103,53 @@ Call `move()` in `onDragOver` for live visual sorting, and restore the snapshot 
 
 ## Input
 
-All input properties accept plain values or getter functions for reactivity.
+Input properties are plain values that are read reactively. To keep an option in sync with reactive state, define it as a **getter property** on the input object (e.g. `createSortable({get id() { return id; }, get index() { return index; }})`) so the primitive re-reads it when the underlying `$state` changes.
 
-<ParamField path="id" type="UniqueIdentifier | (() => UniqueIdentifier)" required>
+<ParamField path="id" type="UniqueIdentifier" required>
   A unique identifier for this sortable instance.
 </ParamField>
 
-<ParamField path="index" type="number | (() => number)" required>
+<ParamField path="index" type="number" required>
   The current index of this item in the sorted list.
 </ParamField>
 
-<ParamField path="group" type="string | (() => string)" optional>
+<ParamField path="group" type="string" optional>
   The group this sortable belongs to. Used for sorting across multiple lists.
 </ParamField>
 
-<ParamField path="accept" type="string | string[] | (() => string | string[])" optional>
+<ParamField path="accept" type="string | string[]" optional>
   The types of draggable elements this sortable accepts.
 </ParamField>
 
-<ParamField path="type" type="string | (() => string)" optional>
+<ParamField path="type" type="string" optional>
   The type of this sortable element.
 </ParamField>
 
-<ParamField path="plugins" type="PluginDescriptor[] | (() => PluginDescriptor[])" optional>
+<ParamField path="plugins" type="PluginDescriptor[]" optional>
   An array of plugin descriptors for per-entity plugin configuration. Use `Plugin.configure()` to create descriptors. For example, `Feedback.configure({ feedback: 'clone' })`.
 </ParamField>
 
-<ParamField path="transition" type="SortableTransition | (() => SortableTransition)" optional>
+<ParamField path="transition" type="SortableTransition" optional>
   Animation transition configuration for sort operations.
 </ParamField>
 
-<ParamField path="modifiers" type="Modifier[] | (() => Modifier[])" optional>
+<ParamField path="modifiers" type="Modifier[]" optional>
   Modifiers to apply to this sortable instance.
 </ParamField>
 
-<ParamField path="sensors" type="Sensor[] | (() => Sensor[])" optional>
+<ParamField path="sensors" type="Sensor[]" optional>
   Sensors to use for this sortable instance.
 </ParamField>
 
-<ParamField path="collisionDetector" type="CollisionDetector | (() => CollisionDetector)" optional>
+<ParamField path="collisionDetector" type="CollisionDetector" optional>
   A custom collision detection algorithm.
 </ParamField>
 
-<ParamField path="collisionPriority" type="number | (() => number)" optional>
+<ParamField path="collisionPriority" type="number" optional>
   The collision priority of this sortable element. Higher values take precedence when multiple droppable elements overlap.
 </ParamField>
 
-<ParamField path="disabled" type="boolean | SortableDisabled | (() => boolean | SortableDisabled)" optional>
+<ParamField path="disabled" type="boolean | SortableDisabled" optional>
   Whether the sortable is disabled. Pass an object to disable dragging and dropping independently:
 
   ```ts
@@ -160,7 +160,7 @@ All input properties accept plain values or getter functions for reactivity.
   ```
 </ParamField>
 
-<ParamField path="data" type="Data | (() => Data)" optional>
+<ParamField path="data" type="Data" optional>
   Custom data to attach to this sortable instance.
 </ParamField>
 

--- a/apps/docs/docs/vue/components/drag-overlay.mdx
+++ b/apps/docs/docs/vue/components/drag-overlay.mdx
@@ -15,24 +15,43 @@ The `DragOverlay` component renders a custom overlay element while a drag operat
 
 Import and place the `DragOverlay` component inside a [`DragDropProvider`](/vue/components/drag-drop-provider). Its children will only be rendered when a drag operation is active.
 
-```vue
-<script setup>
-import {ref} from 'vue';
-import {DragDropProvider, DragOverlay, useDraggable} from '@dnd-kit/vue';
+<Note>
+  Composables like `useDraggable` must be called in a **child component** of `DragDropProvider`, not in the same component that renders the provider — Vue's `provide`/`inject` only resolves injections from ancestor components.
+</Note>
 
-const element = ref(null);
-useDraggable({id: 'my-item', element});
+<CodeGroup>
+```vue App.vue
+<script setup>
+import {DragDropProvider, DragOverlay} from '@dnd-kit/vue';
+import Draggable from './Draggable.vue';
 </script>
 
 <template>
   <DragDropProvider>
-    <button ref="element">Drag me</button>
+    <Draggable id="my-item" />
     <DragOverlay>
       <div>I will be rendered while dragging...</div>
     </DragOverlay>
   </DragDropProvider>
 </template>
 ```
+
+```vue Draggable.vue
+<script setup>
+import {ref} from 'vue';
+import {useDraggable} from '@dnd-kit/vue';
+
+const props = defineProps(['id']);
+const element = ref(null);
+
+useDraggable({id: props.id, element});
+</script>
+
+<template>
+  <button ref="element">Drag me</button>
+</template>
+```
+</CodeGroup>
 
 <Warning>
   You should only render the `DragOverlay` component once per [DragDropProvider](/vue/components/drag-drop-provider).

--- a/apps/docs/docs/vue/composables/use-draggable.mdx
+++ b/apps/docs/docs/vue/composables/use-draggable.mdx
@@ -96,24 +96,39 @@ You can render a completely different element while the draggable element is bei
 
 <img src="/images/draggable/drag-overlay.png" />
 
-```vue
+<CodeGroup>
+```vue App.vue
 <script setup>
-import {ref} from 'vue';
-import {DragDropProvider, DragOverlay, useDraggable} from '@dnd-kit/vue';
-
-const element = ref(null);
-useDraggable({id: 'draggable', element});
+import {DragDropProvider, DragOverlay} from '@dnd-kit/vue';
+import Draggable from './Draggable.vue';
 </script>
 
 <template>
   <DragDropProvider>
-    <button ref="element">Draggable</button>
+    <Draggable id="draggable" />
     <DragOverlay>
       <div>I will be rendered while dragging...</div>
     </DragOverlay>
   </DragDropProvider>
 </template>
 ```
+
+```vue Draggable.vue
+<script setup>
+import {ref} from 'vue';
+import {useDraggable} from '@dnd-kit/vue';
+
+const props = defineProps(['id']);
+const element = ref(null);
+
+useDraggable({id: props.id, element});
+</script>
+
+<template>
+  <button ref="element">Draggable</button>
+</template>
+```
+</CodeGroup>
 
 The `<DragOverlay>` component will only render its children when a drag operation is in progress. This can be useful for rendering a completely different element while the draggable element is being dragged.
 


### PR DESCRIPTION
## Summary

A code-first audit of the docs (the packages in this repo as source of truth) surfaced a set of documentation errors where copy-pasting an example breaks at runtime, doesn't compile, or silently misbehaves. This PR fixes all of the high-severity findings; a list of remaining minor findings (type-table narrowing, missing imports in secondary examples, etc.) is below for potential follow-up.

## Fixes

### Silently-broken examples
- **`accepts` → `accept`** ([concepts/droppable](apps/docs/docs/concepts/droppable.mdx), [quickstart](apps/docs/docs/quickstart.mdx)): the `Droppable` input option is `accept` (`accepts()` is a method). The stray `accepts` key was silently discarded, so all three documented examples accepted **every** draggable.
- **`RestrictToElement.configure({element: container.current})`** ([react/guides/modifiers](apps/docs/docs/react/guides/modifiers.mdx)): captures `null` on first render; the modifier bails on a falsy target so dragging was silently unrestricted. Switched to the function form (evaluated at drag time) and added a Note explaining why.

### Examples that throw or don't compile
- **Vue & Svelte overlay examples** ([vue/drag-overlay](apps/docs/docs/vue/components/drag-overlay.mdx), [vue/use-draggable](apps/docs/docs/vue/composables/use-draggable.mdx), [svelte/drag-overlay](apps/docs/docs/svelte/components/drag-overlay.mdx), [svelte/create-draggable](apps/docs/docs/svelte/primitives/create-draggable.mdx)): called `useDraggable`/`createDraggable` in the same component that renders `DragDropProvider`; `provide`/`inject` and `getContext` only resolve from ancestors, so these throw on mount. Restructured to child components — same bug and same fix as 2dda3f2d (#2035), which only covered the Svelte quickstart.
- **`Snap` → `SnapModifier`** ([extend/modifiers](apps/docs/docs/extend/modifiers.mdx)): there is no `Snap` export. Also removed the `size: {y: 0}` claim — `Math.ceil(y / 0) * 0` is `NaN`, it does not disable an axis.
- **`activationConstraints: {distance: 5}`** ([concepts/drag-drop-manager](apps/docs/docs/concepts/drag-drop-manager.mdx)): the option takes an array of constraint instances (`new PointerActivationConstraints.Distance({value: 5})`), not a plain object.
- **DragDropProvider event handlers** ([react/components/drag-drop-provider](apps/docs/docs/react/components/drag-drop-provider.mdx)): four handlers destructured a top-level `{source, target, event}` that doesn't exist — payloads nest entities under `event.operation`.

### Misleading behavior claims
- **Default collision detection** ([concepts/droppable](apps/docs/docs/concepts/droppable.mdx), [react/guides/collision-detection](apps/docs/docs/react/guides/collision-detection.mdx)): the default is `defaultCollisionDetection` (`pointerIntersection ?? shapeIntersection`), not plain rectangle intersection; `closestCenter` also intersects first and only falls back to center distance.
- **Returning `undefined` from `activationConstraints`** ([react/guides/sensors](apps/docs/docs/react/guides/sensors.mdx)): means *no constraints* (instant activation on pointerdown) — it does not restore the defaults.
- **Debug plugin** ([extend/plugins](apps/docs/docs/extend/plugins.mdx)): listed as a default plugin; it is opt-in via `@dnd-kit/dom/plugins/debug` (the Debug page itself says so). Moved to a separate "opt-in" card group.
- **`useDragDropManager` null claim** ([react/hooks/use-drag-drop-manager](apps/docs/docs/react/hooks/use-drag-drop-manager.mdx)): the context ships a shared default manager, so the hook never returns `null` at runtime; only the TS type is nullable.
- **Droppable `type` semantics** ([react/hooks/use-droppable](apps/docs/docs/react/hooks/use-droppable.mdx), [react/hooks/use-sortable](apps/docs/docs/react/hooks/use-sortable.mdx), [concepts/droppable](apps/docs/docs/concepts/droppable.mdx)): `accept` rules check the **draggable's** `type`; a droppable's own `type` is never consulted. The previous descriptions had the direction inverted.
- **Svelte primitive inputs** ([create-draggable](apps/docs/docs/svelte/primitives/create-draggable.mdx), [create-droppable](apps/docs/docs/svelte/primitives/create-droppable.mdx), [create-sortable](apps/docs/docs/svelte/primitives/create-sortable.mdx)): every option table claimed `X | (() => X)` getter-function unions. The inputs are plain values read reactively inside `$effect`; passing `id: () => 'x'` is a type error and assigns a function as the id at runtime. Reactivity works via getter *properties* on the input object (as `create-sortable`'s own Note already showed). Rewrote the intro sentences and stripped the function unions.

## Not included (minor findings from the same audit)

- Type-table narrowing across all frameworks: `accept` omits the predicate form and `number`/`Symbol` types; `group` documented as `string` but is `string | number`; `plugins` omits bare constructors; `sensors: Sensors[]` is an array-of-arrays as written
- `useDragDropMonitor` events table lists camelCase event names (`dragStart`) but monitor events are lowercase (`dragstart`)
- Missing imports / export mismatches in a few secondary examples (React quickstart CodeGroup, migration guide `isDragging` reference)
- Default plugin list omits `StyleInjector`; pointer-sensor default constraint matrix is oversimplified; keyboard sensor docs claim a nonexistent `keyup` listener; Delay constraint `tolerance` marked optional but required; `'move'` feedback described as skipping top-layer promotion (only the placeholder is skipped); `useDragOperation` documents `undefined` when idle but returns `null`

🤖 Generated with [Claude Code](https://claude.com/claude-code)