### PR TITLE
fix(dom): reduce layout thrashing by caching getScrollPosition in scroll loop

### DIFF
--- a/.changeset/quick-scroll-positions.md
+++ b/.changeset/quick-scroll-positions.md
@@ -1,0 +1,5 @@
+---
+'@dnd-kit/dom': patch
+---
+
+Reuse each scroll container's position measurement during auto-scrolling to avoid duplicate layout reads while preserving the existing scroll utility argument order.

--- a/packages/dom/src/core/plugins/scrolling/Scroller.ts
+++ b/packages/dom/src/core/plugins/scrolling/Scroller.ts
@@ -168,16 +168,21 @@ export class Scroller extends CorePlugin<DragDropManager> {
 
       for (const scrollableElement of elements) {
         const scrollPosition = getScrollPosition(scrollableElement);
-        const elementCanScroll = canScroll(scrollableElement, scrollPosition, by);
+        const elementCanScroll = canScroll(
+          scrollableElement,
+          by,
+          scrollPosition
+        );
 
         if (elementCanScroll.x || elementCanScroll.y) {
           const {speed, direction} = detectScrollIntent(
             scrollableElement,
             currentPosition,
-            scrollPosition,
             intent,
             scrollOptions?.acceleration,
-            scrollOptions?.threshold
+            scrollOptions?.threshold,
+            undefined,
+            scrollPosition
           );
 
           if (scrollIntent) {

--- a/packages/dom/src/core/plugins/scrolling/Scroller.ts
+++ b/packages/dom/src/core/plugins/scrolling/Scroller.ts
@@ -5,6 +5,7 @@ import {
   detectScrollIntent,
   getScrollableAncestors,
   getElementFromPoint,
+  getScrollPosition,
   ScrollDirection,
   scheduler,
   isKeyboardEvent,
@@ -166,12 +167,14 @@ export class Scroller extends CorePlugin<DragDropManager> {
       }
 
       for (const scrollableElement of elements) {
-        const elementCanScroll = canScroll(scrollableElement, by);
+        const scrollPosition = getScrollPosition(scrollableElement);
+        const elementCanScroll = canScroll(scrollableElement, scrollPosition, by);
 
         if (elementCanScroll.x || elementCanScroll.y) {
           const {speed, direction} = detectScrollIntent(
             scrollableElement,
             currentPosition,
+            scrollPosition,
             intent,
             scrollOptions?.acceleration,
             scrollOptions?.threshold

--- a/packages/dom/src/utilities/index.ts
+++ b/packages/dom/src/utilities/index.ts
@@ -38,6 +38,7 @@ export {
   detectScrollIntent,
   getScrollableAncestors,
   getFirstScrollableAncestor,
+  getScrollPosition,
   isDocumentScrollingElement,
   ScrollDirection,
   scrollIntoViewIfNeeded,

--- a/packages/dom/src/utilities/scroll/canScroll.ts
+++ b/packages/dom/src/utilities/scroll/canScroll.ts
@@ -4,8 +4,8 @@ import {getScrollPosition, type ScrollPosition} from './getScrollPosition.ts';
 
 export function canScroll(
   scrollableElement: Element,
-  scrollPosition: ScrollPosition = getScrollPosition(scrollableElement),
-  by?: Coordinates
+  by?: Coordinates,
+  scrollPosition: ScrollPosition = getScrollPosition(scrollableElement)
 ) {
   const {isTop, isBottom, isLeft, isRight, position} = scrollPosition;
 

--- a/packages/dom/src/utilities/scroll/canScroll.ts
+++ b/packages/dom/src/utilities/scroll/canScroll.ts
@@ -1,10 +1,13 @@
 import type {Coordinates} from '@dnd-kit/geometry';
 
-import {getScrollPosition} from './getScrollPosition.ts';
+import {getScrollPosition, type ScrollPosition} from './getScrollPosition.ts';
 
-export function canScroll(scrollableElement: Element, by?: Coordinates) {
-  const {isTop, isBottom, isLeft, isRight, position} =
-    getScrollPosition(scrollableElement);
+export function canScroll(
+  scrollableElement: Element,
+  scrollPosition: ScrollPosition = getScrollPosition(scrollableElement),
+  by?: Coordinates
+) {
+  const {isTop, isBottom, isLeft, isRight, position} = scrollPosition;
 
   const {x, y} = by ?? {x: 0, y: 0};
 

--- a/packages/dom/src/utilities/scroll/detectScrollIntent.ts
+++ b/packages/dom/src/utilities/scroll/detectScrollIntent.ts
@@ -29,11 +29,11 @@ interface ScrollIntent {
 export function detectScrollIntent(
   scrollableElement: Element,
   coordinates: Coordinates,
-  scrollPosition: ScrollPosition = getScrollPosition(scrollableElement),
   intent?: ScrollIntent,
   acceleration = 25,
   thresholdPercentage = defaultThreshold,
-  tolerance = defaultTolerance
+  tolerance = defaultTolerance,
+  scrollPosition: ScrollPosition = getScrollPosition(scrollableElement)
 ) {
   const {x, y} = coordinates;
   const {rect, isTop, isBottom, isLeft, isRight} = scrollPosition;

--- a/packages/dom/src/utilities/scroll/detectScrollIntent.ts
+++ b/packages/dom/src/utilities/scroll/detectScrollIntent.ts
@@ -1,6 +1,6 @@
 import {Rectangle, type Axis, type Coordinates} from '@dnd-kit/geometry';
 
-import {getScrollPosition} from './getScrollPosition.ts';
+import {getScrollPosition, type ScrollPosition} from './getScrollPosition.ts';
 import {getFrameTransform} from '../frame/getFrameTransform.ts';
 import {getComputedStyles} from '../styles/getComputedStyles.ts';
 import {parseTransform} from '../transform/parseTransform.ts';
@@ -29,14 +29,14 @@ interface ScrollIntent {
 export function detectScrollIntent(
   scrollableElement: Element,
   coordinates: Coordinates,
+  scrollPosition: ScrollPosition = getScrollPosition(scrollableElement),
   intent?: ScrollIntent,
   acceleration = 25,
   thresholdPercentage = defaultThreshold,
   tolerance = defaultTolerance
 ) {
   const {x, y} = coordinates;
-  const {rect, isTop, isBottom, isLeft, isRight} =
-    getScrollPosition(scrollableElement);
+  const {rect, isTop, isBottom, isLeft, isRight} = scrollPosition;
   const frameTransform = getFrameTransform(scrollableElement);
   const computedStyles = getComputedStyles(scrollableElement, true);
   const parsedTransform = parseTransform(computedStyles);

--- a/packages/dom/src/utilities/scroll/getScrollPosition.ts
+++ b/packages/dom/src/utilities/scroll/getScrollPosition.ts
@@ -3,7 +3,16 @@ import {getViewportBoundingRectangle} from '../bounding-rectangle/getViewportBou
 import {getWindow} from '../execution-context/getWindow.ts';
 import {isDocumentScrollingElement} from './documentScrollingElement.ts';
 
-export function getScrollPosition(scrollableElement: Element) {
+export interface ScrollPosition {
+  rect: {width: number; height: number; top: number; left: number; bottom: number; right: number};
+  position: {current: {x: number; y: number}; max: {x: number; y: number}};
+  isTop: boolean;
+  isLeft: boolean;
+  isBottom: boolean;
+  isRight: boolean;
+}
+
+export function getScrollPosition(scrollableElement: Element): ScrollPosition {
   const window = getWindow(scrollableElement);
   const rect = isDocumentScrollingElement(scrollableElement)
     ? getViewportBoundingRectangle(scrollableElement)

--- a/packages/dom/tests/scroll-utilities.test.ts
+++ b/packages/dom/tests/scroll-utilities.test.ts
@@ -1,0 +1,134 @@
+import {afterEach, beforeEach, describe, expect, it, mock} from 'bun:test';
+
+import {
+  canScroll,
+  detectScrollIntent,
+  getScrollPosition,
+  ScrollDirection,
+} from '@dnd-kit/dom/utilities';
+
+const originalWindow = Object.getOwnPropertyDescriptor(globalThis, 'window');
+
+beforeEach(() => {
+  Object.defineProperty(globalThis, 'window', {
+    configurable: true,
+    value: {
+      frameElement: null,
+      getComputedStyle: () => ({transform: 'none'}),
+    },
+  });
+});
+
+afterEach(() => {
+  if (originalWindow) {
+    Object.defineProperty(globalThis, 'window', originalWindow);
+  } else {
+    Reflect.deleteProperty(globalThis, 'window');
+  }
+});
+
+function createScrollableElement() {
+  const getBoundingClientRect = mock(() => ({
+    width: 100,
+    height: 100,
+    top: 0,
+    left: 0,
+    bottom: 100,
+    right: 100,
+  }));
+  const element = {
+    ownerDocument: {defaultView: window},
+    clientHeight: 100,
+    clientWidth: 100,
+    scrollHeight: 500,
+    scrollWidth: 500,
+    scrollTop: 100,
+    scrollLeft: 100,
+    getBoundingClientRect,
+  } as unknown as Element;
+
+  return {element, getBoundingClientRect};
+}
+
+describe('scroll utilities', () => {
+  it('keeps the displacement as the second canScroll argument', () => {
+    const {element} = createScrollableElement();
+    element.scrollTop = 390;
+
+    expect(canScroll(element, {x: 0, y: 5}).bottom).toBe(true);
+    expect(canScroll(element, {x: 0, y: 20}).bottom).toBe(false);
+    expect(canScroll(element, {x: 0, y: -400}).top).toBe(false);
+  });
+
+  it('computes the scroll position when optional arguments are omitted', () => {
+    const {element, getBoundingClientRect} = createScrollableElement();
+
+    expect(canScroll(element)).toMatchObject({x: true, y: true});
+    expect(detectScrollIntent(element, {x: 50, y: 95})).toEqual({
+      direction: {x: ScrollDirection.Idle, y: ScrollDirection.Forward},
+      speed: {x: 0, y: 18.75},
+    });
+    expect(getBoundingClientRect).toHaveBeenCalledTimes(2);
+  });
+
+  it('keeps directional intent as the third detectScrollIntent argument', () => {
+    const {element} = createScrollableElement();
+    const result = detectScrollIntent(
+      element,
+      {x: 50, y: 95},
+      {x: ScrollDirection.Idle, y: ScrollDirection.Reverse}
+    );
+
+    expect(result).toEqual({
+      direction: {x: ScrollDirection.Idle, y: ScrollDirection.Idle},
+      speed: {x: 0, y: 0},
+    });
+  });
+
+  it('preserves acceleration, threshold, and tolerance argument positions', () => {
+    const {element} = createScrollableElement();
+    const result = detectScrollIntent(
+      element,
+      {x: 101, y: 95},
+      undefined,
+      40,
+      {x: 0.1, y: 0.1},
+      {x: 2, y: 3}
+    );
+
+    expect(result.direction.y).toBe(ScrollDirection.Forward);
+    expect(result.speed.y).toBe(20);
+    expect(
+      detectScrollIntent(
+        element,
+        {x: 103, y: 95},
+        undefined,
+        40,
+        {x: 0.1, y: 0.1},
+        {x: 2, y: 3}
+      ).speed.y
+    ).toBe(0);
+  });
+
+  it('shares one measurement between the helpers when a position is supplied', () => {
+    const {element, getBoundingClientRect} = createScrollableElement();
+    const scrollPosition = getScrollPosition(element);
+
+    expect(canScroll(element, {x: 0, y: 5}, scrollPosition).bottom).toBe(true);
+    expect(
+      detectScrollIntent(
+        element,
+        {x: 50, y: 95},
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        scrollPosition
+      )
+    ).toEqual({
+      direction: {x: ScrollDirection.Idle, y: ScrollDirection.Forward},
+      speed: {x: 0, y: 18.75},
+    });
+    expect(getBoundingClientRect).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Description

Avoid calling `getBoundingClientRect` twice per scrollable element in `Scroller.scroll()` by computing `getScrollPosition` once and passing the result to both `canScroll()` and `detectScrollIntent()`.

## Root cause

During drag with many sortable items, `Scroller.scroll()` iterates over scrollable elements and calls `canScroll()` (which calls `getScrollPosition()` -> `getBoundingClientRect()`) and then, if the element can scroll, `detectScrollIntent()` (which calls `getScrollPosition()` again -> another `getBoundingClientRect()`). This double read per element forces synchronous re-layout on every frame, contributing to the layout thrashing described in #2110.

## Changes

- **`getScrollPosition.ts`**: Export `ScrollPosition` interface for reuse
- **`canScroll.ts`**: Add optional `scrollPosition` parameter (defaults to self-computed for backward compatibility)
- **`detectScrollIntent.ts`**: Add optional `scrollPosition` parameter (reordered for cleaner call site, defaults to self-computed)
- **`Scroller.ts`**: Compute `getScrollPosition` once per element in the scroll loop and pass the cached result to both `canScroll` and `detectScrollIntent`

## Performance impact

Halves the number of `getBoundingClientRect()` calls per scrollable element in the drag hot path.

Closes #2110