### PR TITLE
fix: keep operation snapshots transform current

### DIFF
--- a/packages/abstract/src/core/manager/operation.ts
+++ b/packages/abstract/src/core/manager/operation.ts
@@ -167,7 +167,7 @@ export class DragOperation<T extends Draggable, U extends Droppable>
 
     for (const modifier of this.modifiers) {
       transform = modifier.apply({
-        ...this.snapshot(),
+        ...untracked(() => this.#snapshot(transform)),
         transform,
       });
     }
@@ -183,16 +183,20 @@ export class DragOperation<T extends Draggable, U extends Droppable>
    * @returns An immutable snapshot of the current operation state
    */
   public snapshot(): DragOperationSnapshot<T, U> {
-    return untracked(() => ({
+    return untracked(() => this.#snapshot(this.transform));
+  }
+
+  #snapshot(transform: Coordinates): DragOperationSnapshot<T, U> {
+    return {
       source: this.source,
       target: this.target,
       activatorEvent: this.activatorEvent,
-      transform: this.#transform,
+      transform,
       shape: this.shape ? snapshot(this.shape) : null,
       position: snapshot(this.position),
       status: snapshot(this.status),
       canceled: this.canceled,
-    }));
+    };
   }
 
   /**

--- a/packages/abstract/tests/manager-modifiers.test.ts
+++ b/packages/abstract/tests/manager-modifiers.test.ts
@@ -25,6 +25,32 @@ function flush() {
 }
 
 describe('Manager-level modifiers', () => {
+  it('should include the latest transformed coordinates in snapshots', async () => {
+    const manager = new DragDropManager({modifiers: [ClampXModifier]});
+    const draggable = new Draggable({id: 'd1', register: false}, manager);
+    let transform: {x: number; y: number} | undefined;
+
+    manager.monitor.addEventListener('dragend', (event) => {
+      transform = event.operation.transform;
+    });
+
+    draggable.register();
+    manager.actions.start({source: draggable, coordinates: {x: 0, y: 0}});
+    await flush();
+
+    batch(() => {
+      manager.dragOperation.position.current = {x: 100, y: 50};
+    });
+
+    manager.actions.stop();
+    await flush();
+
+    expect(transform).toEqual({x: 0, y: 50});
+
+    draggable.destroy();
+    manager.destroy();
+  });
+
   it('should apply manager modifiers when draggable has none', () => {
     const manager = new DragDropManager({modifiers: [ClampXModifier]});
     const draggable = new Draggable({id: 'd1', register: false}, manager);


### PR DESCRIPTION
Fixes #2055.

## Summary
- Compute the current drag transform before returning public operation snapshots.
- Reuse an internal snapshot helper while modifiers are applied so modifier snapshots do not recursively recompute transform.
- Add a regression test that checks event snapshots include the latest transformed coordinates without reading dragOperation.transform first.

## Testing
- npx -y bun@1.3.11 run build
- npx -y bun@1.3.11 test packages/abstract/tests
