### PR TITLE
fix(dom): preserve data types in sortable guards

### DIFF
--- a/.changeset/tidy-sortable-types.md
+++ b/.changeset/tidy-sortable-types.md
@@ -1,0 +1,5 @@
+---
+'@dnd-kit/dom': patch
+---
+
+Preserve custom data types when narrowing with `isSortable` and `isSortableOperation` instead of widening them to `any`. Source and target data types are inferred independently for sortable operations.

--- a/apps/docs/docs/concepts/sortable.mdx
+++ b/apps/docs/docs/concepts/sortable.mdx
@@ -241,6 +241,23 @@ manager.monitor.addEventListener('dragend', (event) => {
 
 `@dnd-kit/dom/sortable` exports two type guards to help you work with sortable drag operations.
 
+Both guards preserve the data types of the input entities. For example, a `Draggable<ItemData>` narrows to `SortableDraggable<ItemData>`, so its `data` remains typed as `ItemData`. `isSortableOperation` preserves the source and target data types independently, even when they differ.
+
+```ts
+import type {Draggable} from '@dnd-kit/dom';
+import {isSortable} from '@dnd-kit/dom/sortable';
+
+interface ItemData {
+  title: string;
+}
+
+function getSortableTitle(source: Draggable<ItemData> | null) {
+  if (isSortable(source)) {
+    return source.data.title; // string
+  }
+}
+```
+
 ### `isSortable`
 
 Checks whether a `Draggable` or `Droppable` instance is a sortable element. If it returns `true`, the type is narrowed to expose sortable-specific properties like `index`, `initialIndex`, `group`, and `initialGroup`.

--- a/apps/docs/docs/react/guides/sortable-state-management.mdx
+++ b/apps/docs/docs/react/guides/sortable-state-management.mdx
@@ -186,6 +186,8 @@ Use the `move` helper when your data structure matches its expectations (flat ar
 
 ## Type guards
 
+Both guards preserve custom `data` types when narrowing to sortable instances. `isSortableOperation` infers the source and target data types independently. See [Type Guards](/concepts/sortable#type-guards) for a typed example.
+
 ### `isSortable`
 
 Checks whether a `Draggable` or `Droppable` is a sortable instance, narrowing the type to expose `index`, `initialIndex`, `group`, and `initialGroup`:

--- a/packages/dom/src/sortable/utilities.ts
+++ b/packages/dom/src/sortable/utilities.ts
@@ -1,24 +1,24 @@
-import type {DragOperation} from '@dnd-kit/abstract';
+import type {Data, DragOperation} from '@dnd-kit/abstract';
 import type {Droppable, Draggable} from '@dnd-kit/dom';
 
 import {SortableDroppable, SortableDraggable} from './sortable.ts';
 
-export function isSortable(
-  element: Draggable | null
-): element is SortableDraggable<any>;
-export function isSortable(
-  element: Droppable | null
-): element is SortableDroppable<any>;
-export function isSortable(
-  element: Draggable | Droppable | null
-): element is SortableDroppable<any> | SortableDraggable<any> {
+export function isSortable<T extends Data = Data>(
+  element: Draggable<T> | null
+): element is SortableDraggable<T>;
+export function isSortable<T extends Data = Data>(
+  element: Droppable<T> | null
+): element is SortableDroppable<T>;
+export function isSortable<T extends Data = Data>(
+  element: Draggable<T> | Droppable<T> | null
+): element is SortableDroppable<T> | SortableDraggable<T> {
   return (
     element instanceof SortableDroppable || element instanceof SortableDraggable
   );
 }
 
-export function isSortableOperation(
-  operation: DragOperation<Draggable, Droppable>
-): operation is DragOperation<SortableDraggable<any>, SortableDroppable<any>> {
+export function isSortableOperation<T extends Data = Data, U extends Data = T>(
+  operation: DragOperation<Draggable<T>, Droppable<U>>
+): operation is DragOperation<SortableDraggable<T>, SortableDroppable<U>> {
   return isSortable(operation.source) && isSortable(operation.target);
 }


### PR DESCRIPTION
Fixes #2132.

Preserve custom data types when narrowing with `isSortable` and `isSortableOperation`, instead of widening them to `any`. Source and target data types are inferred independently, allowing them to have different shapes.

Includes documentation examples and a patch changeset.

Based on the implementation proposed by @evercoyote, credited as a co-author.

Validation:
- All 57 existing DOM tests pass.
- Sortable build and declaration generation pass.