### PR TITLE
Support custom scroll intent detector in Scroller/AutoScroller

### DIFF
--- a/.changeset/tame-dolphins-scroll.md
+++ b/.changeset/tame-dolphins-scroll.md
@@ -1,0 +1,9 @@
+---
+'@dnd-kit/dom': minor
+---
+
+Add support for custom scroll intent detection during auto-scrolling.
+
+- `AutoScroller` accepts a new `detectScrollIntent` option that replaces the default detection logic. A custom detector can fully control the activation conditions and scroll parameters.
+- The `Scroller.scroll` method accepts new `detectScrollIntent` and `onScroll` options. `onScroll` is a synchronous callback that fires right after the asynchronously scheduled scroll task actually applies a position change.
+- The default `detectScrollIntent` implementation has been refactored into composable pure steps exported from `@dnd-kit/dom/utilities`: `detectActivation`, `suppressOpposingIntent`, `applyAcceleration`, `applyAxisInversion` and `stopAtBoundaries`.

--- a/apps/docs/docs/extend/plugins/auto-scroller.mdx
+++ b/apps/docs/docs/extend/plugins/auto-scroller.mdx
@@ -123,6 +123,53 @@ function App() {
   A single number applies to both axes. Use `{ x, y }` for per-axis control. Setting an axis to `0` disables auto-scrolling on that axis.
 </ParamField>
 
+<ParamField path="detectScrollIntent" type="(context: ScrollIntentDetectorContext, options?: ScrollIntentDetectorOptions) => ScrollIntent">
+  Custom function that computes the scroll direction and speed from the pointer position, overriding the built-in detector. See [Custom scroll intent detector](#custom-scroll-intent-detector).
+</ParamField>
+
+## Custom scroll intent detector
+
+By default, the `AutoScroller` activates scrolling when the pointer enters the activation zones near a container's edges. Provide a `detectScrollIntent` function to take full control over the scroll direction and speed.
+
+A detector receives a context describing the scrollable element and pointer, along with the auto scroller options.
+
+The context provides:
+
+- `element` — the scrollable element being evaluated.
+- `scrollPosition` — the container's `rect` and its `isTop` / `isBottom` / `isLeft` / `isRight` edge state.
+- `pointer` — the current pointer coordinates.
+- `inverted` — whether each axis is visually inverted, for example by a negative `scale` transform.
+- `operation` — the active drag operation, when available.
+
+Example:
+
+```ts
+import {DragDropManager, AutoScroller} from '@dnd-kit/dom';
+import {
+  detectScrollIntent,
+  ScrollDirection,
+  type ScrollIntentDetector,
+} from '@dnd-kit/dom/utilities';
+
+const verticalOnly: ScrollIntentDetector = (context, options) => {
+  const intent = detectScrollIntent(context, options);
+
+  return {
+    direction: {...intent.direction, x: ScrollDirection.Idle},
+    speed: {...intent.speed, x: 0},
+  };
+};
+
+const manager = new DragDropManager({
+  plugins: (defaults) => [
+    ...defaults,
+    AutoScroller.configure({detectScrollIntent: verticalOnly}),
+  ],
+});
+```
+
+See [Configuration](#configuration) for setup in other frameworks.
+
 ## Disabling
 
 To disable auto-scrolling, omit the `AutoScroller` from the plugins array:

--- a/apps/stories/stories/react/Sortable/Vertical/CustomScrollIntentExample.tsx
+++ b/apps/stories/stories/react/Sortable/Vertical/CustomScrollIntentExample.tsx
@@ -1,0 +1,180 @@
+import {useState, memo} from 'react';
+import type {PropsWithChildren} from 'react';
+import type {UniqueIdentifier} from '@dnd-kit/abstract';
+import {AutoScroller} from '@dnd-kit/dom';
+import {
+  ScrollDirection,
+  suppressOpposingIntent,
+  applyAcceleration,
+  applyAxisInversion,
+  stopAtBoundaries,
+  type ScrollActivation,
+  type ScrollIntentDetector,
+} from '@dnd-kit/dom/utilities';
+import {DragDropProvider} from '@dnd-kit/react';
+import {useSortable} from '@dnd-kit/react/sortable';
+import {move} from '@dnd-kit/helpers';
+import {directionBiased} from '@dnd-kit/collision';
+
+import {Item} from '../../components/index.ts';
+import {createRange} from '@dnd-kit/stories-shared/utilities';
+
+const UPWARD_ZONE_RATIO = 0.8;
+
+const detectSplitScrollIntent: ScrollIntentDetector = (ctx, options) => {
+  const {pointer, scrollPosition, inverted, requestedDirection} = ctx;
+  const {rect} = scrollPosition;
+
+  const activation: ScrollActivation = {
+    direction: {x: ScrollDirection.Idle, y: ScrollDirection.Idle},
+    intensity: {x: 0, y: 0},
+  };
+
+  const within =
+    rect.height > 0 && pointer.y >= rect.top && pointer.y <= rect.bottom;
+
+  if (within) {
+    const splitY = rect.top + rect.height * UPWARD_ZONE_RATIO;
+
+    if (pointer.y < splitY) {
+      activation.direction.y = ScrollDirection.Reverse;
+      activation.intensity.y =
+        (splitY - pointer.y) / (rect.height * UPWARD_ZONE_RATIO);
+    } else {
+      activation.direction.y = ScrollDirection.Forward;
+      activation.intensity.y =
+        (pointer.y - splitY) / (rect.height * (1 - UPWARD_ZONE_RATIO));
+    }
+  }
+
+  const suppressed = suppressOpposingIntent(activation, requestedDirection);
+  const accelerated = applyAcceleration(suppressed, options?.acceleration);
+  const flipped = applyAxisInversion(accelerated, inverted);
+
+  return stopAtBoundaries(flipped, scrollPosition);
+};
+
+interface Props {
+  itemCount?: number;
+}
+
+export function CustomScrollIntentExample({itemCount = 100}: Props) {
+  const [items, setItems] = useState(createRange(itemCount));
+
+  return (
+    <DragDropProvider
+      plugins={(defaults) => [
+        ...defaults,
+        AutoScroller.configure({detectScrollIntent: detectSplitScrollIntent}),
+      ]}
+      onDragEnd={(event) => {
+        setItems((items) => move(items, event));
+      }}
+    >
+      <ActivationOverlay />
+      <div
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          gap: 18,
+          padding: '0 30px',
+        }}
+      >
+        {items.map((id, index) => (
+          <SortableItem key={id} id={id} index={index} />
+        ))}
+      </div>
+    </DragDropProvider>
+  );
+}
+
+function ActivationOverlay() {
+  const upwardPercent = UPWARD_ZONE_RATIO * 100;
+  const downwardPercent = 100 - upwardPercent;
+
+  return (
+    <div
+      style={{
+        position: 'fixed',
+        inset: 0,
+        pointerEvents: 'none',
+        zIndex: 5,
+      }}
+    >
+      <Zone
+        ratio={UPWARD_ZONE_RATIO}
+        label={`↑ Scroll up · ${upwardPercent}%`}
+        background="rgba(59, 130, 246, 0.06)"
+        accent="rgb(37, 99, 235)"
+        align="flex-start"
+        divider
+      />
+      <Zone
+        ratio={1 - UPWARD_ZONE_RATIO}
+        label={`↓ Scroll down · ${downwardPercent}%`}
+        background="rgba(239, 68, 68, 0.06)"
+        accent="rgb(220, 38, 38)"
+        align="flex-end"
+      />
+    </div>
+  );
+}
+
+interface ZoneProps {
+  ratio: number;
+  label: string;
+  background: string;
+  accent: string;
+  align: 'flex-start' | 'flex-end';
+  divider?: boolean;
+}
+
+function Zone({ratio, label, background, accent, align, divider}: ZoneProps) {
+  return (
+    <div
+      style={{
+        height: `${ratio * 100}%`,
+        background,
+        borderBottom: divider ? `1px dashed ${accent}` : undefined,
+        display: 'flex',
+        alignItems: align,
+        justifyContent: 'center',
+        padding: 12,
+        boxSizing: 'border-box',
+      }}
+    >
+      <span
+        style={{
+          fontSize: 12,
+          fontWeight: 600,
+          color: accent,
+          background: 'rgba(255, 255, 255, 0.9)',
+          padding: '2px 8px',
+          borderRadius: 4,
+        }}
+      >
+        {label}
+      </span>
+    </div>
+  );
+}
+
+const SortableItem = memo(function SortableItem({
+  id,
+  index,
+}: PropsWithChildren<{id: UniqueIdentifier; index: number}>) {
+  const [element, setElement] = useState<Element | null>(null);
+  const {isDragging} = useSortable({
+    id,
+    index,
+    element,
+    collisionDetector: directionBiased,
+  });
+
+  return (
+    <Item ref={setElement} shadow={isDragging}>
+      {id}
+    </Item>
+  );
+});

--- a/apps/stories/stories/react/Sortable/Vertical/Vertical.stories.tsx
+++ b/apps/stories/stories/react/Sortable/Vertical/Vertical.stories.tsx
@@ -5,6 +5,7 @@ import {Feedback} from '@dnd-kit/dom';
 import {SortableExample} from '../SortableExample';
 import {AnchorElementsExample} from './AnchorElementsExample';
 import {AutoScrollExample} from './AutoScrollExample';
+import {CustomScrollIntentExample} from './CustomScrollIntentExample';
 
 const meta: Meta<typeof SortableExample> = {
   title: 'React/Sortable/Vertical list',
@@ -166,6 +167,18 @@ export const AutoScrollCustomSpeed: AutoScrollStory = {
   args: {
     itemCount: 100,
     acceleration: 50,
+  },
+};
+
+export const AutoScrollCustomIntent: StoryObj<
+  typeof CustomScrollIntentExample
+> = {
+  name: 'Auto-scroll custom intent detector',
+  render: (args: React.ComponentProps<typeof CustomScrollIntentExample>) => (
+    <CustomScrollIntentExample {...args} />
+  ),
+  args: {
+    itemCount: 100,
   },
 };
 

--- a/apps/stories/tests/sortable-autoscroll-options.spec.ts
+++ b/apps/stories/tests/sortable-autoscroll-options.spec.ts
@@ -77,4 +77,42 @@ test.describe('AutoScroller options', () => {
       await dnd.waitForDrop();
     });
   });
