### PR TITLE
fix(sortable): stabilize animations inside scaled ancestors

### DIFF
--- a/.changeset/scaled-items-settle.md
+++ b/.changeset/scaled-items-settle.md
@@ -1,0 +1,5 @@
+---
+'@dnd-kit/dom': patch
+---
+
+Keep sortable animations stable when an ancestor uses a CSS scale transform.

--- a/apps/stories/stories/react/Sortable/ScaledSortableApp.tsx
+++ b/apps/stories/stories/react/Sortable/ScaledSortableApp.tsx
@@ -1,0 +1,74 @@
+import React, {useState} from 'react';
+import {DragDropProvider} from '@dnd-kit/react';
+import {useSortable} from '@dnd-kit/react/sortable';
+
+function SortableItem({
+  id,
+  index,
+  group,
+}: {
+  id: string;
+  index: number;
+  group: string;
+}) {
+  const [element, setElement] = useState<Element | null>(null);
+
+  useSortable({id, index, group, element});
+
+  return (
+    <div
+      ref={setElement}
+      className="scaled-item"
+      style={{
+        marginBlockEnd: 8,
+        padding: 16,
+        border: '1px solid #999',
+        borderRadius: 6,
+        background: 'white',
+        cursor: 'grab',
+        userSelect: 'none',
+      }}
+    >
+      {id}
+    </div>
+  );
+}
+
+function SortableList({scale}: {scale: number}) {
+  const group = `scale-${scale}`;
+
+  return (
+    <section>
+      <h2>Scale {scale}</h2>
+      <div
+        className="scaled-list"
+        data-scale={scale}
+        style={{
+          width: 180,
+          transform: `scale(${scale})`,
+          transformOrigin: 'top left',
+        }}
+      >
+        {['A', 'B', 'C', 'D', 'E'].map((item, index) => (
+          <SortableItem
+            key={item}
+            id={`${group}-${item}`}
+            index={index}
+            group={group}
+          />
+        ))}
+      </div>
+    </section>
+  );
+}
+
+export default function ScaledSortableApp() {
+  return (
+    <DragDropProvider>
+      <main style={{display: 'flex', gap: 160, alignItems: 'flex-start'}}>
+        <SortableList scale={1} />
+        <SortableList scale={2} />
+      </main>
+    </DragDropProvider>
+  );
+}

--- a/apps/stories/stories/react/Sortable/Sortable.stories.tsx
+++ b/apps/stories/stories/react/Sortable/Sortable.stories.tsx
@@ -4,6 +4,7 @@ import SortableApp from './SortableApp.tsx';
 import sortableSource from './SortableApp.tsx?raw';
 import {baseStyles, sortableStyles} from '@dnd-kit/stories-shared/styles/sandbox';
 import {QuickstartExample} from './Quickstart.tsx';
+import ScaledSortableApp from './ScaledSortableApp.tsx';
 
 import docs from './docs/SortableDocs.mdx';
 
