### PR TITLE
fix(Accessibility): suppress self-dragover announcements for custom announcements (Fixes #2120)

### DIFF
--- a/packages/dom/src/core/plugins/accessibility/Accessibility.ts
+++ b/packages/dom/src/core/plugins/accessibility/Accessibility.ts
@@ -95,6 +95,18 @@ export class Accessibility extends Plugin<DragDropManager> {
             const element = liveRegionTextNode;
             if (!element) return;
 
+            /**
+             * Suppress self-dragover announcements (source over its own droppable
+             * target) regardless of whether custom announcements are provided.
+             * The default `dragover` announcement has this guard, but it must
+             * also be applied when users pass custom `announcements` to the
+             * Accessibility plugin.
+             */
+            if (eventName === 'dragover') {
+              const {source, target} = event.operation;
+              if (source?.id === target?.id) return;
+            }
+
             const announcement = getAnnouncement?.(event, manager);
 
             if (announcement && element.nodeValue !== announcement) {


### PR DESCRIPTION
## Summary

Fixes #2120 — suppress self-dragover announcements even when custom `announcements` are passed to the `Accessibility` plugin.

### Problem

When users pass **custom** `announcements` to the `Accessibility` plugin, the self-dragover suppression (`source.id === target?.id`) is NOT applied. The guard only exists in the default `dragover` announcement (`defaults.ts`), so a custom `dragover` announcement still fires when a draggable hovers over its own droppable target — producing noise for screen reader users (e.g. "Draggable item X was moved over droppable target X").

### Root cause

The guard lives in `defaultAnnouncements.dragover` (`defaults.ts`), but the `Accessibility` plugin calls whichever announcement is provided. If a user supplies custom announcements, the guard is bypassed.

### Fix

Moved the self-dragover guard into the `Accessibility` plugin's event listener, so it applies uniformly whether default or custom announcements are used:

```ts
if (eventName === 'dragover') {
  const {source, target} = event.operation;
  if (source?.id === target?.id) return;
}
```

## Test plan

- For sortables, the draggable and droppable share one id, so the self-target `dragover` now returns early and never reaches the live region.
- Default announcements remain unchanged (the guard was already there for them).
- Custom announcements now also suppress self-dragover, matching the default behavior.