### PR TITLE
fix(react): defer provider manager cleanup

### DIFF
--- a/apps/stories/stories/react/DragDropProvider/DragDropProvider.stories.tsx
+++ b/apps/stories/stories/react/DragDropProvider/DragDropProvider.stories.tsx
@@ -1,0 +1,43 @@
+import {useState} from 'react';
+import type {Meta, StoryObj} from '@storybook/react-vite';
+import {DragDropProvider, useDraggable} from '@dnd-kit/react';
+
+function Draggable() {
+  const {isDragging, ref} = useDraggable({id: 'draggable'});
+
+  return (
+    <button ref={ref} data-dnd-dragging={isDragging || undefined} type="button">
+      Draggable
+    </button>
+  );
+}
+
+function DragDropProviderCleanup() {
+  const [isMounted, setIsMounted] = useState(true);
+
+  return (
+    <div>
+      <button onClick={() => setIsMounted((mounted) => !mounted)} type="button">
+        {isMounted ? 'Unmount provider' : 'Mount provider'}
+      </button>
+      {isMounted ? (
+        <DragDropProvider>
+          <Draggable />
+        </DragDropProvider>
+      ) : (
+        <p>Provider unmounted</p>
+      )}
+    </div>
+  );
+}
+
+const meta: Meta<typeof DragDropProviderCleanup> = {
+  title: 'React/DragDropProvider',
+  component: DragDropProviderCleanup,
+  tags: ['!autodocs', 'hidden'],
+};
+
+export default meta;
+type Story = StoryObj<typeof DragDropProviderCleanup>;
+
+export const Cleanup: Story = {};

--- a/apps/stories/tests/drag-drop-provider.spec.ts
+++ b/apps/stories/tests/drag-drop-provider.spec.ts
@@ -1,0 +1,30 @@
+import {test, expect} from '../../stories-shared/tests/fixtures.ts';
+
+test.describe('DragDropProvider', () => {
+  test('cleans up without React errors', async ({dnd}) => {
+    const errors: string[] = [];
+
+    dnd.page.on('console', (message) => {
+      if (message.type() === 'error') {
+        errors.push(message.text());
+      }
+    });
+    dnd.page.on('pageerror', (error) => errors.push(error.message));
+
+    await dnd.goto('react-dragdropprovider--cleanup');
+    await expect(
+      dnd.page.getByRole('button', {name: 'Unmount provider'})
+    ).toBeVisible();
+
+    await dnd.keyboard.pickup(
+      dnd.page.getByRole('button', {name: 'Draggable'})
+    );
+    await dnd.keyboard.cancel();
+
+    await dnd.page.getByRole('button', {name: 'Unmount provider'}).click();
+    await expect(dnd.page.getByText('Provider unmounted')).toBeVisible();
+    await dnd.page.waitForTimeout(0);
+
+    expect(errors).toEqual([]);
+  });
+});

--- a/packages/react/src/core/context/DragDropProvider.tsx
+++ b/packages/react/src/core/context/DragDropProvider.tsx
@@ -1,11 +1,6 @@
 'use client';
 
-import {
-  useEffect,
-  useRef,
-  useInsertionEffect,
-  type PropsWithChildren,
-} from 'react';
+import {useEffect, useRef, type PropsWithChildren} from 'react';
 import type {Data, DragDropEventHandlers} from '@dnd-kit/abstract';
 import {
   DragDropManager,
@@ -155,13 +150,25 @@ export function DragDropProvider<
 
 function useStableInstance<T extends {destroy(): void}>(create: () => T): T {
   const ref = useRef<T | null>(null);
+  const cleanupVersion = useRef(0);
 
   if (!ref.current) {
     ref.current = create();
   }
 
-  useInsertionEffect(() => {
-    return () => ref.current?.destroy();
+  useEffect(() => {
+    const version = ++cleanupVersion.current;
+
+    return () => {
+      const instance = ref.current;
+
+      queueMicrotask(() => {
+        // Strict Mode replays passive Effects while preserving this ref.
+        if (cleanupVersion.current === version) {
+          instance?.destroy();
+        }
+      });
+    };
   }, []);
 
   return ref.current;


### PR DESCRIPTION
Fixes #2116

## Summary

`DragDropProvider` can destroy its manager during React Strict Mode’s development-only Effect replay.

This moves manager disposal out of `useInsertionEffect` and defers cleanup to a microtask. The version guard ignores the temporary Strict Mode cleanup while still destroying the manager after a real unmount.

- add an interactive Storybook regression story for provider cleanup
- add a Playwright regression test covering a keyboard drag followed by provider unmount

## Validation

- `bun run build`
- `playwright test apps/stories/tests/drag-drop-provider.spec.ts`

No changeset is included because this fixes lifecycle behavior without changing the public API.