@@ -29,6 +30,11 @@ type Story = StoryObj<typeof SortableApp>;
 
 export const Example: Story = {
   name: 'Example',
+};
+
+export const ScaledParent: Story = {
+  name: 'Scaled parent',
+  render: () => <ScaledSortableApp />,
 };
 
 export const Quickstart: Story = {

--- a/apps/stories/tests/sortable-scaled.spec.ts
+++ b/apps/stories/tests/sortable-scaled.spec.ts
@@ -1,0 +1,57 @@
+import {test, expect} from '../../stories-shared/tests/fixtures.ts';
+
+test.describe('Sortable inside a scaled parent', () => {
+  test('items do not oscillate while sorting', async ({dnd}) => {
+    await dnd.goto('react-sortable--scaled-parent');
+
+    const list = dnd.page.locator('.scaled-list[data-scale="2"]');
+    const items = list.locator('.scaled-item');
+    const source = items.filter({hasText: 'scale-2-C'}).first();
+    const target = items.filter({hasText: 'scale-2-E'});
+    const sourceBox = await source.boundingBox();
+    const targetBox = await target.boundingBox();
+
+    if (!sourceBox || !targetBox) {
+      throw new Error('Could not get sortable item bounds');
+    }
+
+    const start = {
+      x: sourceBox.x + sourceBox.width / 2,
+      y: sourceBox.y + sourceBox.height / 2,
+    };
+    const end = {
+      x: targetBox.x + targetBox.width / 2,
+      y: targetBox.y + targetBox.height / 2,
+    };
+
+    await dnd.page.mouse.move(start.x, start.y);
+    await dnd.page.mouse.down();
+
+    const indices: number[] = [];
+
+    for (let step = 1; step <= 24; step++) {
+      const progress = step / 24;
+
+      await dnd.page.mouse.move(
+        start.x + (end.x - start.x) * progress,
+        start.y + (end.y - start.y) * progress
+      );
+      await dnd.page.waitForTimeout(40);
+
+      const order = await list
+        .locator('.scaled-item:not([data-dnd-placeholder])')
+        .allTextContents();
+      const index = order.map((value) => value.trim()).indexOf('scale-2-C');
+
+      if (index >= 0 && indices.at(-1) !== index) {
+        indices.push(index);
+      }
+    }
+
+    await expect(dnd.dragging).toHaveCount(1);
+    expect(indices).toEqual([2, 3, 4]);
+
+    await dnd.page.mouse.up();
+    await dnd.waitForDrop();
+  });
+});

--- a/packages/dom/src/sortable/sortable.ts
+++ b/packages/dom/src/sortable/sortable.ts
@@ -24,6 +24,9 @@ import {
   getComputedStyles,
   getWindow,
   computeTranslate,
+  isElement,
+  isShadowRoot,
+  parseTransform,
   prefersReducedMotion,
   ProxiedElements,
 } from '@dnd-kit/dom/utilities';
@@ -132,6 +135,33 @@ function normalizeDisabled(
     draggable: disabled?.draggable ?? false,
     droppable: disabled?.droppable ?? false,
   };
+}
+
+function getAncestorScale(element: Element) {
+  const scale = {x: 1, y: 1};
+  let ancestor = element.parentNode;
+
+  while (ancestor) {
+    if (isShadowRoot(ancestor)) {
+      ancestor = ancestor.host;
+      continue;
+    }
+
+    if (!isElement(ancestor)) {
+      break;
+    }
+
+    const transform = parseTransform(getComputedStyles(ancestor));
+
+    if (transform) {
+      scale.x *= transform.scaleX;
+      scale.y *= transform.scaleY;
+    }
+
+    ancestor = ancestor.parentNode;
+  }
+
+  return scale;
 }
 
 interface TemporaryState {
@@ -301,9 +331,15 @@ export class Sortable<T extends Data = Data> {
           return;
         }
 
+        const scale = getAncestorScale(element);
         const delta = {
-          x: shape.boundingRectangle.left - updatedShape.boundingRectangle.left,
-          y: shape.boundingRectangle.top - updatedShape.boundingRectangle.top,
+          x:
+            (shape.boundingRectangle.left -
+              updatedShape.boundingRectangle.left) /
+            (scale.x || 1),
+          y:
+            (shape.boundingRectangle.top - updatedShape.boundingRectangle.top) /
+            (scale.y || 1),
         };
 
         const {translate} = getComputedStyles(element);


### PR DESCRIPTION
## Summary

- normalize sortable animation deltas using the cumulative scale of transformed ancestors
- add a scaled-parent Storybook example
- add Playwright regression coverage for oscillating item positions
- add a patch changeset for `@dnd-kit/dom`

Fixes #2041

## Testing

- `npx playwright test tests/sortable-scaled.spec.ts`
- `npx tsup --entry.sortable src/sortable/index.ts`