+
+  test.describe('custom scroll intent detector', () => {
+    test.beforeEach(async ({dnd}) => {
+      await dnd.goto('react-sortable-vertical-list--auto-scroll-custom-intent');
+      await expect(dnd.items.first()).toBeVisible();
+    });
+
+    test('auto-scrolls by the customized 80-20 activation zones', async ({
+      dnd,
+    }) => {
+      const first = dnd.items.nth(0);
+      const box = await first.boundingBox();
+      const viewport = dnd.page.viewportSize()!;
+      const centerX = box!.x + box!.width / 2;
+
+      const getScrollTop = () =>
+        dnd.page.evaluate(() => document.scrollingElement?.scrollTop ?? 0);
+
+      await dnd.page.mouse.move(centerX, box!.y + box!.height / 2);
+      await dnd.page.mouse.down();
+
+      // Lower zone (bottom 20%): scroll the page down.
+      await dnd.page.mouse.move(centerX, viewport.height - 10, {steps: 20});
+
+      await expect.poll(getScrollTop, {timeout: 3_000}).toBeGreaterThan(0);
+      const scrolledDown = await getScrollTop();
+
+      // Upper zone (top 80%): scroll the page up.
+      await dnd.page.mouse.move(centerX, viewport.height / 2, {steps: 20});
+
+      await expect
+        .poll(getScrollTop, {timeout: 3_000})
+        .toBeLessThan(scrolledDown);
+
+      await dnd.page.mouse.up();
+      await dnd.waitForDrop();
+    });
+  });
 });

--- a/packages/dom/src/core/index.ts
+++ b/packages/dom/src/core/index.ts
@@ -12,10 +12,7 @@ export type {
 } from './manager/events.ts';
 
 export {Draggable, Droppable} from './entities/index.ts';
-export type {
-  DraggableInput,
-  DroppableInput,
-} from './entities/index.ts';
+export type {DraggableInput, DroppableInput} from './entities/index.ts';
 
 export type {Sensors} from './sensors/types.ts';
 export {
@@ -46,4 +43,6 @@ export type {
   DropAnimation,
   DropAnimationOptions,
   DropAnimationFunction,
+  ScrollOptions,
+  ScrollSnapshot,
 } from './plugins/index.ts';

--- a/packages/dom/src/core/plugins/index.ts
+++ b/packages/dom/src/core/plugins/index.ts
@@ -15,7 +15,11 @@ export type {
 } from './feedback/index.ts';
 
 export {AutoScroller, Scroller, ScrollListener} from './scrolling/index.ts';
-export type {AutoScrollerOptions} from './scrolling/index.ts';
+export type {
+  AutoScrollerOptions,
+  ScrollOptions,
+  ScrollSnapshot,
+} from './scrolling/index.ts';
 
 export {PreventSelection} from './selection/PreventSelection.ts';
 

--- a/packages/dom/src/core/plugins/scrolling/AutoScroller.ts
+++ b/packages/dom/src/core/plugins/scrolling/AutoScroller.ts
@@ -2,6 +2,7 @@ import {configurator, Plugin} from '@dnd-kit/abstract';
 import {effect} from '@dnd-kit/state';
 import type {CleanupFunction} from '@dnd-kit/state';
 import type {Axis} from '@dnd-kit/geometry';
+import type {ScrollIntentDetector} from '@dnd-kit/dom/utilities';
 
 import type {DragDropManager} from '../../manager/index.ts';
 import {Scroller} from './Scroller.ts';
@@ -20,6 +21,11 @@ export interface AutoScrollerOptions {
    * @default { x: 0.2, y: 0.2 }
    */
   threshold?: number | Record<Axis, number>;
+  /**
+   * Custom scroll intent detector used to compute the scroll direction and
+   * speed from the pointer position.
+   */
+  detectScrollIntent?: ScrollIntentDetector;
 }
 
 const AUTOSCROLL_INTERVAL = 10;
@@ -52,6 +58,7 @@ export class AutoScroller extends Plugin<DragDropManager, AutoScrollerOptions> {
             typeof this.options?.threshold === 'number'
               ? {x: this.options.threshold, y: this.options.threshold}
               : this.options?.threshold,
+          detectScrollIntent: this.options?.detectScrollIntent,
         };
 
         const canScroll = scroller.scroll(undefined, scrollOptions);

--- a/packages/dom/src/core/plugins/scrolling/Scroller.ts
+++ b/packages/dom/src/core/plugins/scrolling/Scroller.ts
@@ -13,7 +13,6 @@ import {
   scheduler,
   isKeyboardEvent,
   getDocument,
-  getFrameTransform,
   getRoot,
 } from '@dnd-kit/dom/utilities';
 import {Axes, type Axis, type Coordinates} from '@dnd-kit/geometry';
@@ -22,10 +21,16 @@ import type {DragDropManager} from '../../manager/index.ts';
 
 import {ScrollIntentTracker} from './ScrollIntent.ts';
 
+export interface ScrollSnapshot {
+  element: Element;
+  before: {scrollLeft: number; scrollTop: number};
+}
+
 export interface ScrollOptions {
   acceleration?: number;
   threshold?: Record<Axis, number>;
   detectScrollIntent?: ScrollIntentDetector;
+  onScroll?: (snapshot: ScrollSnapshot) => void;
 }
 
 export class Scroller extends CorePlugin<DragDropManager> {
@@ -123,17 +128,34 @@ export class Scroller extends CorePlugin<DragDropManager> {
     });
   }
 
-  #meta: {element: Element; by: Coordinates} | undefined;
+  #meta:
+    | {
+        element: Element;
+        by: Coordinates;
+        onScroll?: ScrollOptions['onScroll'];
+      }
+    | undefined;
 
   #scroll = () => {
     if (!this.#meta) {
       return;
     }
 
-    const {element, by} = this.#meta;
+    const {element, by, onScroll} = this.#meta;
+    const before = {
+      scrollLeft: element.scrollLeft,
+      scrollTop: element.scrollTop,
+    };
 
     if (by.y) element.scrollTop += by.y;
     if (by.x) element.scrollLeft += by.x;
