### PR TITLE
fix(dom): support drag-and-drop in detached window contexts (window.open popups)

### DIFF
--- a/packages/dom/src/global.d.ts
+++ b/packages/dom/src/global.d.ts
@@ -1,9 +1,0 @@
-// packages/dom/src/global.d.ts
-declare global {
-  // Optional registry of extra Document objects (e.g. window.open popups) for
-  // cross-window drag support. Host apps populate this via registerDndDocument().
-  // eslint-disable-next-line no-var
-  var __dndKitDocuments__: Set<Document> | undefined;
-}
-
-export {};

--- a/packages/dom/src/global.d.ts
+++ b/packages/dom/src/global.d.ts
@@ -1,0 +1,9 @@
+// packages/dom/src/global.d.ts
+declare global {
+  // Optional registry of extra Document objects (e.g. window.open popups) for
+  // cross-window drag support. Host apps populate this via registerDndDocument().
+  // eslint-disable-next-line no-var
+  var __dndKitDocuments__: Set<Document> | undefined;
+}
+
+export {};

--- a/packages/dom/src/utilities/execution-context/dndKitDocuments.d.ts
+++ b/packages/dom/src/utilities/execution-context/dndKitDocuments.d.ts
@@ -1,0 +1,4 @@
+declare global {
+  // eslint-disable-next-line no-var
+  var __dndKitDocuments__: Set<Document> | undefined;
+}

--- a/packages/dom/src/utilities/execution-context/getDocuments.ts
+++ b/packages/dom/src/utilities/execution-context/getDocuments.ts
@@ -44,5 +44,20 @@ export function getDocuments(
     // Ignore cross-origin parent access
   }
 
+   // Traverse any window.open() popup documents registered by the host app.
+  try {
+    const extraDocuments = (globalThis as any).__dndKitDocuments__ as Set<Document> | undefined;
+    if (extraDocuments) {
+      for (const extraDoc of extraDocuments) {
+        if (extraDoc && !seen.has(extraDoc)) {
+          seen.add(extraDoc);
+          docs.push(extraDoc);
+        }
+      }
+    }
+  } catch {
+    // Ignore
+  }
+
   return docs;
 }

--- a/packages/dom/src/utilities/scheduling/scheduler.ts
+++ b/packages/dom/src/utilities/scheduling/scheduler.ts
@@ -35,7 +35,6 @@ export class Scheduler<T extends (callback: Callback) => any> {
   };
 }
 
-// AFTER:
 export const scheduler = new Scheduler((callback) => {
   // If the main document is hidden (e.g. user opened a popup window), run rAF
   // on the visible popup window instead so the scheduler isn't throttled.

--- a/packages/dom/src/utilities/scheduling/scheduler.ts
+++ b/packages/dom/src/utilities/scheduling/scheduler.ts
@@ -35,7 +35,27 @@ export class Scheduler<T extends (callback: Callback) => any> {
   };
 }
 
+// AFTER:
 export const scheduler = new Scheduler((callback) => {
+  // If the main document is hidden (e.g. user opened a popup window), run rAF
+  // on the visible popup window instead so the scheduler isn't throttled.
+  try {
+    if (typeof document !== 'undefined' && document.hidden) {
+      const extraDocuments = (globalThis as any).__dndKitDocuments__ as Set<Document> | undefined;
+      if (extraDocuments) {
+        for (const extraDoc of extraDocuments) {
+          const win = extraDoc?.defaultView;
+          if (win && extraDoc.visibilityState === 'visible' && typeof win.requestAnimationFrame === 'function') {
+            win.requestAnimationFrame(callback);
+            return;
+          }
+        }
+      }
+    }
+  } catch {
+    // Ignore
+  }
+
   if (typeof requestAnimationFrame === 'function') {
     requestAnimationFrame(callback);
   } else {


### PR DESCRIPTION
Problem: getDocuments misses window.open popup documents; Scheduler freezes when the main tab is backgrounded during a popup drag
Approach: opt-in global registry globalThis.__dndKitDocuments__: Set<Document> — consumers register popup documents on open and deregister on close; zero impact when the registry is absent
Affected files: packages/dom/src/utilities/... (wherever getDocuments and Scheduler live in the source tree)
Include a minimal reproduction: open a window.open popup, mount a DragDropProvider in it, try to drag — events are lost