### PR TITLE
fix(dom): reset auto scroller state on cleanup

### DIFF
--- a/.changeset/quiet-scrolls-stop.md
+++ b/.changeset/quiet-scrolls-stop.md
@@ -1,0 +1,5 @@
+---
+'@dnd-kit/dom': patch
+---
+
+Stop AutoScroller from leaving the shared scroller in an auto-scrolling state after its interval is cleaned up.

--- a/packages/dom/src/core/plugins/scrolling/AutoScroller.ts
+++ b/packages/dom/src/core/plugins/scrolling/AutoScroller.ts
@@ -68,6 +68,7 @@ export class AutoScroller extends Plugin<DragDropManager, AutoScrollerOptions> {
 
           return () => {
             clearInterval(interval);
+            scroller.autoScrolling = false;
           };
         } else {
           scroller.autoScrolling = false;

--- a/packages/dom/tests/auto-scroller.test.ts
+++ b/packages/dom/tests/auto-scroller.test.ts
@@ -1,0 +1,37 @@
+import {describe, expect, it, jest} from 'bun:test';
+import type {DragDropManager} from '@dnd-kit/abstract';
+
+import {AutoScroller} from '../src/core/plugins/scrolling/AutoScroller.ts';
+import {Scroller} from '../src/core/plugins/scrolling/Scroller.ts';
+
+function createManager(scroller: Pick<Scroller, 'autoScrolling' | 'scroll'>) {
+  return {
+    dragOperation: {
+      position: {current: {x: 0, y: 0}},
+      status: {dragging: true},
+    },
+    registry: {
+      plugins: {
+        get(plugin: unknown) {
+          return plugin === Scroller ? scroller : undefined;
+        },
+      },
+    },
+  } as DragDropManager<any, any>;
+}
+
+describe('AutoScroller', () => {
+  it('resets the scroller state when auto-scrolling is cleaned up', () => {
+    const scroller = {
+      autoScrolling: false,
+      scroll: jest.fn(() => true),
+    };
+    const autoScroller = new AutoScroller(createManager(scroller));
+
+    expect(scroller.autoScrolling).toBe(true);
+
+    autoScroller.destroy();
+
+    expect(scroller.autoScrolling).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- reset the shared Scroller.autoScrolling flag when AutoScroller cleans up its interval
- add a regression test for AutoScroller cleanup
- add a patch changeset for @dnd-kit/dom

Closes #2072.

## Testing
- ./node_modules/.bin/prettier --check packages/dom/src/core/plugins/scrolling/AutoScroller.ts packages/dom/tests/auto-scroller.test.ts .changeset/quiet-scrolls-stop.md
- ./node_modules/.bin/tsc packages/dom/tests/auto-scroller.test.ts --noEmit --target es6 --module NodeNext --moduleResolution NodeNext --lib dom,dom.iterable,ES2015 --allowImportingTsExtensions --isolatedModules --strict --skipLibCheck --types bun-types

Note: I could not run bun test locally because bun is not installed in this environment.