+
+    if (
+      element.scrollLeft !== before.scrollLeft ||
+      element.scrollTop !== before.scrollTop
+    ) {
+      onScroll?.({element, before});
+    }
   };
 
   public scroll = (
@@ -218,6 +240,7 @@ export class Scroller extends CorePlugin<DragDropManager> {
                   x: scrollLeftBy,
                   y: scrollTopBy,
                 },
+                onScroll: scrollOptions?.onScroll,
               };
 
               scheduler.schedule(this.#scroll);

--- a/packages/dom/src/core/plugins/scrolling/Scroller.ts
+++ b/packages/dom/src/core/plugins/scrolling/Scroller.ts
@@ -3,6 +3,9 @@ import {computed, deepEqual, reactive} from '@dnd-kit/state';
 import {
   canScroll,
   detectScrollIntent,
+  getFrameTransformedScrollPosition,
+  getAxisInversionState,
+  type ScrollIntentDetectorContext,
   getScrollableAncestors,
   getElementFromPoint,
   ScrollDirection,
@@ -151,13 +154,13 @@ export class Scroller extends CorePlugin<DragDropManager> {
 
     if (currentPosition) {
       const {by} = options ?? {};
-      const intent = by
+      const requestedDirection = by
         ? {
             x: getScrollIntent(by.x),
             y: getScrollIntent(by.y),
           }
         : undefined;
-      const scrollIntent = intent
+      const scrollIntent = requestedDirection
         ? undefined
         : this.scrollIntentTracker.current;
 
@@ -169,13 +172,16 @@ export class Scroller extends CorePlugin<DragDropManager> {
         const elementCanScroll = canScroll(scrollableElement, by);
 
         if (elementCanScroll.x || elementCanScroll.y) {
-          const {speed, direction} = detectScrollIntent(
-            scrollableElement,
-            currentPosition,
-            intent,
-            scrollOptions?.acceleration,
-            scrollOptions?.threshold
-          );
+          const ctx: ScrollIntentDetectorContext = {
+            element: scrollableElement,
+            scrollPosition:
+              getFrameTransformedScrollPosition(scrollableElement),
+            inverted: getAxisInversionState(scrollableElement),
+            pointer: currentPosition,
+            operation: this.manager.dragOperation,
+            requestedDirection,
+          };
+          const {speed, direction} = detectScrollIntent(ctx, scrollOptions);
 
           if (scrollIntent) {
             for (const axis of Axes) {

--- a/packages/dom/src/core/plugins/scrolling/Scroller.ts
+++ b/packages/dom/src/core/plugins/scrolling/Scroller.ts
@@ -207,7 +207,9 @@ export class Scroller extends CorePlugin<DragDropManager> {
           };
           const detect: ScrollIntentDetector =
             scrollOptions?.detectScrollIntent ?? detectScrollIntent;
-          const {speed, direction} = detect(ctx, scrollOptions);
+          const detected = detect(ctx, scrollOptions);
+          const speed = {...detected.speed};
+          const direction = {...detected.direction};
 
           if (scrollIntent) {
             for (const axis of Axes) {

--- a/packages/dom/src/core/plugins/scrolling/Scroller.ts
+++ b/packages/dom/src/core/plugins/scrolling/Scroller.ts
@@ -5,6 +5,7 @@ import {
   detectScrollIntent,
   getFrameTransformedScrollPosition,
   getAxisInversionState,
+  type ScrollIntentDetector,
   type ScrollIntentDetectorContext,
   getScrollableAncestors,
   getElementFromPoint,
@@ -24,6 +25,7 @@ import {ScrollIntentTracker} from './ScrollIntent.ts';
 export interface ScrollOptions {
   acceleration?: number;
   threshold?: Record<Axis, number>;
+  detectScrollIntent?: ScrollIntentDetector;
 }
 
 export class Scroller extends CorePlugin<DragDropManager> {
@@ -181,7 +183,9 @@ export class Scroller extends CorePlugin<DragDropManager> {
             operation: this.manager.dragOperation,
             requestedDirection,
           };
-          const {speed, direction} = detectScrollIntent(ctx, scrollOptions);
+          const detect: ScrollIntentDetector =
+            scrollOptions?.detectScrollIntent ?? detectScrollIntent;
+          const {speed, direction} = detect(ctx, scrollOptions);
 
           if (scrollIntent) {
             for (const axis of Axes) {

--- a/packages/dom/src/core/plugins/scrolling/index.ts
+++ b/packages/dom/src/core/plugins/scrolling/index.ts
@@ -1,4 +1,5 @@
 export {Scroller} from './Scroller.ts';
+export type {ScrollOptions, ScrollSnapshot} from './Scroller.ts';
 export {AutoScroller} from './AutoScroller.ts';
 export type {AutoScrollerOptions} from './AutoScroller.ts';
 export {ScrollListener} from './ScrollListener.ts';

--- a/packages/dom/src/utilities/index.ts
+++ b/packages/dom/src/utilities/index.ts
@@ -51,6 +51,7 @@ export {
 } from './scroll/index.ts';
 export type {
   ScrollActivation,
+  ScrollIntentDetector,
   ScrollIntentDetectorContext,
   ScrollIntentDetectorOptions,
   ScrollIntent,

--- a/packages/dom/src/utilities/index.ts
+++ b/packages/dom/src/utilities/index.ts
@@ -36,6 +36,11 @@ export {showPopover, hidePopover, supportsPopover} from './popover/index.ts';
 export {
   canScroll,
   detectScrollIntent,
+  detectActivation,
+  suppressOpposingIntent,
+  applyAcceleration,
+  applyAxisInversion,
+  stopAtBoundaries,
   getFrameTransformedScrollPosition,
   getAxisInversionState,
   getScrollableAncestors,
@@ -45,6 +50,7 @@ export {
   scrollIntoViewIfNeeded,
 } from './scroll/index.ts';
 export type {
+  ScrollActivation,
   ScrollIntentDetectorContext,
   ScrollIntentDetectorOptions,
   ScrollIntent,

--- a/packages/dom/src/utilities/index.ts
+++ b/packages/dom/src/utilities/index.ts
@@ -36,11 +36,19 @@ export {showPopover, hidePopover, supportsPopover} from './popover/index.ts';
 export {
   canScroll,
   detectScrollIntent,
+  getFrameTransformedScrollPosition,
+  getAxisInversionState,
   getScrollableAncestors,
   getFirstScrollableAncestor,
   isDocumentScrollingElement,
   ScrollDirection,
   scrollIntoViewIfNeeded,
+} from './scroll/index.ts';
+export type {
+  ScrollIntentDetectorContext,
+  ScrollIntentDetectorOptions,
+  ScrollIntent,
+  ScrollPosition,
 } from './scroll/index.ts';
 
 export {scheduler, Scheduler, timeout} from './scheduling/index.ts';

--- a/packages/dom/src/utilities/scroll/detectScrollIntent.ts
+++ b/packages/dom/src/utilities/scroll/detectScrollIntent.ts
@@ -1,4 +1,9 @@
-import type {Axis, Coordinates} from '@dnd-kit/geometry';
+import {
+  Axes,
+  type Axis,
+  type BoundingRectangle,
+  type Coordinates,
+} from '@dnd-kit/geometry';
 import type {DragOperation, Draggable, Droppable} from '@dnd-kit/abstract';
 
 import {getFrameTransformedScrollPosition} from './getFrameTransformedScrollPosition.ts';
@@ -9,6 +14,11 @@ export enum ScrollDirection {
   Idle = 0,
   Forward = 1,
   Reverse = -1,
+}
+
+export interface ScrollActivation {
+  direction: Record<Axis, ScrollDirection>;
+  intensity: Record<Axis, number>;
 }
 
 export interface ScrollIntentDetectorContext {
@@ -105,109 +115,18 @@ function detectScrollIntentImpl(
   options?: ScrollIntentDetectorOptions
 ): ScrollIntent {
   const {pointer, scrollPosition, inverted, requestedDirection} = ctx;
-  const {
-    rect: scrollContainerRect,
-    isTop,
-    isLeft,
-    isBottom,
-    isRight,
-  } = scrollPosition;
-  const {x, y} = pointer;
-  const {x: isXAxisInverted, y: isYAxisInverted} = inverted;
 
-  const acceleration = options?.acceleration ?? defaultAcceleration;
-  const thresholdPercentage = options?.threshold ?? defaultThreshold;
-  const tolerance = options?.tolerance ?? defaultTolerance;
+  const activation = detectActivation(
+    pointer,
+    scrollPosition.rect,
+    options?.threshold,
+    options?.tolerance
+  );
+  const suppressed = suppressOpposingIntent(activation, requestedDirection);
+  const resolved = applyAcceleration(suppressed, options?.acceleration);
+  const flipped = applyAxisInversion(resolved, inverted);
 
-  const direction: Record<Axis, ScrollDirection> = {
-    x: ScrollDirection.Idle,
-    y: ScrollDirection.Idle,
-  };
-  const speed = {
-    x: 0,
-    y: 0,
-  };
-  const threshold = {
-    height: scrollContainerRect.height * thresholdPercentage.y,
-    width: scrollContainerRect.width * thresholdPercentage.x,
-  };
-
-  if (
-    threshold.height > 0 &&
-    (!isTop || (isYAxisInverted && !isBottom)) &&
-    y <= scrollContainerRect.top + threshold.height &&
-    requestedDirection?.y !== ScrollDirection.Forward &&
-    x >= scrollContainerRect.left - tolerance.x &&
-    x <= scrollContainerRect.right + tolerance.x
-  ) {
-    // Scroll Up (or Down if inverted)
-    direction.y = isYAxisInverted
-      ? ScrollDirection.Forward
-      : ScrollDirection.Reverse;
-    speed.y =
-      acceleration *
-      Math.abs(
-        (scrollContainerRect.top + threshold.height - y) / threshold.height
-      );
-  } else if (
-    threshold.height > 0 &&
-    (!isBottom || (isYAxisInverted && !isTop)) &&
-    y >= scrollContainerRect.bottom - threshold.height &&
-    requestedDirection?.y !== ScrollDirection.Reverse &&
-    x >= scrollContainerRect.left - tolerance.x &&
-    x <= scrollContainerRect.right + tolerance.x
-  ) {
-    // Scroll Down (or Up if inverted)
-    direction.y = isYAxisInverted
-      ? ScrollDirection.Reverse
-      : ScrollDirection.Forward;
-    speed.y =
-      acceleration *
-      Math.abs(
-        (scrollContainerRect.bottom - threshold.height - y) / threshold.height
-      );
-  }
-
-  if (
-    threshold.width > 0 &&
-    (!isRight || (isXAxisInverted && !isLeft)) &&
-    x >= scrollContainerRect.right - threshold.width &&
-    requestedDirection?.x !== ScrollDirection.Reverse &&
-    y >= scrollContainerRect.top - tolerance.y &&
-    y <= scrollContainerRect.bottom + tolerance.y
-  ) {
-    // Scroll Right (or Left if inverted)
-    direction.x = isXAxisInverted
-      ? ScrollDirection.Reverse
-      : ScrollDirection.Forward;
-    speed.x =
-      acceleration *
-      Math.abs(
-        (scrollContainerRect.right - threshold.width - x) / threshold.width
-      );
-  } else if (
-    threshold.width > 0 &&
-    (!isLeft || (isXAxisInverted && !isRight)) &&
-    x <= scrollContainerRect.left + threshold.width &&
-    requestedDirection?.x !== ScrollDirection.Forward &&
-    y >= scrollContainerRect.top - tolerance.y &&
-    y <= scrollContainerRect.bottom + tolerance.y
-  ) {
-    // Scroll Left (or Right if inverted)
-    direction.x = isXAxisInverted
-      ? ScrollDirection.Forward
-      : ScrollDirection.Reverse;
-    speed.x =
-      acceleration *
-      Math.abs(
-        (scrollContainerRect.left + threshold.width - x) / threshold.width
-      );
-  }
-
-  return {
-    direction,
-    speed,
-  };
+  return stopAtBoundaries(flipped, scrollPosition);
 }
 
 function isScrollIntentDetectorContext(
@@ -219,4 +138,133 @@ function isScrollIntentDetectorContext(
     'pointer' in value &&
     'inverted' in value
   );
+}
+
+export function detectActivation(
+  pointer: Coordinates,
+  rect: BoundingRectangle,
+  threshold: Record<Axis, number> = defaultThreshold,
+  tolerance: Record<Axis, number> = defaultTolerance
+): ScrollActivation {
+  const direction: Record<Axis, ScrollDirection> = {
+    x: ScrollDirection.Idle,
+    y: ScrollDirection.Idle,
+  };
+  const intensity: Record<Axis, number> = {x: 0, y: 0};
+  
+  const band = {x: rect.width * threshold.x, y: rect.height * threshold.y};
+  const within = {
+    x:
+      pointer.x >= rect.left - tolerance.x &&
+      pointer.x <= rect.right + tolerance.x,
+    y:
+      pointer.y >= rect.top - tolerance.y &&
+      pointer.y <= rect.bottom + tolerance.y,
+  };
+
+  if (band.y > 0 && pointer.y <= rect.top + band.y && within.x) {
+    direction.y = ScrollDirection.Reverse;
+    intensity.y = Math.abs((rect.top + band.y - pointer.y) / band.y);
+  } else if (band.y > 0 && pointer.y >= rect.bottom - band.y && within.x) {
+    direction.y = ScrollDirection.Forward;
+    intensity.y = Math.abs((rect.bottom - band.y - pointer.y) / band.y);
+  }
+
+  if (band.x > 0 && pointer.x >= rect.right - band.x && within.y) {
+    direction.x = ScrollDirection.Forward;
+    intensity.x = Math.abs((rect.right - band.x - pointer.x) / band.x);
+  } else if (band.x > 0 && pointer.x <= rect.left + band.x && within.y) {
+    direction.x = ScrollDirection.Reverse;
+    intensity.x = Math.abs((rect.left + band.x - pointer.x) / band.x);
+  }
+
+  return {direction, intensity};
+}
+
+export function suppressOpposingIntent(
+  activation: ScrollActivation,
+  requestedDirection?: Record<Axis, ScrollDirection>
+): ScrollActivation {
+  if (!requestedDirection) {
+    return activation;
+  }
+
+  const direction = {...activation.direction};
+  const intensity = {...activation.intensity};
+
+  for (const axis of Axes) {
+    const current = direction[axis];
+
+    if (
+      current !== ScrollDirection.Idle &&
+      requestedDirection[axis] === invert(current)
+    ) {
+      direction[axis] = ScrollDirection.Idle;
+      intensity[axis] = 0;
+    }
+  }
+
+  return {direction, intensity};
+}
+
+export function applyAcceleration(
+  activation: ScrollActivation,
+  acceleration: number = defaultAcceleration
+): ScrollIntent {
+  const {direction, intensity} = activation;
+  const speed: Record<Axis, number> = {
+    x: intensity.x * acceleration,
+    y: intensity.y * acceleration,
+  };
+
+  return {direction, speed};
+}
+
+export function applyAxisInversion(
+  intent: ScrollIntent,
+  inverted: Record<Axis, boolean>
+): ScrollIntent {
+  const {direction, speed} = intent;
+
+  return {
+    direction: {
+      x: inverted.x ? invert(direction.x) : direction.x,
+      y: inverted.y ? invert(direction.y) : direction.y,
+    },
+    speed,
+  };
+}
+
+function invert(direction: ScrollDirection): ScrollDirection {
+  switch (direction) {
+    case ScrollDirection.Forward:
+      return ScrollDirection.Reverse;
+    case ScrollDirection.Reverse:
+      return ScrollDirection.Forward;
+    case ScrollDirection.Idle:
+      return ScrollDirection.Idle;
+  }
+}
+
+export function stopAtBoundaries(
+  intent: ScrollIntent,
+  scrollPosition: ScrollPosition
+): ScrollIntent {
+  const direction = {...intent.direction};
+  const speed = {...intent.speed};
+  const atStart = {x: scrollPosition.isLeft, y: scrollPosition.isTop};
+  const atEnd = {x: scrollPosition.isRight, y: scrollPosition.isBottom};
+
+  for (const axis of Axes) {
+    const blocked =
+      (direction[axis] === ScrollDirection.Forward && atEnd[axis]) ||
+      (direction[axis] === ScrollDirection.Reverse && atStart[axis]);
+
+    if (blocked) {
+      direction[axis] = ScrollDirection.Idle;
+      speed[axis] = 0;
+    }
+  }
+
+  return {direction, speed};
 }

--- a/packages/dom/src/utilities/scroll/detectScrollIntent.ts
+++ b/packages/dom/src/utilities/scroll/detectScrollIntent.ts
@@ -41,6 +41,11 @@ export interface ScrollIntent {
   speed: Record<Axis, number>;
 }
 
+export type ScrollIntentDetector = (
+  ctx: ScrollIntentDetectorContext,
+  options?: ScrollIntentDetectorOptions
+) => ScrollIntent;
+
 const defaultAcceleration = 25;
 
 const defaultThreshold: Record<Axis, number> = {

--- a/packages/dom/src/utilities/scroll/detectScrollIntent.ts
+++ b/packages/dom/src/utilities/scroll/detectScrollIntent.ts
@@ -1,15 +1,37 @@
-import {Rectangle, type Axis, type Coordinates} from '@dnd-kit/geometry';
+import type {Axis, Coordinates} from '@dnd-kit/geometry';
+import type {DragOperation, Draggable, Droppable} from '@dnd-kit/abstract';
 
-import {getScrollPosition} from './getScrollPosition.ts';
-import {getFrameTransform} from '../frame/getFrameTransform.ts';
-import {getComputedStyles} from '../styles/getComputedStyles.ts';
-import {parseTransform} from '../transform/parseTransform.ts';
+import {getFrameTransformedScrollPosition} from './getFrameTransformedScrollPosition.ts';
+import {getAxisInversionState} from './getAxisInversionState.ts';
+import type {ScrollPosition} from './getScrollPosition.ts';
 
 export enum ScrollDirection {
   Idle = 0,
   Forward = 1,
   Reverse = -1,
 }
+
+export interface ScrollIntentDetectorContext {
+  element: Element;
+  scrollPosition: ScrollPosition;
+  pointer: Coordinates;
+  inverted: Record<Axis, boolean>;
+  operation?: DragOperation<Draggable, Droppable>;
+  requestedDirection?: Record<Axis, ScrollDirection>;
+}
+
+export interface ScrollIntentDetectorOptions {
+  acceleration?: number;
+  threshold?: Record<Axis, number>;
+  tolerance?: Record<Axis, number>;
+}
+
+export interface ScrollIntent {
+  direction: Record<Axis, ScrollDirection>;
+  speed: Record<Axis, number>;
+}
+
+const defaultAcceleration = 25;
 
 const defaultThreshold: Record<Axis, number> = {
   x: 0.2,
@@ -21,35 +43,82 @@ const defaultTolerance: Record<Axis, number> = {
   y: 10,
 };
 
-interface ScrollIntent {
-  x: ScrollDirection;
-  y: ScrollDirection;
-}
+/**
+ * The default scroll intent detector.
+ *
+ * Scrolls when the pointer enters the activation zones near the container's edges.
+ */
+export function detectScrollIntent(
+  ctx: ScrollIntentDetectorContext,
+  options?: ScrollIntentDetectorOptions
+): ScrollIntent;
 
+/**
+ * The default scroll intent detector.
+ *
+ * Scrolls when the pointer enters the activation zones near the container's edges.
+ *
+ * @deprecated Pass a `ScrollIntentDetectorContext` instead. The positional signature is
+ * kept for backward compatibility and will be removed in a future release.
+ */
 export function detectScrollIntent(
   scrollableElement: Element,
   coordinates: Coordinates,
-  intent?: ScrollIntent,
-  acceleration = 25,
-  thresholdPercentage = defaultThreshold,
-  tolerance = defaultTolerance
-) {
-  const {x, y} = coordinates;
-  const {rect, isTop, isBottom, isLeft, isRight} =
-    getScrollPosition(scrollableElement);
-  const frameTransform = getFrameTransform(scrollableElement);
-  const computedStyles = getComputedStyles(scrollableElement, true);
-  const parsedTransform = parseTransform(computedStyles);
-  const isXAxisInverted =
-    parsedTransform !== null ? parsedTransform?.scaleX < 0 : false;
-  const isYAxisInverted =
-    parsedTransform !== null ? parsedTransform?.scaleY < 0 : false;
-  const scrollContainerRect = new Rectangle(
-    rect.left * frameTransform.scaleX + frameTransform.x,
-    rect.top * frameTransform.scaleY + frameTransform.y,
-    rect.width * frameTransform.scaleX,
-    rect.height * frameTransform.scaleY
-  );
+  requestedDirection?: Record<Axis, ScrollDirection>,
+  acceleration?: number,
+  thresholdPercentage?: Record<Axis, number>,
+  tolerance?: Record<Axis, number>
+): ScrollIntent;
+
+export function detectScrollIntent(
+  ctxOrElement: ScrollIntentDetectorContext | Element,
+  coordinatesOrOptions?: Coordinates | ScrollIntentDetectorOptions,
+  requestedDirection?: Record<Axis, ScrollDirection>,
+  acceleration?: number,
+  thresholdPercentage?: Record<Axis, number>,
+  tolerance?: Record<Axis, number>
+): ScrollIntent {
+  if (isScrollIntentDetectorContext(ctxOrElement)) {
+    return detectScrollIntentImpl(
+      ctxOrElement,
+      coordinatesOrOptions as ScrollIntentDetectorOptions | undefined
+    );
+  }
+
+  const ctx: ScrollIntentDetectorContext = {
+    element: ctxOrElement,
+    scrollPosition: getFrameTransformedScrollPosition(ctxOrElement),
+    inverted: getAxisInversionState(ctxOrElement),
+    pointer: coordinatesOrOptions as Coordinates,
+    requestedDirection,
+  };
+
+  return detectScrollIntentImpl(ctx, {
+    acceleration,
+    threshold: thresholdPercentage,
+    tolerance,
+  });
+}
+
+function detectScrollIntentImpl(
+  ctx: ScrollIntentDetectorContext,
+  options?: ScrollIntentDetectorOptions
+): ScrollIntent {
+  const {pointer, scrollPosition, inverted, requestedDirection} = ctx;
+  const {
+    rect: scrollContainerRect,
+    isTop,
+    isLeft,
+    isBottom,
+    isRight,
+  } = scrollPosition;
+  const {x, y} = pointer;
+  const {x: isXAxisInverted, y: isYAxisInverted} = inverted;
+
+  const acceleration = options?.acceleration ?? defaultAcceleration;
+  const thresholdPercentage = options?.threshold ?? defaultThreshold;
+  const tolerance = options?.tolerance ?? defaultTolerance;
+
   const direction: Record<Axis, ScrollDirection> = {
     x: ScrollDirection.Idle,
     y: ScrollDirection.Idle,
@@ -67,7 +136,7 @@ export function detectScrollIntent(
     threshold.height > 0 &&
     (!isTop || (isYAxisInverted && !isBottom)) &&
     y <= scrollContainerRect.top + threshold.height &&
-    intent?.y !== ScrollDirection.Forward &&
+    requestedDirection?.y !== ScrollDirection.Forward &&
     x >= scrollContainerRect.left - tolerance.x &&
     x <= scrollContainerRect.right + tolerance.x
   ) {
@@ -84,7 +153,7 @@ export function detectScrollIntent(
     threshold.height > 0 &&
     (!isBottom || (isYAxisInverted && !isTop)) &&
     y >= scrollContainerRect.bottom - threshold.height &&
-    intent?.y !== ScrollDirection.Reverse &&
+    requestedDirection?.y !== ScrollDirection.Reverse &&
     x >= scrollContainerRect.left - tolerance.x &&
     x <= scrollContainerRect.right + tolerance.x
   ) {
@@ -103,7 +172,7 @@ export function detectScrollIntent(
     threshold.width > 0 &&
     (!isRight || (isXAxisInverted && !isLeft)) &&
     x >= scrollContainerRect.right - threshold.width &&
-    intent?.x !== ScrollDirection.Reverse &&
+    requestedDirection?.x !== ScrollDirection.Reverse &&
     y >= scrollContainerRect.top - tolerance.y &&
     y <= scrollContainerRect.bottom + tolerance.y
   ) {
@@ -120,7 +189,7 @@ export function detectScrollIntent(
     threshold.width > 0 &&
     (!isLeft || (isXAxisInverted && !isRight)) &&
     x <= scrollContainerRect.left + threshold.width &&
-    intent?.x !== ScrollDirection.Forward &&
+    requestedDirection?.x !== ScrollDirection.Forward &&
     y >= scrollContainerRect.top - tolerance.y &&
     y <= scrollContainerRect.bottom + tolerance.y
   ) {
@@ -139,4 +208,15 @@ export function detectScrollIntent(
     direction,
     speed,
   };
+}
+
+function isScrollIntentDetectorContext(
+  value: ScrollIntentDetectorContext | Element
+): value is ScrollIntentDetectorContext {
+  return (
+    'element' in value &&
+    'scrollPosition' in value &&
+    'pointer' in value &&
+    'inverted' in value
+  );
 }

--- a/packages/dom/src/utilities/scroll/getAxisInversionState.ts
+++ b/packages/dom/src/utilities/scroll/getAxisInversionState.ts
@@ -1,0 +1,13 @@
+import type {Axis} from '@dnd-kit/geometry';
+
+import {getComputedStyles} from '../styles/getComputedStyles.ts';
+import {parseTransform} from '../transform/parseTransform.ts';
+
+export function getAxisInversionState(element: Element): Record<Axis, boolean> {
+  const parsedTransform = parseTransform(getComputedStyles(element, true));
+
+  return {
+    x: parsedTransform !== null ? parsedTransform.scaleX < 0 : false,
+    y: parsedTransform !== null ? parsedTransform.scaleY < 0 : false,
+  };
+}

--- a/packages/dom/src/utilities/scroll/getFrameTransformedScrollPosition.ts
+++ b/packages/dom/src/utilities/scroll/getFrameTransformedScrollPosition.ts
@@ -1,0 +1,22 @@
+import {Rectangle} from '@dnd-kit/geometry';
+
+import {getScrollPosition, type ScrollPosition} from './getScrollPosition.ts';
+import {getFrameTransform} from '../frame/getFrameTransform.ts';
+
+export function getFrameTransformedScrollPosition(
+  element: Element
+): ScrollPosition {
+  const scrollPosition = getScrollPosition(element);
+  const frameTransform = getFrameTransform(element);
+  const {rect} = scrollPosition;
+
+  return {
+    ...scrollPosition,
+    rect: new Rectangle(
+      rect.left * frameTransform.scaleX + frameTransform.x,
+      rect.top * frameTransform.scaleY + frameTransform.y,
+      rect.width * frameTransform.scaleX,
+      rect.height * frameTransform.scaleY
+    ),
+  };
+}

--- a/packages/dom/src/utilities/scroll/getScrollPosition.ts
+++ b/packages/dom/src/utilities/scroll/getScrollPosition.ts
@@ -1,9 +1,20 @@
+import type {BoundingRectangle, Coordinates} from '@dnd-kit/geometry';
+
 import {getBoundingRectangle} from '../bounding-rectangle/getBoundingRectangle.ts';
 import {getViewportBoundingRectangle} from '../bounding-rectangle/getViewportBoundingRectangle.ts';
 import {getWindow} from '../execution-context/getWindow.ts';
 import {isDocumentScrollingElement} from './documentScrollingElement.ts';
 
-export function getScrollPosition(scrollableElement: Element) {
+export interface ScrollPosition {
+  rect: BoundingRectangle;
+  position: {current: Coordinates; max: Coordinates};
+  isTop: boolean;
+  isLeft: boolean;
+  isBottom: boolean;
+  isRight: boolean;
+}
+
+export function getScrollPosition(scrollableElement: Element): ScrollPosition {
   const window = getWindow(scrollableElement);
   const rect = isDocumentScrollingElement(scrollableElement)
     ? getViewportBoundingRectangle(scrollableElement)

--- a/packages/dom/src/utilities/scroll/index.ts
+++ b/packages/dom/src/utilities/scroll/index.ts
@@ -5,7 +5,15 @@ export {
 } from './getScrollableAncestors.ts';
 export {getScrollableElement} from './getScrollableElement.ts';
 export {detectScrollIntent, ScrollDirection} from './detectScrollIntent.ts';
+export {getFrameTransformedScrollPosition} from './getFrameTransformedScrollPosition.ts';
+export {getAxisInversionState} from './getAxisInversionState.ts';
+export type {
+  ScrollIntentDetectorContext,
+  ScrollIntentDetectorOptions,
+  ScrollIntent,
+} from './detectScrollIntent.ts';
 export {getScrollPosition} from './getScrollPosition.ts';
+export type {ScrollPosition} from './getScrollPosition.ts';
 export {isDocumentScrollingElement} from './documentScrollingElement.ts';
 export {isScrollable} from './isScrollable.ts';
 export {isFixed} from './isFixed.ts';

--- a/packages/dom/src/utilities/scroll/index.ts
+++ b/packages/dom/src/utilities/scroll/index.ts
@@ -4,13 +4,22 @@ export {
   getScrollableAncestors,
 } from './getScrollableAncestors.ts';
 export {getScrollableElement} from './getScrollableElement.ts';
-export {detectScrollIntent, ScrollDirection} from './detectScrollIntent.ts';
+export {
+  detectScrollIntent,
+  ScrollDirection,
+  detectActivation,
+  suppressOpposingIntent,
+  applyAcceleration,
+  applyAxisInversion,
+  stopAtBoundaries,
+} from './detectScrollIntent.ts';
 export {getFrameTransformedScrollPosition} from './getFrameTransformedScrollPosition.ts';
 export {getAxisInversionState} from './getAxisInversionState.ts';
 export type {
+  ScrollActivation,
+  ScrollIntent,
   ScrollIntentDetectorContext,
   ScrollIntentDetectorOptions,
-  ScrollIntent,
 } from './detectScrollIntent.ts';
 export {getScrollPosition} from './getScrollPosition.ts';
 export type {ScrollPosition} from './getScrollPosition.ts';

--- a/packages/dom/src/utilities/scroll/index.ts
+++ b/packages/dom/src/utilities/scroll/index.ts
@@ -18,6 +18,7 @@ export {getAxisInversionState} from './getAxisInversionState.ts';
 export type {
   ScrollActivation,
   ScrollIntent,
+  ScrollIntentDetector,
   ScrollIntentDetectorContext,
   ScrollIntentDetectorOptions,
 } from './detectScrollIntent.ts';

--- a/packages/dom/tests/detect-scroll-intent.test.ts
+++ b/packages/dom/tests/detect-scroll-intent.test.ts
@@ -1,0 +1,156 @@
+import {describe, expect, it, mock} from 'bun:test';
+import {Rectangle} from '@dnd-kit/geometry';
+
+import {
+  detectScrollIntent,
+  ScrollDirection,
+} from '../src/utilities/scroll/detectScrollIntent.ts';
+
+const element = {} as Element;
+const rect = new Rectangle(0, 0, 100, 100);
+
+const edgeCases = [
+  {name: 'top', axis: 'y', direction: ScrollDirection.Reverse},
+  {name: 'bottom', axis: 'y', direction: ScrollDirection.Forward},
+  {name: 'left', axis: 'x', direction: ScrollDirection.Reverse},
+  {name: 'right', axis: 'x', direction: ScrollDirection.Forward},
+];
+
+const getScrollPosition = mock(() => ({
+  rect,
+  isTop: false,
+  isLeft: false,
+  isBottom: false,
+  isRight: false,
+}));
+const parseTransform = mock(() => ({x: 0, y: 0, scaleX: 1, scaleY: 1}));
+
+mock.module('../src/utilities/scroll/getScrollPosition.ts', () => ({
+  getScrollPosition,
+}));
+mock.module('../src/utilities/frame/getFrameTransform.ts', () => ({
+  getFrameTransform: () => ({x: 0, y: 0, scaleX: 1, scaleY: 1}),
+}));
+mock.module('../src/utilities/styles/getComputedStyles.ts', () => ({
+  getComputedStyles: () => ({transform: 'none'}),
+}));
+mock.module('../src/utilities/transform/parseTransform.ts', () => ({
+  parseTransform,
+}));
+
+describe('detectScrollIntent', () => {
+  it.each(edgeCases)(
+    'scrolls toward the $name edge with speed increasing linearly',
+    ({axis, direction}) => {
+      const reverse = direction === ScrollDirection.Reverse;
+      const edge = {x: 50, y: 50, [axis]: reverse ? 0 : 100};
+      const midpoint = {x: 50, y: 50, [axis]: reverse ? 10 : 90};
+
+      const atEdge = detectScrollIntent(element, edge);
+      expect(atEdge.direction).toEqual({
+        x: ScrollDirection.Idle,
+        y: ScrollDirection.Idle,
+        [axis]: direction,
+      });
+      expect(atEdge.speed).toEqual({x: 0, y: 0, [axis]: 25});
+
+      const halfwayToEdge = detectScrollIntent(element, midpoint);
+      expect(halfwayToEdge.direction).toEqual({
+        x: ScrollDirection.Idle,
+        y: ScrollDirection.Idle,
+        [axis]: direction,
+      });
+      expect(halfwayToEdge.speed).toEqual({x: 0, y: 0, [axis]: 12.5});
+    }
+  );
+
+  it('stays idle at the bottom edge when the container cannot scroll further', () => {
+    getScrollPosition.mockReturnValueOnce({
+      rect,
+      isTop: false,
+      isLeft: false,
+      isBottom: true,
+      isRight: false,
+    });
+
+    const {direction, speed} = detectScrollIntent(element, {x: 50, y: 100});
+    expect(direction).toEqual({
+      x: ScrollDirection.Idle,
+      y: ScrollDirection.Idle,
+    });
+    expect(speed).toEqual({x: 0, y: 0});
+  });
+
+  it('stays idle in the central dead zone', () => {
+    const {direction, speed} = detectScrollIntent(element, {x: 50, y: 50});
+    expect(direction).toEqual({
+      x: ScrollDirection.Idle,
+      y: ScrollDirection.Idle,
+    });
+    expect(speed).toEqual({x: 0, y: 0});
+  });
+
+  it('customizes scroll speed with the acceleration option', () => {
+    const {direction, speed} = detectScrollIntent(
+      element,
+      {x: 50, y: 0},
+      undefined,
+      50
+    );
+    expect(direction.y).toBe(ScrollDirection.Reverse);
+    expect(speed.y).toBe(50);
+  });
+
+  it('customizes the activation zone with the threshold option', () => {
+    const pointer = {x: 50, y: 30};
+
+    const narrow = detectScrollIntent(element, pointer);
+    expect(narrow.direction.y).toBe(ScrollDirection.Idle);
+
+    const wide = detectScrollIntent(element, pointer, undefined, undefined, {
+      x: 0.5,
+      y: 0.5,
+    });
+    expect(wide.direction.y).toBe(ScrollDirection.Reverse);
+    expect(wide.speed.y).toBe(10);
+  });
+
+  it('customizes the cross-axis tolerance with the tolerance option', () => {
+    const coordinates = {x: 105, y: 0};
+
+    const withinTolerance = detectScrollIntent(element, coordinates);
+    expect(withinTolerance.direction.y).toBe(ScrollDirection.Reverse);
+
+    const outsideTolerance = detectScrollIntent(
+      element,
+      coordinates,
+      undefined,
+      undefined,
+      undefined,
+      {x: 0, y: 0}
+    );
+    expect(outsideTolerance.direction.y).toBe(ScrollDirection.Idle);
+  });
+
+  it('ignores the top edge when it opposes the intended scroll direction', () => {
+    const {direction, speed} = detectScrollIntent(
+      element,
+      {x: 50, y: 0},
+      {x: ScrollDirection.Idle, y: ScrollDirection.Forward}
+    );
+    expect(direction).toEqual({
+      x: ScrollDirection.Idle,
+      y: ScrollDirection.Idle,
+    });
+    expect(speed).toEqual({x: 0, y: 0});
+  });
+
+  it('reverses scroll direction on inverted axes', () => {
+    parseTransform.mockReturnValueOnce({x: 0, y: 0, scaleX: -1, scaleY: -1});
+    const {direction, speed} = detectScrollIntent(element, {x: 0, y: 0});
+    expect(direction.x).toBe(ScrollDirection.Forward);
+    expect(direction.y).toBe(ScrollDirection.Forward);
+    expect(speed.x).toBe(25);
+    expect(speed.y).toBe(25);
+  });
+});

--- a/packages/dom/tests/detect-scroll-intent.test.ts
+++ b/packages/dom/tests/detect-scroll-intent.test.ts
@@ -159,6 +159,20 @@ describe('detectScrollIntent', () => {
     expect(speed.y).toBe(25);
   });
 
+  it('stays idle on an inverted axis when the container cannot scroll further', () => {
+    const {direction, speed} = detectScrollIntent({
+      ...defaultContext,
+      pointer: {x: 50, y: 0},
+      inverted: {x: false, y: true},
+      scrollPosition: {...defaultContext.scrollPosition, isBottom: true},
+    });
+    expect(direction).toEqual({
+      x: ScrollDirection.Idle,
+      y: ScrollDirection.Idle,
+    });
+    expect(speed).toEqual({x: 0, y: 0});
+  });
+
   describe('legacy signature', () => {
     it.each(edgeCases)(
       'scrolls toward the $name edge with speed increasing linearly',

--- a/packages/dom/tests/detect-scroll-intent.test.ts
+++ b/packages/dom/tests/detect-scroll-intent.test.ts
@@ -4,10 +4,22 @@ import {Rectangle} from '@dnd-kit/geometry';
 import {
   detectScrollIntent,
   ScrollDirection,
+  type ScrollIntentDetectorContext,
 } from '../src/utilities/scroll/detectScrollIntent.ts';
 
-const element = {} as Element;
-const rect = new Rectangle(0, 0, 100, 100);
+const defaultContext: ScrollIntentDetectorContext = {
+  element: {} as Element,
+  pointer: {x: 50, y: 50},
+  scrollPosition: {
+    rect: new Rectangle(0, 0, 100, 100),
+    position: {current: {x: 50, y: 50}, max: {x: 100, y: 100}},
+    isTop: false,
+    isLeft: false,
+    isBottom: false,
+    isRight: false,
+  },
+  inverted: {x: false, y: false},
+};
 
 const edgeCases = [
   {name: 'top', axis: 'y', direction: ScrollDirection.Reverse},
@@ -16,13 +28,7 @@ const edgeCases = [
   {name: 'right', axis: 'x', direction: ScrollDirection.Forward},
 ];
 
-const getScrollPosition = mock(() => ({
-  rect,
-  isTop: false,
-  isLeft: false,
-  isBottom: false,
-  isRight: false,
-}));
+const getScrollPosition = mock(() => defaultContext.scrollPosition);
 const parseTransform = mock(() => ({x: 0, y: 0, scaleX: 1, scaleY: 1}));
 
 mock.module('../src/utilities/scroll/getScrollPosition.ts', () => ({
@@ -32,7 +38,7 @@ mock.module('../src/utilities/frame/getFrameTransform.ts', () => ({
   getFrameTransform: () => ({x: 0, y: 0, scaleX: 1, scaleY: 1}),
 }));
 mock.module('../src/utilities/styles/getComputedStyles.ts', () => ({
-  getComputedStyles: () => ({transform: 'none'}),
+  getComputedStyles: () => ({}),
 }));
 mock.module('../src/utilities/transform/parseTransform.ts', () => ({
   parseTransform,
@@ -46,7 +52,7 @@ describe('detectScrollIntent', () => {
       const edge = {x: 50, y: 50, [axis]: reverse ? 0 : 100};
       const midpoint = {x: 50, y: 50, [axis]: reverse ? 10 : 90};
 
-      const atEdge = detectScrollIntent(element, edge);
+      const atEdge = detectScrollIntent({...defaultContext, pointer: edge});
       expect(atEdge.direction).toEqual({
         x: ScrollDirection.Idle,
         y: ScrollDirection.Idle,
@@ -54,7 +60,10 @@ describe('detectScrollIntent', () => {
       });
       expect(atEdge.speed).toEqual({x: 0, y: 0, [axis]: 25});
 
-      const halfwayToEdge = detectScrollIntent(element, midpoint);
+      const halfwayToEdge = detectScrollIntent({
+        ...defaultContext,
+        pointer: midpoint,
+      });
       expect(halfwayToEdge.direction).toEqual({
         x: ScrollDirection.Idle,
         y: ScrollDirection.Idle,
@@ -65,15 +74,11 @@ describe('detectScrollIntent', () => {
   );
 
   it('stays idle at the bottom edge when the container cannot scroll further', () => {
-    getScrollPosition.mockReturnValueOnce({
-      rect,
-      isTop: false,
-      isLeft: false,
-      isBottom: true,
-      isRight: false,
+    const {direction, speed} = detectScrollIntent({
+      ...defaultContext,
+      pointer: {x: 50, y: 100},
+      scrollPosition: {...defaultContext.scrollPosition, isBottom: true},
     });
-
-    const {direction, speed} = detectScrollIntent(element, {x: 50, y: 100});
     expect(direction).toEqual({
       x: ScrollDirection.Idle,
       y: ScrollDirection.Idle,
@@ -82,7 +87,10 @@ describe('detectScrollIntent', () => {
   });
 
   it('stays idle in the central dead zone', () => {
-    const {direction, speed} = detectScrollIntent(element, {x: 50, y: 50});
+    const {direction, speed} = detectScrollIntent({
+      ...defaultContext,
+      pointer: {x: 50, y: 50},
+    });
     expect(direction).toEqual({
       x: ScrollDirection.Idle,
       y: ScrollDirection.Idle,
@@ -92,10 +100,8 @@ describe('detectScrollIntent', () => {
 
   it('customizes scroll speed with the acceleration option', () => {
     const {direction, speed} = detectScrollIntent(
-      element,
-      {x: 50, y: 0},
-      undefined,
-      50
+      {...defaultContext, pointer: {x: 50, y: 0}},
+      {acceleration: 50}
     );
     expect(direction.y).toBe(ScrollDirection.Reverse);
     expect(speed.y).toBe(50);
@@ -104,40 +110,36 @@ describe('detectScrollIntent', () => {
   it('customizes the activation zone with the threshold option', () => {
     const pointer = {x: 50, y: 30};
 
-    const narrow = detectScrollIntent(element, pointer);
+    const narrow = detectScrollIntent({...defaultContext, pointer});
     expect(narrow.direction.y).toBe(ScrollDirection.Idle);
 
-    const wide = detectScrollIntent(element, pointer, undefined, undefined, {
-      x: 0.5,
-      y: 0.5,
-    });
+    const wide = detectScrollIntent(
+      {...defaultContext, pointer},
+      {threshold: {x: 0.5, y: 0.5}}
+    );
     expect(wide.direction.y).toBe(ScrollDirection.Reverse);
     expect(wide.speed.y).toBe(10);
   });
 
   it('customizes the cross-axis tolerance with the tolerance option', () => {
-    const coordinates = {x: 105, y: 0};
+    const pointer = {x: 105, y: 0};
 
-    const withinTolerance = detectScrollIntent(element, coordinates);
+    const withinTolerance = detectScrollIntent({...defaultContext, pointer});
     expect(withinTolerance.direction.y).toBe(ScrollDirection.Reverse);
 
     const outsideTolerance = detectScrollIntent(
-      element,
-      coordinates,
-      undefined,
-      undefined,
-      undefined,
-      {x: 0, y: 0}
+      {...defaultContext, pointer},
+      {tolerance: {x: 0, y: 0}}
     );
     expect(outsideTolerance.direction.y).toBe(ScrollDirection.Idle);
   });
 
   it('ignores the top edge when it opposes the intended scroll direction', () => {
-    const {direction, speed} = detectScrollIntent(
-      element,
-      {x: 50, y: 0},
-      {x: ScrollDirection.Idle, y: ScrollDirection.Forward}
-    );
+    const {direction, speed} = detectScrollIntent({
+      ...defaultContext,
+      pointer: {x: 50, y: 0},
+      requestedDirection: {x: ScrollDirection.Idle, y: ScrollDirection.Forward},
+    });
     expect(direction).toEqual({
       x: ScrollDirection.Idle,
       y: ScrollDirection.Idle,
@@ -146,11 +148,148 @@ describe('detectScrollIntent', () => {
   });
 
   it('reverses scroll direction on inverted axes', () => {
-    parseTransform.mockReturnValueOnce({x: 0, y: 0, scaleX: -1, scaleY: -1});
-    const {direction, speed} = detectScrollIntent(element, {x: 0, y: 0});
+    const {direction, speed} = detectScrollIntent({
+      ...defaultContext,
+      pointer: {x: 0, y: 0},
+      inverted: {x: true, y: true},
+    });
     expect(direction.x).toBe(ScrollDirection.Forward);
     expect(direction.y).toBe(ScrollDirection.Forward);
     expect(speed.x).toBe(25);
     expect(speed.y).toBe(25);
+  });
+
+  describe('legacy signature', () => {
+    it.each(edgeCases)(
+      'scrolls toward the $name edge with speed increasing linearly',
+      ({axis, direction}) => {
+        const reverse = direction === ScrollDirection.Reverse;
+        const edge = {x: 50, y: 50, [axis]: reverse ? 0 : 100};
+        const midpoint = {x: 50, y: 50, [axis]: reverse ? 10 : 90};
+
+        const atEdge = detectScrollIntent(defaultContext.element, edge);
+        expect(atEdge.direction).toEqual({
+          x: ScrollDirection.Idle,
+          y: ScrollDirection.Idle,
+          [axis]: direction,
+        });
+        expect(atEdge.speed).toEqual({x: 0, y: 0, [axis]: 25});
+
+        const halfwayToEdge = detectScrollIntent(
+          defaultContext.element,
+          midpoint
+        );
+        expect(halfwayToEdge.direction).toEqual({
+          x: ScrollDirection.Idle,
+          y: ScrollDirection.Idle,
+          [axis]: direction,
+        });
+        expect(halfwayToEdge.speed).toEqual({x: 0, y: 0, [axis]: 12.5});
+      }
+    );
+
+    it('stays idle at the bottom edge when the container cannot scroll further', () => {
+      getScrollPosition.mockReturnValueOnce({
+        ...defaultContext.scrollPosition,
+        isBottom: true,
+      });
+      const {direction, speed} = detectScrollIntent(defaultContext.element, {
+        x: 50,
+        y: 100,
+      });
+      expect(direction).toEqual({
+        x: ScrollDirection.Idle,
+        y: ScrollDirection.Idle,
+      });
+      expect(speed).toEqual({x: 0, y: 0});
+    });
+
+    it('stays idle in the central dead zone', () => {
+      const {direction, speed} = detectScrollIntent(defaultContext.element, {
+        x: 50,
+        y: 50,
+      });
+      expect(direction).toEqual({
+        x: ScrollDirection.Idle,
+        y: ScrollDirection.Idle,
+      });
+      expect(speed).toEqual({x: 0, y: 0});
+    });
+
+    it('customizes scroll speed with the acceleration option', () => {
+      const {direction, speed} = detectScrollIntent(
+        defaultContext.element,
+        {x: 50, y: 0},
+        undefined,
+        50
+      );
+      expect(direction.y).toBe(ScrollDirection.Reverse);
+      expect(speed.y).toBe(50);
+    });
+
+    it('customizes the activation zone with the threshold option', () => {
+      const pointer = {x: 50, y: 30};
+
+      const narrow = detectScrollIntent(defaultContext.element, pointer);
+      expect(narrow.direction.y).toBe(ScrollDirection.Idle);
+
+      const wide = detectScrollIntent(
+        defaultContext.element,
+        pointer,
+        undefined,
+        undefined,
+        {
+          x: 0.5,
+          y: 0.5,
+        }
+      );
+      expect(wide.direction.y).toBe(ScrollDirection.Reverse);
+      expect(wide.speed.y).toBe(10);
+    });
+
+    it('customizes the cross-axis tolerance with the tolerance option', () => {
+      const coordinates = {x: 105, y: 0};
+
+      const withinTolerance = detectScrollIntent(
+        defaultContext.element,
+        coordinates
+      );
+      expect(withinTolerance.direction.y).toBe(ScrollDirection.Reverse);
+
+      const outsideTolerance = detectScrollIntent(
+        defaultContext.element,
+        coordinates,
+        undefined,
+        undefined,
+        undefined,
+        {x: 0, y: 0}
+      );
+      expect(outsideTolerance.direction.y).toBe(ScrollDirection.Idle);
+    });
+
+    it('ignores the top edge when it opposes the intended scroll direction', () => {
+      const {direction, speed} = detectScrollIntent(
+        defaultContext.element,
+        {x: 50, y: 0},
+        {x: ScrollDirection.Idle, y: ScrollDirection.Forward}
+      );
+      expect(direction).toEqual({
+        x: ScrollDirection.Idle,
+        y: ScrollDirection.Idle,
+      });
+      expect(speed).toEqual({x: 0, y: 0});
+    });
+
+    it('reverses scroll direction on inverted axes', () => {
+      parseTransform.mockReturnValueOnce({x: 0, y: 0, scaleX: -1, scaleY: -1});
+      const {direction, speed} = detectScrollIntent(defaultContext.element, {
+        x: 0,
+        y: 0,
+      });
+      expect(direction.x).toBe(ScrollDirection.Forward);
+      expect(direction.y).toBe(ScrollDirection.Forward);
+      expect(speed.x).toBe(25);
+      expect(speed.y).toBe(25);
+    });
   });
 });


### PR DESCRIPTION
## Summary

Make auto-scroll behavior customizable by supporting a custom scroll intent detector.

- **Custom scroll intent detector**: `AutoScroller` and `Scroller.scroll` now accept a custom detector that replaces the default detection logic entirely. This gives full control over when and how fast scrolling happens, covering behaviors that cannot be expressed with the existing `threshold` and `acceleration` options alone (asymmetric activation zones, custom speed curves, non-edge-based activation, etc.).
- **`onScroll` callback**: `Scroller.scroll` gains an `onScroll` option — a synchronous callback that fires right after the asynchronously scheduled scroll task actually applies a position change, letting callers react the moment a scroll takes effect.
- **Composable default implementation**: the default detection logic is refactored into small pure steps, exported as building blocks so custom detectors can compose them instead of reimplementing boundary handling, axis inversion, and acceleration from scratch.
- **Backward compatible**: the previous signature of `detectScrollIntent` is kept (deprecated), and behavior for existing callers is unchanged.