### PR TITLE
fix: keep auto-scroller enabled during keyboard drag to prevent item escaping scrollable container

### DIFF
--- a/packages/dom/src/core/sensors/keyboard/KeyboardSensor.ts
+++ b/packages/dom/src/core/sensors/keyboard/KeyboardSensor.ts
@@ -12,7 +12,6 @@ import {
 
 import type {DragDropManager} from '../../manager/index.ts';
 import type {Draggable} from '../../entities/index.ts';
-import {AutoScroller} from '../../plugins/index.ts';
 import {isKeyboardKey, type KeyCode} from './KeyboardSensor.helpers.ts';
 
 export type {KeyCode};
@@ -173,8 +172,6 @@ export class KeyboardSensor extends Sensor<
 
     if (controller.signal.aborted) return this.cleanup();
 
-    this.sideEffects();
-
     const sourceDocument = getDocument(element);
     const listeners = [
       this.listeners.bind(sourceDocument, [
@@ -268,18 +265,6 @@ export class KeyboardSensor extends Sensor<
       this.manager.actions.move({
         event,
         by,
-      });
-    }
-  }
-
-  private sideEffects() {
-    const autoScroller = this.manager.registry.plugins.get(AutoScroller as any);
-
-    if (autoScroller?.disabled === false) {
-      autoScroller.disable();
-
-      this.#cleanupFunctions.push(() => {
-        autoScroller.enable();
       });
     }
   }


### PR DESCRIPTION
## Description

Fixes #2119

When keyboard-dragging an item inside a scrollable container, holding down the arrow key could move the item entirely outside the container because the `AutoScroller` plugin was disabled during keyboard drag.

## Root Cause

The `KeyboardSensor.sideEffects()` method disabled the `AutoScroller` plugin when a keyboard drag started. Without the auto-scroller, the scrollable container would not scroll as the item approached its edges, allowing the user to move the item beyond the container bounds.

## Fix

Removed the `sideEffects()` call from `handleStart()` and the `sideEffects()` method entirely. The `AutoScroller` and `Scroller` plugins now remain enabled during keyboard drag, allowing the container to scroll naturally as the keyboard-dragged item approaches its edges.

- The `Scroller` plugin already handles per-keyboard-event scrolling via its `dragmove` event listener (line 104-118 in Scroller.ts)
- The `AutoScroller` plugin provides continuous interval-based scrolling that fills the gap when the user holds down an arrow key

## Test Plan

1. Create a sortable list inside a scrollable container
2. Tab to an item and press Enter to start keyboard drag
3. Hold down the Arrow Down key
4. Previously: item would scroll beyond container bounds
5. Now: container scrolls along with the item, keeping it visible