### PR TITLE
fix: remove popover attribute when showPopover fails to prevent Chrome hiding dragged item

### DIFF
--- a/packages/dom/src/core/plugins/feedback/Feedback.ts
+++ b/packages/dom/src/core/plugins/feedback/Feedback.ts
@@ -363,7 +363,14 @@ export class Feedback extends Plugin<DragDropManager, FeedbackOptions> {
       if (!feedbackElement.hasAttribute('popover')) {
         feedbackElement.setAttribute('popover', 'manual');
       }
-      showPopover(feedbackElement);
+      if (!showPopover(feedbackElement)) {
+        // showPopover can fail silently if the element is not connected
+        // or showPopover() throws. When it fails, the popover="manual"
+        // attribute remains set but the popover is never opened, causing
+        // Chrome's UA stylesheet [popover]:not(:popover-open) { display: none }
+        // to hide the dragged element. Remove the attribute as a fallback.
+        feedbackElement.removeAttribute('popover');
+      }
       feedbackElement.addEventListener('beforetoggle', preventPopoverClose);
     }
 

--- a/packages/dom/src/utilities/popover/showPopover.ts
+++ b/packages/dom/src/utilities/popover/showPopover.ts
@@ -1,6 +1,6 @@
 import {supportsPopover} from './supportsPopover.ts';
 
-export function showPopover(element: Element) {
+export function showPopover(element: Element): boolean {
   try {
     if (
       supportsPopover(element) &&
@@ -10,8 +10,11 @@ export function showPopover(element: Element) {
       !element.matches(':popover-open')
     ) {
       element.showPopover();
+      return true;
     }
   } catch (error) {
     // no-op
   }
+
+  return false;
 }


### PR DESCRIPTION
## Problem

In Chrome, when dragging a sortable item using `@dnd-kit/svelte` (or `@dnd-kit/dom`), the active dragged item becomes invisible. All other sortable items remain visible, and the drag operation itself works correctly (collision detection, reordering, drop).

The element has `popover="manual"` set but isn't `:popover-open`, so Chrome's UA stylesheet hides it:

```css
[popover]:where(:not(:popover-open)) { display: none; }
```

## Root cause

In `Feedback.ts`, the `popover="manual"` attribute is set unconditionally before calling `showPopover()`. However, `showPopover()` has guards that can fail silently:

- If the element is not connected to the DOM at that moment
- If `showPopover()` throws

When `showPopover()` fails, the `popover="manual"` attribute remains applied but the popover is never opened, triggering the Chrome UA rule that hides the element.

## Fix

Two changes:

1. **`showPopover.ts`**: Return a `boolean` indicating whether the popover was successfully shown (`true`) or not (`false`).

2. **`Feedback.ts`**: Check the return value of `showPopover()`. If it returns `false`, remove the `popover` attribute as a fallback, so the element stays visible.

## Test plan

1. Reproduce the issue with the minimal Svelte 5 sortable example from the issue report
2. Verify the dragged item is visible during drag in Chrome
3. Verify popover promotion still works when `showPopover()` succeeds (e.g. in cross-frame scenarios)
4. Verify no regression in the `Debug` plugin which also uses `showPopover()`

Fixes #2111