### PR TITLE
[#2112] Fix not cleanup of default sensors for Svelte library

### DIFF
--- a/packages/svelte/src/core/context/DragDropProvider.svelte
+++ b/packages/svelte/src/core/context/DragDropProvider.svelte
@@ -43,8 +43,8 @@
 
   const {renderer, trackRendering} = createRenderer();
 
-  // Create manager once; plugins/sensors/modifiers are synced reactively via $effect below
-  const manager = managerProp ?? new DragDropManager({});
+  const manager =
+    managerProp ?? new DragDropManager({plugins, sensors, modifiers});
 
   manager.renderer = renderer;
 


### PR DESCRIPTION
Previously the manager was constructed with an empty config, so defaultPreset.sensors (including KeyboardSensor) was always instantiated and bound to draggables before the reactive effect corrected it. Destroying a sensor doesn't unbind listeners already bound to draggables, so the default KeyboardSensor kept handling events even when a custom or no keyboard sensor was passed. Now the manager is created with the actual props, matching the React and Vue providers.