### PR TITLE
fix: respect `transition: null` in framework bindings

### DIFF
--- a/.changeset/tidy-pugs-obey.md
+++ b/.changeset/tidy-pugs-obey.md
@@ -1,0 +1,9 @@
+---
+'@dnd-kit/dom': patch
+'@dnd-kit/react': patch
+'@dnd-kit/vue': patch
+'@dnd-kit/solid': patch
+'@dnd-kit/svelte': patch
+---
+
+Respect `transition: null` in the React, Vue, Solid and Svelte sortable bindings. The bindings previously merged `defaultSortableTransition` before constructing or updating the core `Sortable`, which replaced an explicit `null` with the default transition, so sortable items kept animating. They now use the new `resolveSortableTransition` helper exported from `@dnd-kit/dom/sortable`, which preserves `null` while still merging partial transitions with the defaults.

--- a/apps/docs/docs/solid/hooks/use-sortable.mdx
+++ b/apps/docs/docs/solid/hooks/use-sortable.mdx
@@ -118,8 +118,9 @@ export default function App() {
   An array of plugin descriptors for per-entity plugin configuration. Use `Plugin.configure()` to create descriptors. For example, `Feedback.configure({ feedback: 'clone' })`.
 </ParamField>
 
-<ParamField path="transition" type="SortableTransition" optional>
-  Animation transition configuration.
+<ParamField path="transition" type="SortableTransition | null" optional>
+  Animation transition configuration. Set to `null` to disable sortable
+  transitions entirely.
 </ParamField>
 
 <ParamField path="modifiers" type="Modifier[]" optional>

--- a/apps/docs/docs/svelte/primitives/create-sortable.mdx
+++ b/apps/docs/docs/svelte/primitives/create-sortable.mdx
@@ -129,8 +129,9 @@ Input properties are plain values that are read reactively. To keep an option in
   An array of plugin descriptors for per-entity plugin configuration. Use `Plugin.configure()` to create descriptors. For example, `Feedback.configure({ feedback: 'clone' })`.
 </ParamField>
 
-<ParamField path="transition" type="SortableTransition" optional>
-  Animation transition configuration for sort operations.
+<ParamField path="transition" type="SortableTransition | null" optional>
+  Animation transition configuration for sort operations. Set to `null` to
+  disable sortable transitions entirely.
 </ParamField>
 
 <ParamField path="modifiers" type="Modifier[]" optional>

--- a/apps/docs/docs/vue/composables/use-sortable.mdx
+++ b/apps/docs/docs/vue/composables/use-sortable.mdx
@@ -119,8 +119,9 @@ All input properties accept plain values or Vue refs/getters (`MaybeRefOrGetter`
   An array of plugin descriptors for per-entity plugin configuration. Use `Plugin.configure()` to create descriptors. For example, `Feedback.configure({ feedback: 'clone' })`.
 </ParamField>
 
-<ParamField path="transition" type="MaybeRefOrGetter<SortableTransition>" optional>
-  Animation transition configuration for sort operations.
+<ParamField path="transition" type="MaybeRefOrGetter<SortableTransition | null>" optional>
+  Animation transition configuration for sort operations. Set to `null` to
+  disable sortable transitions entirely.
 </ParamField>
 
 <ParamField path="modifiers" type="MaybeRefOrGetter<Modifier[]>" optional>

--- a/apps/stories/stories/react/Sortable/SortableExample.tsx
+++ b/apps/stories/stories/react/Sortable/SortableExample.tsx
@@ -24,7 +24,7 @@ interface Props {
   plugins?: Customizable<Plugins>;
   modifiers?: Modifiers;
   layout?: 'vertical' | 'horizontal' | 'grid';
-  transition?: SortableTransition;
+  transition?: SortableTransition | null;
   itemCount?: number;
   optimistic?: boolean;
   collisionDetector?: CollisionDetector;
@@ -87,7 +87,7 @@ interface SortableProps {
   dragHandle?: boolean;
   plugins?: Customizable<Plugins>;
   optimistic?: boolean;
-  transition?: SortableTransition;
+  transition?: SortableTransition | null;
   style?: React.CSSProperties;
 }
 

--- a/apps/stories/stories/react/Sortable/Vertical/Vertical.stories.tsx
+++ b/apps/stories/stories/react/Sortable/Vertical/Vertical.stories.tsx
@@ -128,13 +128,11 @@ export const CustomTransition: Story = {
   },
 };
 
-export const DisableTransition: Story = {
-  name: 'Disable transition',
+export const DisabledTransition: Story = {
+  name: 'Disabled transition',
   args: {
     debug: false,
-    transition: {
-      duration: 0,
-    },
+    transition: null,
   },
 };
 

--- a/packages/dom/src/sortable/index.ts
+++ b/packages/dom/src/sortable/index.ts
@@ -1,6 +1,7 @@
 export {
   Sortable,
   defaultSortableTransition,
+  resolveSortableTransition,
   SortableDraggable,
   SortableDroppable,
 } from './sortable.ts';

--- a/packages/dom/src/sortable/sortable.ts
+++ b/packages/dom/src/sortable/sortable.ts
@@ -118,6 +118,14 @@ export const defaultSortableTransition: SortableTransition = {
   idle: false,
 };
 
+export function resolveSortableTransition(
+  transition: SortableTransition | null | undefined
+): SortableTransition | null {
+  return transition === null
+    ? null
+    : {...defaultSortableTransition, ...transition};
+}
+
 function normalizeDisabled(
   disabled: SortableDisabledValue | undefined
 ): Required<SortableDisabled> {

--- a/packages/dom/tests/sortable-transition.test.ts
+++ b/packages/dom/tests/sortable-transition.test.ts
@@ -1,0 +1,48 @@
+import {describe, expect, it} from 'bun:test';
+
+import {
+  Sortable,
+  defaultSortableTransition,
+  resolveSortableTransition,
+} from '@dnd-kit/dom/sortable';
+import type {SortableInput} from '@dnd-kit/dom/sortable';
+
+function createSortable(input: Partial<SortableInput<any>> = {}) {
+  return new Sortable({id: 's1', index: 0, ...input}, undefined);
+}
+
+describe('resolveSortableTransition', () => {
+  it('falls back to the default transition when omitted', () => {
+    expect(resolveSortableTransition(undefined)).toEqual(
+      defaultSortableTransition
+    );
+  });
+
+  it('merges partial transitions with the default transition', () => {
+    expect(resolveSortableTransition({duration: 150})).toEqual({
+      ...defaultSortableTransition,
+      duration: 150,
+    });
+  });
+
+  it('preserves null so that transitions can be disabled', () => {
+    expect(resolveSortableTransition(null)).toBeNull();
+  });
+});
+
+describe('Sortable transition', () => {
+  it('defaults to the default transition when omitted', () => {
+    expect(createSortable().transition).toEqual(defaultSortableTransition);
+  });
+
+  it('preserves an explicit null transition', () => {
+    expect(createSortable({transition: null}).transition).toBeNull();
+  });
+
+  it('can be updated from a transition to null', () => {
+    const sortable = createSortable();
+    sortable.transition = resolveSortableTransition(null);
+
+    expect(sortable.transition).toBeNull();
+  });
+});

--- a/packages/react/src/sortable/useSortable.ts
+++ b/packages/react/src/sortable/useSortable.ts
@@ -1,7 +1,7 @@
 import {useCallback} from 'react';
 import {batch, deepEqual} from '@dnd-kit/state';
 import {type Data} from '@dnd-kit/abstract';
-import {Sortable, defaultSortableTransition} from '@dnd-kit/dom/sortable';
+import {Sortable, resolveSortableTransition} from '@dnd-kit/dom/sortable';
 import type {SortableInput} from '@dnd-kit/dom/sortable';
 import {useInstance} from '@dnd-kit/react';
 import {
@@ -38,7 +38,7 @@ export function useSortable<T extends Data = Data>(input: UseSortableInput<T>) {
     type,
     plugins,
   } = input;
-  const transition = {...defaultSortableTransition, ...input.transition};
+  const transition = resolveSortableTransition(input.transition);
   const sortable = useInstance((manager) => {
     return new Sortable(
       {

--- a/packages/solid/src/sortable/useSortable.ts
+++ b/packages/solid/src/sortable/useSortable.ts
@@ -1,6 +1,6 @@
 import {type Data} from '@dnd-kit/abstract';
 import type {SortableInput} from '@dnd-kit/dom/sortable';
-import {defaultSortableTransition, Sortable} from '@dnd-kit/dom/sortable';
+import {resolveSortableTransition, Sortable} from '@dnd-kit/dom/sortable';
 import {batch} from '@dnd-kit/state';
 import {createEffect, createSignal, on} from 'solid-js';
 
@@ -18,10 +18,7 @@ export interface UseSortableInput<T extends Data = Data>
 export function useSortable<T extends Data = Data>(
   input: UseSortableInput<T>
 ) {
-  const transition = {
-    ...defaultSortableTransition,
-    ...input.transition,
-  };
+  const transition = resolveSortableTransition(input.transition);
 
   const sortable = useInstance((manager) => {
     return new Sortable(
@@ -67,9 +64,7 @@ export function useSortable<T extends Data = Data>(
     sortable.accept = input.accept;
     sortable.type = input.type;
     sortable.collisionPriority = input.collisionPriority;
-    sortable.transition = input.transition
-      ? {...defaultSortableTransition, ...input.transition}
-      : defaultSortableTransition;
+    sortable.transition = resolveSortableTransition(input.transition);
 
     if (input.collisionDetector) {
       sortable.collisionDetector = input.collisionDetector;

--- a/packages/svelte/src/sortable/createSortable.svelte.ts
+++ b/packages/svelte/src/sortable/createSortable.svelte.ts
@@ -1,8 +1,8 @@
 import {type Data, type Plugins} from '@dnd-kit/abstract';
 import type {SortableInput} from '@dnd-kit/dom/sortable';
 import {
-  defaultSortableTransition,
   OptimisticSortingPlugin,
+  resolveSortableTransition,
   Sortable,
 } from '@dnd-kit/dom/sortable';
 import {batch} from '@dnd-kit/state';
@@ -30,10 +30,7 @@ export function createSortable<T extends Data = Data>(
         ...input,
         register: false,
         plugins: input.plugins ?? withoutOptimisticSorting,
-        transition: {
-          ...defaultSortableTransition,
-          ...input.transition,
-        },
+        transition: resolveSortableTransition(input.transition),
       },
       manager
     );
@@ -53,10 +50,7 @@ export function createSortable<T extends Data = Data>(
     sortable.type = input.type;
     sortable.collisionPriority = input.collisionPriority;
     sortable.collisionDetector = input.collisionDetector;
-    sortable.transition = {
-      ...defaultSortableTransition,
-      ...input.transition,
-    };
+    sortable.transition = resolveSortableTransition(input.transition);
 
     if (input.data) {
       sortable.data = input.data;

--- a/packages/vue/src/sortable/useSortable.ts
+++ b/packages/vue/src/sortable/useSortable.ts
@@ -1,6 +1,6 @@
 import {type Data} from '@dnd-kit/abstract';
 import type {SortableInput} from '@dnd-kit/dom/sortable';
-import {defaultSortableTransition, Sortable} from '@dnd-kit/dom/sortable';
+import {resolveSortableTransition, Sortable} from '@dnd-kit/dom/sortable';
 import {batch} from '@dnd-kit/state';
 import {useDeepSignal} from '@dnd-kit/vue/composables';
 import {toValueDeep, unrefElement} from '@dnd-kit/vue/utilities';
@@ -26,10 +26,9 @@ export interface UseSortableInput<T extends Data = Data>
 }
 
 export function useSortable<T extends Data = Data>(input: UseSortableInput<T>) {
-  const transition = computed(() => ({
-    ...defaultSortableTransition,
-    ...toValue(input.transition),
-  }));
+  const transition = computed(() =>
+    resolveSortableTransition(toValue(input.transition))
+  );
 
   const sortable = useInstance((manager) => {
     const _input = toValueDeep(input);


### PR DESCRIPTION
The React, Vue, Solid and Svelte bindings each merged `defaultSortableTransition` before constructing or updating the core `Sortable`, so an explicit `transition: null` was replaced by the default transition object and items kept animating. `null` is the documented and typed sentinel for disabling sortable transitions, and the core already supports it: the constructor default only applies to `undefined`, and `Sortable.animate()` returns early on a falsy transition.

Added a `resolveSortableTransition` helper to `@dnd-kit/dom/sortable` and used it in all four bindings, so that:

- an omitted transition resolves to `defaultSortableTransition`
- a partial transition merges with the defaults
- an explicit `null` is preserved

The `Disable transition` story previously faked this with `{duration: 0}`; it now uses `transition: null`. The story id is unchanged.

Fixes #2077